### PR TITLE
fix(o11y): Enable JMX stats collection for Kafka

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -22,12 +22,12 @@ dependencies:
   version: 18.19.4
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 25.3.5
+  version: 28.0.4
 - name: otel
   repository: file://charts/otel
   version: 0.1.0
 - name: flat-run-fields-updater
   repository: file://charts/flat-run-fields-updater
   version: 0.1.0
-digest: sha256:72ce111a55d35fac65edc81862f81dd1c0a6ad747aa2a6b2522966f91b27c814
-generated: "2024-03-26T20:48:42.072569696Z"
+digest: sha256:a48a5077b8fc6f5fa2bf54c3b1c99285ef07b26383c500e6fad9aa916e89aeeb
+generated: "2024-04-12T14:45:10.302362-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.12.6
+version: 0.12.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -41,7 +41,7 @@ dependencies:
     condition: redis.install
     repository: https://charts.bitnami.com/bitnami
   - name: kafka
-    version: "25.*.*"
+    version: "28.*.*"
     condition: kafka.install
     repository: https://charts.bitnami.com/bitnami
   - name: otel

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -225,3 +225,23 @@ kafka:
   kraft:
     # This field is a UUID. It is *strongly* recommended to supply a new UUID yourself for production installs.
     clusterId: "ffFF1H3AQKGdBnsqAbJKew"
+  metrics:
+    kafka:
+      enabled: true
+    jmx:
+      enabled: true
+  controller:
+    podAnnotations:
+      ad.datadoghq.com/kafka.checks: |
+        {
+          "kafka": {
+            "init_config": {
+              "is_jmx": true,
+              "collect_default_metrics": true
+            },
+            "instances": [{
+              "host": "%%host%%",
+              "port": "5555"
+            }]
+          }
+        }


### PR DESCRIPTION
Update kafka version to fix auth issues between metrics pod and broker pods
Enable prometheus endpoints for metrics and jmx stats
Add annotation for datadog autodiscovery of jmx stats