### PR TITLE
feat: Allow ingress to be disabled for customers using Istio 

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.12.6
+version: 0.12.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/ingress.yaml
+++ b/charts/operator-wandb/templates/ingress.yaml
@@ -20,6 +20,7 @@ spec:
           ingress:
             class: {{ .Values.ingress.class }}
 {{- end }}
+{{- if .Values.ingress.install }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -78,3 +79,4 @@ spec:
             port:
               number: 8082
   {{- end }}
+{{- end }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -103,6 +103,7 @@ global:
     runUpdatesShadowTopic: ""
 
 ingress:
+  install: true
   nameOverride: ""
   defaultBackend: "app"
   annotations: {}


### PR DESCRIPTION
Example istio networking:
```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  labels:
    app.kubernetes.io/managed-by: Helm
  name: wandb-vs
  namespace: wandb-operator
spec:
  gateways:
  - wandb-operator/wandb-gw
  hosts:
  - '*'
  http:
  - match:
    - uri:
        prefix: /console
      port: 31005
    route:
    - destination:
        host: wandb-console.wandb-operator.svc.cluster.local
        port:
          number: 8082
  - match:
    - uri:
        prefix: /
      port: 31005
    route:
    - destination:
        host: wandb-app.wandb-operator.svc.cluster.local
        port:
          number: 8080 
```

Eventually we could also technically template this out with an `istio.install: true`