### PR TITLE
chore(weave): Use app fullname for weave auth

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.12.6
+version: 0.12.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.12.7
+version: 0.12.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/weave/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/weave/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
+Create a default fully qualified app name. (Should be something like wandb-weave)
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
@@ -17,6 +17,24 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name. (Should be something like wandb-app)
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "weave.appFullname" -}}
+{{- if .Values.appFullnameOverride }}
+{{- .Values.appFullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Values.appServiceName .Values.appNameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/operator-wandb/charts/weave/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/weave/templates/_helpers.tpl
@@ -31,10 +31,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "weave.appFullname" -}}
-{{- if .Values.appFullnameOverride }}
-{{- .Values.appFullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- if .Values.app.fullnameOverride }}
+{{- .Values.app.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Values.appServiceName .Values.appNameOverride }}
+{{- $name := default .Values.app.serviceName .Values.app.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: WEAVE_LOCAL_ARTIFACT_DIR
               value: /vol/weave/cache
             - name: WEAVE_AUTH_GRAPHQL_URL
-              value: {{ .Values.global.host }}/graphql
+              value: http://{{ include "weave.appFullname" . }}.default.svc.cluster.local:8080/graphql
             - name: WEAVE_SERVER_NUM_WORKERS
               value: "4"
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: WEAVE_LOCAL_ARTIFACT_DIR
               value: /vol/weave/cache
             - name: WEAVE_AUTH_GRAPHQL_URL
-              value: http://{{ include "weave.appFullname" . }}.default.svc.cluster.local:8080/graphql
+              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080/graphql
             - name: WEAVE_SERVER_NUM_WORKERS
               value: "4"
 

--- a/charts/operator-wandb/charts/weave/values.yaml
+++ b/charts/operator-wandb/charts/weave/values.yaml
@@ -1,5 +1,10 @@
 enabled: true
 
+# These need to be set as well if app name overrides are set
+appServiceName: "app"
+appNameOverride: ""
+appFullnameOverride: ""
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/operator-wandb/charts/weave/values.yaml
+++ b/charts/operator-wandb/charts/weave/values.yaml
@@ -1,9 +1,11 @@
 enabled: true
 
 # These need to be set as well if app name overrides are set
-appServiceName: "app"
-appNameOverride: ""
-appFullnameOverride: ""
+app:
+  serviceName: "app"
+  clusterDomain: "cluster.local"
+  nameOverride: ""
+  fullnameOverride: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
weave was using host url for auth
this would fail if the url was ip allow listed
make the request to app.fullName(wandb-app) 

[dd error ](https://app.datadoghq.com/apm/trace/7825151400505903724?colorBy=service&env=managed-install&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5329251616330542402&spanViewType=errors&timeHint=1713267779966.6892&view=spans)

screenshot showing the proper url in the env and that you can curl it (qa-aws)
<img width="832" alt="Screenshot 2024-04-16 at 1 02 29 PM" src="https://github.com/wandb/helm-charts/assets/25037002/145e964d-d36d-486e-9fac-3dbe99ab60bc">

