### PR TITLE
add variable for mounting git credentials

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: launch-agent
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.2.0
+version: 0.3.0
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/README.md
+++ b/charts/launch-agent/README.md
@@ -18,3 +18,17 @@ By default, this chart will also install [volcano](https://volcano.sh), but this
 ```bash
 helm install <package-name> <launch-agent-chart-path> --set agent.apiKey=<your-api-key> --set-file launchConfig=<path-to-launch-config.yaml>
 ```
+
+## Chart variables
+
+Below is a table describing chart variables, their type, whether the user is required to provide a value, the default value, and a description of how the variable is used.
+
+| Variables | Type | Required | Default | Description |
+|--------|-----|------|--|-------|
+| `agent.apiKey` | string | **Yes** | n/a | W&B API key to be used by the agent. |
+| `agent.Image` | string | No | `wandb/launch-agent-dev:latest` | Container image for the agent.
+| `agent.imagePullPolicy` | string | No | Always | Pull policy for the agent container image.
+| `agent.resources` | object | No | Limit to 1 CPU, 1Gi RAM. | [Pod spec resources block](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the agent.
+| `launchConfig` | string | **Yes** | n/a | Launch agent configuration file contents. This config will be mounted at `/home/launch_agent/.config/wandb` in the agent container. For more details on how this config is structured, see [these docs](https://docs.wandb.ai/guides/launch/run-agent).
+| `gitCreds` | string | No | `null` | If set, the conents of this string will be stored in a k8s secret and then mounted in the agent container at `~/.git-credentials` and used to grant the agent permission to clone private repositories via https. For more information on what the contents of this file should look like, see the [official git documentation](https://git-scm.com/docs/git-credential-store#_storage_format).
+| `volcano` | bool | No | `true` | Controls whether the volcano scheduler should be installed in your cluster along with the agent. Set to `false` to disable volcano install.

--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -42,7 +42,23 @@ spec:
             - name: wandb-launch-config
               mountPath: /home/launch_agent/.config/wandb
               readOnly: true
+            {{ if .Values.gitCreds}}
+            - name: git-creds
+              mountPath: /home/launch_agent/
+              readOnly: true
+            - name: git-config
+              mountPath: /home/launch_agent/
+              readOnly: true
+            {{ end }}
       volumes:
         - name: wandb-launch-config
           configMap:
             name: wandb-launch-configmap
+        {{ if .Values.gitCreds}}
+        - name: git-creds
+          secret:
+            secretName: git-creds
+        - name: git-config
+          secret:
+            secretName: git-config
+        {{ end}}

--- a/charts/launch-agent/templates/secret.yaml
+++ b/charts/launch-agent/templates/secret.yaml
@@ -6,3 +6,17 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   password: {{ required "Please set agent.apiKey to a W&B API key" .Values.agent.apiKey }}
+
+{{- if .Values.gitCreds }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-creds
+  namespace: wandb
+type: kubernetes.io/basic-auth
+stringData:
+  .git-crededentials: {{ .Values.gitCreds }}
+  .gitconfig: |
+    [credential]
+      helper = store
+{{ end }}

--- a/charts/launch-agent/templates/volcano.yaml
+++ b/charts/launch-agent/templates/volcano.yaml
@@ -1,5 +1,5 @@
 # condition this whole file out if the user doesn't want to install the admission controller
-{{- if .Values.volcano }}
+{{ if .Values.volcano }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/charts/launch-agent/values.yaml
+++ b/charts/launch-agent/values.yaml
@@ -14,4 +14,10 @@ agent:
 # This should be set to the literal contents of your launch agent config.
 launchConfig: |
 
+# Set to false to disable volcano install.
 volcano: true
+
+# The contents of a git credentials file. This will be stored in a k8s secret
+# and mounted into the agent container. Set this if you want to clone private
+# repos.
+gitCreds: |


### PR DESCRIPTION
This PR introduces a `gitCreds` variable which can be set to the literal contents of a `.git-credentials` file. The chart puts this into a secret and mounts it in the home directory of the agent container, if `gitCreds` is specified by the user. It will also mount
```
[credentials]
helper = store
```
in `~/.gitconfig` to prevent git from prompting for a username and password and instead going straight to the cred store we have mounted.

I also added a table that documents all the variables to the readme.