### PR TITLE
fix: Check if secondary is nil

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.13.2
+version: 0.13.3
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/ingress.yaml
+++ b/charts/operator-wandb/templates/ingress.yaml
@@ -85,7 +85,7 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if .Values.ingress.secondary.create }}
+{{- if and .Values.ingress.secondary .Values.ingress.secondary.create }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
```
➜ helm upgrade wandb . --reuse-values                                                     
Error: UPGRADE FAILED: template: operator-wandb/templates/ingress.yaml:89:14: executing "operator-wandb/templates/ingress.yaml" at <.Values.ingress.secondary.create>: nil pointer evaluating interface {}.create
```