### PR TITLE
chore(weave): add weave public url

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.3
+version: 0.14.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -54,13 +54,15 @@ spec:
             - name: ONLY_SERVICE
               value: weave
             - name: WANDB_BASE_URL
+              value: http://{{ include "weave.appFullname" . }}:8080
+            - name: WANDB_PUBLIC_BASE_URL
               value: {{ .Values.global.host }}
             - name: WEAVE_LOG_FORMAT
               value: json
             - name: WEAVE_LOCAL_ARTIFACT_DIR
               value: /vol/weave/cache
             - name: WEAVE_AUTH_GRAPHQL_URL
-              value: http://{{ include "weave.appFullname" . }}.{{ $.Release.Namespace }}.svc.{{ .Values.app.clusterDomain }}:8080/graphql
+              value: http://{{ include "weave.appFullname" . }}:8080/graphql
             - name: WEAVE_SERVER_NUM_WORKERS
               value: "4"
 


### PR DESCRIPTION
This var allows weave to use a more direct url when making pod to pod request while maintaining the normal wandb base url for frontend requests
This fixes an issues where wandb pod ip allowlisting blocked the weave pod from making requests to the public ip