### PR TITLE
feat: Create api key secret in all namespaces

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: launch-agent
 icon: https://em-content.zobj.net/thumbs/240/apple/354/rocket_1f680.png
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.11.6
+version: 0.11.7
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
             - name: WANDB_LAUNCH_START_TIMEOUT
               value: "{{ .Values.agent.startTimeout }}"
+            - name: WANDB_RELEASE_NAME
+              value: "{{ .Release.Name }}"
           volumeMounts:
             - name: wandb-launch-config
               mountPath: /home/launch_agent/.config/wandb

--- a/charts/launch-agent/templates/secret.yaml
+++ b/charts/launch-agent/templates/secret.yaml
@@ -8,6 +8,8 @@ kind: Secret
 metadata:
   name: wandb-api-key-{{ $root.Release.Name }}
   namespace: {{ $ns }}
+  labels:
+    wandb.ai/created-by: helm-chart
 type: kubernetes.io/basic-auth
 stringData:
   password: {{ required "Please set agent.apiKey to a W&B API key" $root.Values.agent.apiKey }}

--- a/charts/launch-agent/templates/secret.yaml
+++ b/charts/launch-agent/templates/secret.yaml
@@ -1,16 +1,20 @@
 {{- if not .Values.agent.useExternalWandbSecret }}
+{{- $root := . -}}
+{{- $unique := uniq (append .Values.additionalTargetNamespaces .Values.namespace) }}
+{{- range $ns := $unique }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: wandb-api-key-{{ .Release.Name }}
-  namespace: {{ .Values.namespace }}
+  name: wandb-api-key-{{ $root.Release.Name }}
+  namespace: {{ $ns }}
 type: kubernetes.io/basic-auth
 stringData:
-  password: {{ required "Please set agent.apiKey to a W&B API key" .Values.agent.apiKey }}
+  password: {{ required "Please set agent.apiKey to a W&B API key" $root.Values.agent.apiKey }}
 ...
 {{ end }}
 
+{{- end }}
 {{- if .Values.gitCreds }}
 ---
 apiVersion: v1


### PR DESCRIPTION
This is a companion PR to [this SDK PR](https://github.com/wandb/wandb/pull/6722). Instead of only creating the `wandb-api-key` secret in the agent's namespace, create one in every namespace used by the agent. This way, secrets are created when the agent is spun up instead of at job runtime. This also allows the helm deployment to manage cleanup of the secrets when the agent is spun down.

Since we allow multiple agents on the same namespace, and different agents may want to use different secrets, these separate secrets are denoted by the agent's `.Release.Name`, which is passed to the agent through the `WANDB_RELEASE_NAME` env var.