### PR TITLE
chore(weave): Revert weave cache import update

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
 
         - name: {{ include "weave.fullname" . }}-cache-clear
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ["python", "-m", "weave.legacy.clear_cache"]
+          command: ["python", "-m", "weave.clear_cache"]
             
           env:
             - name: WEAVE_LOCAL_ARTIFACT_DIR


### PR DESCRIPTION
reverts the change 
https://github.com/wandb/helm-charts/pull/159

to maintain back compat with 56 and below