### PR TITLE
chore(dev): add AWS_REGION to frfu deployment

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.13
+version: 0.14.14
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -120,6 +120,10 @@ spec:
               value: "{{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}"
             - name: BUCKET
               value: "{{ include "flat-run-fields-updater.bucket" .}}"
+            - name: AWS_REGION
+              value: {{ .Values.global.bucket.region }}
+            - name: AWS_S3_KMS_ID
+              value: "{{ .Values.global.bucket.kmsKey }}"
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
               value: >
                 {


### PR DESCRIPTION
Seeing errors in datadog when spinning up FRFU deployment on AWS: https://app.datadoghq.com/logs?query=customer-ns%3Awandb-qa-aws%20container_name%3Aflat-run-fields-updater%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZC8gckgnFx-TQAAAAAAAAAYAAAAAEFaQzhnZHQ1QUFDRUtGT0VBSzNhWEFBTwAAACQAAAAAMDE5MGJjODEtZmJlYS00ZGViLWE2ZmEtM2UyZDY3ODAyYWMy&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=service%2Casc&viz=stream&from_ts=1721148577565&to_ts=1721149477565&live=true

```
!!! The AWS_REGION environment variable is required when specifying BUCKET. Please restart the container with AWS_REGION set to the region containing your bucket.
```

Believe this is the fix. Tested application

```
jessicaxiang@Jessica-Xiang-RCPYPN70YT helm-charts % helm upgrade wandb ./charts/operator-wandb/ --reuse-values
Release "wandb" has been upgraded. Happy Helming!
NAME: wandb
LAST DEPLOYED: Tue Jul 16 10:20:58 2024
NAMESPACE: default
STATUS: deployed
REVISION: 360
TEST SUITE: None
```

<img width="859" alt="Screenshot 2024-07-16 at 10 22 50 AM" src="https://github.com/user-attachments/assets/17e3eb71-e5d9-4f59-9fa2-5e0f263ed4dd">

