### PR TITLE
Adding property to control if secret is being created by Helm Chart

### DIFF
--- a/charts/wandb/templates/secrets.yaml
+++ b/charts/wandb/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createSecrets }}
 {{- $secretName := print (include "wandb.fullname" .) "-secrets" }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 apiVersion: v1
@@ -27,4 +28,5 @@ data:
 {{- end}}
 {{- if .Values.sso.clientSecret }}
   CLIENT_SECRET: {{ .Values.clientSecret | b64enc }}
+{{- end}}
 {{- end}}

--- a/charts/wandb/values.yaml
+++ b/charts/wandb/values.yaml
@@ -40,6 +40,10 @@ hostAliases: []
 # You'll likely want to use `--set-file customCACerts={/path/to/rootCA.crt}`
 customCACerts: []
 
+
+# Set to false e.g. if Sealed Secrets are used
+createSecrets: true
+
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
Introducing a property that can disable secret generation of the Helm Chart in order to provide the secret from an external source e.g. from Sealed Secrets.