### PR TITLE
chore: tell gorilla what the `resource.{requests,limits}.memory` is

### DIFF
--- a/charts/wandb/Chart.yaml
+++ b/charts/wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.11.0"
 icon: https://wandb.ai/logo.svg
 maintainers:

--- a/charts/wandb/templates/deployment.yaml
+++ b/charts/wandb/templates/deployment.yaml
@@ -49,6 +49,16 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+            - name: GORILLA_MEM_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: gorilla
+                  resource: requests.memory
+            - name: GORILLA_MEM_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: gorilla
+                  resource: limits.memory
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Provide gorilla its memory request and limit. This way, gorilla can use this information to mark itself unhealthy for k8s to stop sending it requests: https://github.com/wandb/core/pull/9695

Note: this functionality of marking itself unhealthy based on memory usage is turned **off** by default.