### PR TITLE
feat: This branch has a working operator Proof of Concept using minio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .vscode/
 dryrun.yaml
 test-values.yaml
+minio-data
+license.txt
+.ds_store
+```

--- a/run-operator.sh
+++ b/run-operator.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+export LICENSE=$(cat license.txt)
+
+if ! command -v minio &>/dev/null; then
+    brew install minio/stable/minio
+else
+    echo "MinIO is already installed."
+fi
+
+# Check if mc is installed
+if ! command -v mc &>/dev/null; then
+    brew install minio/stable/mc
+else
+    echo "mc (MinIO Client) is already installed."
+fi
+
+# MinIO configurations
+export MINIO_ROOT_USER=minio
+export MINIO_ROOT_PASSWORD=minio123
+export MINIO_ADDRESS="127.0.0.1:9000"
+export MINIO_BINARY=$(which minio)
+export MINIO_DATA_DIR="./minio-data"
+export MINIO_PID_FILE="/tmp/minio.pid"
+export MINIO_WANDB_BUCKET="wandb"
+export MINIO_ALIAS="myminio"
+
+# Check if MinIO is running
+is_minio_running() {
+    if [ -f "$MINIO_PID_FILE" ]; then
+        if ps -p $(cat "$MINIO_PID_FILE") >/dev/null 2>&1; then
+            return 0
+        else
+            rm "$MINIO_PID_FILE"
+            return 1
+        fi
+    else
+        return 1
+    fi
+}
+
+start_minio() {
+    if ! is_minio_running; then
+        nohup $MINIO_BINARY server $MINIO_DATA_DIR >/dev/null 2>&1 &
+        echo $! >"$MINIO_PID_FILE"
+        echo "MinIO started."
+    else
+        echo "MinIO is already running."
+    fi
+}
+
+stop_minio() {
+    if is_minio_running; then
+        kill $(cat "$MINIO_PID_FILE")
+        rm "$MINIO_PID_FILE"
+        echo "MinIO stopped."
+    else
+        echo "MinIO is not running."
+    fi
+}
+
+minio="start"
+# minio="stop"
+# Script main execution
+case "$minio" in
+start)
+    start_minio
+    ;;
+stop)
+    stop_minio
+    exit
+    ;;
+*)
+    echo "Usage: $0 {start|stop}"
+    ;;
+esac
+
+mc alias set $MINIO_ALIAS http://$MINIO_ADDRESS $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+
+if ! mc ls $MINIO_ALIAS | grep -qE "^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{3}\][[:space:]]+[0-9BKMGT]+[[:space:]]+${MINIO_WANDB_BUCKET}/$"; then
+    mc mb $MINIO_ALIAS/$MINIO_WANDB_BUCKET
+    echo "wandb bucket created on MinIO."
+else
+    echo "wandb bucket already exists on MinIO."
+fi
+
+helm upgrade --namespace=wandb \
+    --create-namespace \
+    --install wandb \
+    ./charts/operator
+
+FORCE_REBUILD=false
+
+# Check if FORCE_REBUILD is set to true or dependencies are missing
+if $FORCE_REBUILD || helm dep list ./charts/operator-wandb | grep -q "missing"; then
+    helm dependency build ./charts/operator-wandb
+fi
+
+MANIFEST=$(
+    cat <<EOF
+apiVersion: apps.wandb.com/v1
+kind: WeightsAndBiases
+metadata:
+  labels:
+    app.kubernetes.io/name: weightsandbiases
+    app.kubernetes.io/instance: wandb
+    wandb.ai/console-default: "true"
+  name: wandb
+spec:
+  values:
+    global:
+      host: "http://localhost"
+      license: "$LICENSE"
+      bucket:
+        name: "$MINIO_ROOT_USER:$MINIO_ROOT_PASSWORD@host.docker.internal:9000/$MINIO_WANDB_BUCKET"
+        region: "us-east-2"
+EOF
+)
+
+echo "$MANIFEST"
+
+echo "$MANIFEST" | kubectl apply -f -
+
+# To enable the ui and console run the following commands in a new terminal.
+kubectl port-forward svc/wandb-app 8080:8080 &
+kubectl port-forward svc/wandb-console 8081:8082 &

--- a/run-wandb.sh
+++ b/run-wandb.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+export LICENSE=$(cat license.txt)
+
+helm upgrade --namespace=wandb \
+    --create-namespace \
+    --install wandb \
+    ./charts/wandb-oper \
+    --set license=$LICENSE \
+    --set image.repository=wandb/local \
+    --set-string extraEnv[0].name=GORILLA_CUSTOMER_SECRET_STORE_SOURCE --set-string extraEnv[0].value='k8s-secretmanager://wandb-secrets' \
+    --set-string extraEnv[1].name=GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE --set-string extraEnv[1].value='wandb'
+
+# --set bucket=$BUCKET /
+# --set bucketRegion=$BUCKET_REGION


### PR DESCRIPTION
Simply set your kubernetes context to your local docker desktop environment, set a `license.txt` in the root of this repo,
<img width="768" alt="Screen Shot 2023-10-16 at 9 14 45 PM" src="https://github.com/wandb/helm-charts/assets/77289967/52344273-9429-4a1b-9139-fdda1f8c037c">
and `./run-operator.sh` to get a fully working operator up and running locally. 
(Tested on an M1/M2 mac)

This should allow for anyone at W&B to test the operator locally with ease and add features that don't require direct interactions with cloud native resources.

This script will spin up a local version of minio which is a good test for how onprem customers will run our software. 

Lastly, run 
``` bash
kubectl port-forward svc/wandb-app 8080:8080 &
kubectl port-forward svc/wandb-console 8081:8082 &
```
to access the wandb app at http://localhost:8080 and the console at http://localhost:8081. 