### PR TITLE
feat: add affinity template into agent

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: launch-agent
 icon: https://em-content.zobj.net/thumbs/240/apple/354/rocket_1f680.png
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.13.3
+version: 0.13.4
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -148,6 +148,8 @@ spec:
         {{- toYaml .Values.agent.nodeSelector | nindent 8 }}
       tolerations:
         {{- toYaml .Values.agent.tolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.agent.affinity | nindent 8 }}
 ---
 {{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1

--- a/charts/launch-agent/values.yaml
+++ b/charts/launch-agent/values.yaml
@@ -21,6 +21,8 @@ agent:
   minAvailable: 1
   # Tolerations for the agent pod.
   tolerations: []
+  # Affinites for the agent pod.
+  affinity: {}
 
 # Namespace to deploy launch agent into
 namespace: wandb


### PR DESCRIPTION
This templates affinity into the agent's deployment spec so users can manage affinities similarly to tolerations and nodeSelectors