### PR TITLE
pin agent image to sdk release 0.16.0

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: launch-agent
 icon: https://em-content.zobj.net/thumbs/240/apple/354/rocket_1f680.png
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.11.3
+version: 0.11.4
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/values.yaml
+++ b/charts/launch-agent/values.yaml
@@ -5,7 +5,7 @@ agent:
   # Providing API key can be done external to this chart
   useExternalWandbSecret: false
   # Container image to use for the agent.
-  image: wandb/launch-agent:latest
+  image: wandb/launch-agent:0.16.0-state-fix
   # Image pull policy for agent image.
   imagePullPolicy: Always
   # Resources block for the agent spec.


### PR DESCRIPTION
Now that we have versioning for our agent releases we should be pinning the agent image in a chart version to a permanently unique tag, which for the agent repo means sdk version.