### PR TITLE
feat(backend): enable subpath in GCP

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.16
+version: 0.14.17
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/app/templates/_helpers.tpl
@@ -116,7 +116,7 @@ app deployments.
 {{- $bucket = printf "az://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
 {{- end -}}
 {{- if eq .Values.global.bucket.provider "gcs" -}}
-{{- $bucket = printf "gs://%s" .Values.global.bucket.name -}}
+{{- $bucket = printf "gs://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
 {{- end -}}
 {{- if eq .Values.global.bucket.provider "s3" -}}
 {{- if and .Values.global.bucket.accessKey .Values.global.bucket.secretKey -}}

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
@@ -112,7 +112,7 @@ Create the name of the service account to use
 {{- $bucket = printf "az://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
 {{- end -}}
 {{- if eq .Values.global.bucket.provider "gcs" -}}
-{{- $bucket = printf "gs://%s" .Values.global.bucket.name -}}
+{{- $bucket = printf "gs://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
 {{- end -}}
 {{- if eq .Values.global.bucket.provider "s3" -}}
 {{- if and .Values.global.bucket.accessKey .Values.global.bucket.secretKey -}}

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -116,7 +116,7 @@ app deployments.
 {{- $bucket = printf "az://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
 {{- end -}}
 {{- if eq .Values.global.bucket.provider "gcs" -}}
-{{- $bucket = printf "gs://%s" .Values.global.bucket.name -}}
+{{- $bucket = printf "gs://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
 {{- end -}}
 {{- if eq .Values.global.bucket.provider "s3" -}}
 {{- if and .Values.global.bucket.accessKey .Values.global.bucket.secretKey -}}


### PR DESCRIPTION
This PR enables support for subpaths in GCP https://github.com/wandb/terraform-google-wandb/pull/145/files

Testing:
Manually deployed with https://github.com/wandb/helm-charts/blob/levinandrew/byob-subpath/charts/operator-wandb/local-development.md
- when the new `bucket_path` in the above terraform, was NOT specified, when I ssh'd to the wandb-app pod, I saw 
```
wandb@wandb-app-65d8cb96-m7jb5:~$ env | grep -i bucket
BUCKET=gs://andrew-levin-gcp-intense-goblin
```
- when the new `bucket_path` was specified as `"nested/path/test", I saw
```
wandb@wandb-app-7cbb475896-79266:~$ env | grep -i nested
BUCKET=gs://andrew-levin-gcp-intense-goblin/nested/path/test
    "store": "gs://andrew-levin-gcp-intense-goblin/nested/path/test",
OVERFLOW_BUCKET_ADDR=gs://andrew-levin-gcp-intense-goblin/nested/path/test
GORILLA_FILE_STORE=gs://andrew-levin-gcp-intense-goblin/nested/path/test
```