### PR TITLE
fix: add hc annotation to the console service in AWS clusters

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.4
+version: 0.14.5
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.5
+version: 0.14.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/console/templates/service.yaml
+++ b/charts/operator-wandb/charts/console/templates/service.yaml
@@ -11,7 +11,10 @@ metadata:
     {{-   toYaml .Values.service.labels | nindent 4 }}
     {{- end }}
   annotations:
-    {{- include "wandb.deploymentAnnotations" $ | nindent 4 }}
+    {{- if eq .Values.global.cloudProvider "aws" }}
+    alb.ingress.kubernetes.io/healthcheck-path: /console/api/ready
+    {{- end }}
+    {{- include "wandb.serviceAnnotations" $ | nindent 4 }}
     {{- if .Values.service.annotations -}}
     {{-   toYaml .Values.service.annotations | nindent 4 }}
     {{- end }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -14,6 +14,8 @@ global:
   host: "http://localhost:8080"
   license: ""
 
+  cloudProvider: ""
+
   storageClass: ""
 
   banners:


### PR DESCRIPTION
AWS Load Balancer controller will use annotations on the service to configure health checks on the ALB target groups that relate to it otherwise it will default to `/` 

https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#health-check

- Add a cloudProvider value to globals
- When cloudProvider is AWS add relevant annotations to the Service for console