### PR TITLE
chore(dev): fix flat run fields updater redis volume

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.5
+version: 0.14.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -163,4 +163,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        {{- if ne (include "wandb.redis.caCert" .) "" }}
+        - name: {{ include "flat-run-fields-updater.fullname" . }}-redis-ca
+          secret:
+            secretName: "{{ include "wandb.redis.passwordSecret" . }}"
+            items:
+              - key: REDIS_CA_CERT
+                path: redis_ca.pem
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
Seeing 
```
"cannot patch \"wandb-flat-run-fields-updater\" with kind Deployment: Deployment.apps \"wandb-flat-run-fields-updater\" is invalid: spec.template.spec.containers[0].volumeMounts[0].name: Not found: \"wandb-flat-run-fields-updater-redis-ca\""
```

Noticing all the other deployments seem to have this additional block.