### PR TITLE
make the volcano variable work again

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: launch-agent
 icon: https://em-content.zobj.net/thumbs/240/apple/354/rocket_1f680.png
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.10.0
+version: 0.10.1
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/templates/volcano.yaml
+++ b/charts/launch-agent/templates/volcano.yaml
@@ -1,4 +1,4 @@
-{{ if .Variables.volcano }}
+{{ if .Values.volcano }}
 # Vendored volcano.sh deployment. Short term workaround.
 apiVersion: v1
 kind: Namespace

--- a/charts/launch-agent/templates/volcano.yaml
+++ b/charts/launch-agent/templates/volcano.yaml
@@ -1,3 +1,4 @@
+{{ if .Variables.volcano }}
 # Vendored volcano.sh deployment. Short term workaround.
 apiVersion: v1
 kind: Namespace
@@ -17881,3 +17882,4 @@ spec:
       - system-node-critical
       - system-cluster-critical
 ---
+{{ end }}


### PR DESCRIPTION
when I fixed the volcano deployment I copied their manifest again and didn't add back the templating that makes the volcano install conditional on the volcano helm variable.