### PR TITLE
fix: Clean up DD_* env vars in weave-trace deployment

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.15.8
+version: 0.15.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/weave-trace/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave-trace/templates/deployment.yaml
@@ -97,18 +97,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "wandb.clickhouse.passwordSecret" . }}
                   key: CLICKHOUSE_PASSWORD
-            {{- if .Values.datadog.enabled }}
-            - name: DD_SERVICE
-              value: "{{ .Values.datadog.service }}"
-            - name: DD_ENV
-              value: "{{ .Values.datadog.env }}"
-            - name: DD_TRACE_ENABLED
-              value: "{{ .Values.datadog.traceEnabled }}"
-            - name: DD_LOGS_ENABLED
-              value: "{{ .Values.env.logsEnabled }}"
-            - name: DD_LOGS_INJECTION
-              value: "{{ .Values.env.logsInjection }}"
-            {{- end }}
             {{- include "weaveTrace.extraEnv" (dict "global" .Values.global "local" .Values) | nindent 12 }}
             {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
           {{- if not .Values.datadog.enabled }}


### PR DESCRIPTION
- [x] No longer want to set `DD_*` vars through the helm chart.  These will be set either by operator or terraform in the future.