### PR TITLE
fix: Normalize the service account create logic for all wandb applications

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.14.16
+version: 0.15.0
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/serviceaccount.yaml
+++ b/charts/operator-wandb/charts/app/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,3 +15,4 @@ metadata:
     {{- if .Values.serviceAccount.annotations -}}
     {{-   toYaml .Values.serviceAccount.annotations | nindent 4 }}
     {{- end }}
+  {{- end }}

--- a/charts/operator-wandb/charts/app/values.yaml
+++ b/charts/operator-wandb/charts/app/values.yaml
@@ -53,6 +53,7 @@ resources:
 
 serviceAccount:
   create: true
+  annotations: {}
 
 role: {}
 roleBinding: {}

--- a/charts/operator-wandb/charts/console/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/console/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {{-   toYaml .Values.pod.annotations | nindent 4 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "console.fullname" . }}
+      serviceAccountName: {{ include "console.serviceAccountName" . }}
       {{- if .tolerations }}
       tolerations:
         {{- toYaml .tolerations | nindent 8 }}

--- a/charts/operator-wandb/charts/console/templates/serviceaccount.yaml
+++ b/charts/operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,3 +15,4 @@ metadata:
     {{- if .Values.serviceAccount.annotations -}}
     {{-   toYaml .Values.serviceAccount.annotations | nindent 4 }}
     {{- end }}
+{{- end }}

--- a/charts/operator-wandb/charts/console/values.yaml
+++ b/charts/operator-wandb/charts/console/values.yaml
@@ -21,7 +21,9 @@ extraCors: []
 common:
   labels: {}
 deployment: {}
-serviceAccount: {}
+serviceAccount:
+  create: true
+  annotations: {}
 clusterRole: {}
 
 pod:

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -140,6 +140,7 @@ spec:
           
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      serviceAccountName: {{ include "parquet.serviceAccountName" . }}
       volumes:
         {{- if ne (include "wandb.redis.caCert" .) "" }}
         - name: {{ include "parquet.fullname" . }}-redis-ca

--- a/charts/operator-wandb/charts/parquet/templates/serviceaccount.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/serviceaccount.yaml
@@ -2,12 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "flat-run-fields-updater.serviceAccountName" . }}
-  namespace: {{ $.Release.Namespace }}
+  name: {{ include "parquet.serviceAccountName" . }}
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
-    {{- include "flat-run-fields-updater.commonLabels" . | nindent 4 }}
-    {{- include "flat-run-fields-updater.labels" . | nindent 4 }}
+    {{- include "parquet.commonLabels" . | nindent 4 }}
+    {{- include "parquet.labels" . | nindent 4 }}
     {{- if .Values.serviceAccount.labels -}}
     {{-   toYaml .Values.serviceAccount.labels | nindent 4 }}
     {{- end }}

--- a/charts/operator-wandb/charts/parquet/values.yaml
+++ b/charts/operator-wandb/charts/parquet/values.yaml
@@ -22,7 +22,9 @@ cronJob:
   exportHistoryToParquet:
     enabled: false
     schedule: "11 * * * *"
-serviceAccount: {}
+serviceAccount:
+  create: true
+  annotations: {}
 clusterRole: {}
 
 service:


### PR DESCRIPTION
Normalize the service account create logic for all wandb applications

https://github.com/wandb/terraform-google-wandb/pull/151

To support changes in terraform-google-wandb version 5.0 with `enable_workload_identity`
