### PR TITLE
Add service account name as environment variable in agent pod

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: launch-agent
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
                 secretKeyRef:
                   name: wandb-api-key
                   key: password
+            - name: WANDB_LAUNCH_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           volumeMounts:
             - name: wandb-launch-config
               mountPath: /home/launch_agent/.config/wandb


### PR DESCRIPTION
Exposing the name of the service account that the wandb launch agent is using in an environment variable so that the agent can read it and use the same service account when it creates kaniko pods.