### PR TITLE
chore(dev): increase default kafka partitions for frfu

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.15.7
+version: 0.15.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -113,7 +113,7 @@ global:
     runUpdatesShadowTopic: ""
     # This value will only apply upon initial topic creation.
     # If the topic already exists then changing the number of partitions is not possible.
-    runUpdatesShadowNumPartitions: 1
+    runUpdatesShadowNumPartitions: 3
 
   customCACerts: []
 


### PR DESCRIPTION
We can't re-partition without downtime so best to start higher than we think we'll need. I don't think any of our customers would actually struggle with 1. We can set this for different customers with environment variables but setting it here streamlines the deployment process.