### PR TITLE
enable launch-agent codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
-
-/charts/launch-agent/    @bcsherma @gtarpenning @KyleGoyette @nickpenaranda @TimH98 @wandb-zacharyblasczyk
-
 * @gls4 @jsbroks @nfoucha @vanpelt
+/charts/launch-agent/ @bcsherma @gtarpenning @KyleGoyette @nickpenaranda @TimH98 @wandb-zacharyblasczyk


### PR DESCRIPTION
Prior to this PR the `CODEOWNERS` file has launch codeowners specified before the default setting. [These docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#:~:text=%23%20These%20owners%20will%20be%20the%20default%20owners%20for%20everything%20in%0A%23%20the%20repo.%20Unless%20a%20later%20match%20takes%20precedence%2C%0A%23%20%40global%2Downer1%20and%20%40global%2Downer2%20will%20be%20requested%20for%0A%23%20review%20when%20someone%20opens%20a%20pull%20request.%0A*%20%20%20%20%20%20%20%40global%2Downer1%20%40global%2Downer2) seem to suggest that we need the default to be specified before the more specific codeowner assignments.