### PR TITLE
chore(dev): run updates shadow partitions

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.12
+version: 0.14.13
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -228,7 +228,7 @@ spec:
             - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
               value: {{ include "wandb.kafka.runUpdatesShadowTopic" .}}
             - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-              value: {{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}
+              value: "{{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}"
             - name: OVERFLOW_BUCKET_ADDR
               value: "{{ include "app.bucket" .}}"
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -117,7 +117,7 @@ spec:
             - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
               value: {{ include "wandb.kafka.runUpdatesShadowTopic" .}}
             - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-              value: {{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}
+              value: "{{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}"
             - name: BUCKET
               value: "{{ include "flat-run-fields-updater.bucket" .}}"
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -105,7 +105,7 @@ global:
     runUpdatesShadowTopic: ""
     # This value will only apply upon initial topic creation.
     # If the topic already exists then changing the number of partitions is not possible.
-    runUpdatesShadowNumPartitions: "1"
+    runUpdatesShadowNumPartitions: 1
 
 ingress:
   install: true


### PR DESCRIPTION
Realized that my initial attempted fix here: https://github.com/wandb/helm-charts/pull/168 did not update both deployments (app and frfu). Something still seemed to be broken on the latest chart version. 

Manually applied this change
```
jessicaxiang@Jessica-Xiang-RCPYPN70YT helm-charts % helm upgrade wandb ./charts/operator-wandb/ --reuse-values
Release "wandb" has been upgraded. Happy Helming!
NAME: wandb
LAST DEPLOYED: Tue Jul 16 09:36:52 2024
NAMESPACE: default
STATUS: deployed
REVISION: 352
TEST SUITE: None
jessicaxiang@Jessica-Xiang-RCPYPN70YT helm-charts %
```

Things seem to be working again: https://qa-aws.wandb.io/console/settings/advanced

<img width="1216" alt="Screenshot 2024-07-16 at 9 38 05 AM" src="https://github.com/user-attachments/assets/93541cfd-7421-4703-8523-0bc00fd5b3f5">
