### PR TITLE
chore(weave): Add weave private url to helm chart

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.12.11
+version: 0.12.12
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.12.12
+version: 0.13.1
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: ONLY_SERVICE
               value: weave
             - name: WANDB_BASE_URL
-              value: {{ .Values.global.host }}
+              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080/
             - name: WEAVE_LOG_FORMAT
               value: json
             - name: WEAVE_LOCAL_ARTIFACT_DIR

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -56,13 +56,13 @@ spec:
             - name: WANDB_BASE_URL
               value: {{ .Values.global.host }}
             - name: WANDB_PRIVATE_BASE_URL
-              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080
+              value: http://{{ include "weave.appFullname" . }}:8080
             - name: WEAVE_LOG_FORMAT
               value: json
             - name: WEAVE_LOCAL_ARTIFACT_DIR
               value: /vol/weave/cache
             - name: WEAVE_AUTH_GRAPHQL_URL
-              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080/graphql
+              value: http://{{ include "weave.appFullname" . }}:8080/graphql
             - name: WEAVE_SERVER_NUM_WORKERS
               value: "4"
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -54,7 +54,9 @@ spec:
             - name: ONLY_SERVICE
               value: weave
             - name: WANDB_BASE_URL
-              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080/
+              value: {{ .Values.global.host }}
+            - name: WANDB_PRIVATE_BASE_URL
+              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080
             - name: WEAVE_LOG_FORMAT
               value: json
             - name: WEAVE_LOCAL_ARTIFACT_DIR

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -54,9 +54,9 @@ spec:
             - name: ONLY_SERVICE
               value: weave
             - name: WANDB_BASE_URL
-              value: {{ .Values.global.host }}
-            - name: WANDB_PRIVATE_BASE_URL
               value: http://{{ include "weave.appFullname" . }}:8080
+            - name: WANDB_PUBLIC_BASE_URL
+              value: {{ .Values.global.host }}
             - name: WEAVE_LOG_FORMAT
               value: json
             - name: WEAVE_LOCAL_ARTIFACT_DIR

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
 
         - name: {{ include "weave.fullname" . }}-cache-clear
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ["python", "-m", "weave.clear_cache"]
+          command: ["python", "-m", "weave.legacy.clear_cache"]
             
           env:
             - name: WEAVE_LOCAL_ARTIFACT_DIR


### PR DESCRIPTION
This var allows weave to use a more direct private url when making pod to pod request while maintaining the normal wandb base url for frontend requests
This fixes an issues where wandb pod ip allowlisting blocked the weave pod from making requests to the public ip

updates an import for a failing pod