### PR TITLE
adding variable for service account annotations

### DIFF
--- a/charts/launch-agent/templates/rbac.yaml
+++ b/charts/launch-agent/templates/rbac.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: wandb-launch-serviceaccount
   namespace: wandb
+{{ if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/launch-agent/values.yaml
+++ b/charts/launch-agent/values.yaml
@@ -21,3 +21,8 @@ volcano: true
 # and mounted into the agent container. Set this if you want to clone private
 # repos.
 gitCreds: |
+
+# Annotations for the wandb service account. Useful when setting up workload identity on gcp.
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: 


### PR DESCRIPTION
Adding a variable for service account annotations. Useful for worklaod identity setup