### PR TITLE
fix: volcano resource quota

### DIFF
--- a/charts/launch-agent/templates/volcano.yaml
+++ b/charts/launch-agent/templates/volcano.yaml
@@ -8,6 +8,25 @@ metadata:
     kubernetes.io/metadata.name: volcano-system
 ---
 apiVersion: v1
+kind: ResourceQuota
+metadata:
+  # annotations:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: volcano-quota
+  namespace: volcano-system
+spec:
+  hard:
+    pods: 1G
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+      - system-cluster-critical
+---
+apiVersion: v1
 kind: Namespace
 metadata:
   name: volcano-monitoring


### PR DESCRIPTION
In some environments, like GKE, you need to manually add a resource quota to allow system-critical pods to run in the namespaces created by volcano.