### PR TITLE
fix: Add search tags to YACE resources to scope metrics to customer

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.15.3
+version: 0.15.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/yace/values.yaml
+++ b/charts/operator-wandb/charts/yace/values.yaml
@@ -16,6 +16,7 @@ tolerations: []
 extraEnv: {}
 extraEnvFrom: {}
 
+searchTags: {}
 
 config: |-
   apiVersion: v1alpha1
@@ -45,6 +46,10 @@ config: |-
             statistics: [Average]
           - name: CPUCreditUsage
             statistics: [Average]
+        {{- if .Values.searchTags }}
+        searchTags:
+          {{ .Values.searchTags | toYaml }}
+        {{- end }}
       - type: AWS/RDS
         regions:
         {{- range .Values.regions }}
@@ -73,6 +78,10 @@ config: |-
             statistics: [Average]
           - name: WriteIOPS
             statistics: [Average]
+        {{- if .Values.searchTags }}
+        searchTags:
+          {{ .Values.searchTags | toYaml }}
+        {{- end }}
 service:
   type: ClusterIP
   annotations: {}


### PR DESCRIPTION
The YACE exporter is not scoped to the correct resources, which causes my calls to GetMetricData, which costs money