### PR TITLE
fix: Fix CACert value reference

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
             {{- end }}
-            {{- range $index, $v := .Values.customCACerts }}
+            {{- range $index, $v := .Values.global.customCACerts }}
             - name: wandb-ca-certs
               mountPath: /usr/local/share/ca-certificates/customCA{{$index}}.crt
               subPath: customCA{{$index}}.crt
@@ -286,7 +286,7 @@ spec:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
         {{- end }}
-        {{- if .Values.customCACerts }}
+        {{- if .Values.global.customCACerts }}
         - name: wandb-ca-certs
           configMap:
             name: {{ include "wandb.fullname" . }}-ca-certs


### PR DESCRIPTION
This may fix the injection of custom CA to the wandb-app if the intention is to make the certs a global config.

If the idea is to make it local to `app` only I can move it to the correct chart.

```
helm dependency build ./charts/operator-wandb
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "metrics-server" chart repository
...Successfully got an update from the "descheduler" chart repository
...Successfully got an update from the "ceph-csi" chart repository
...Successfully got an update from the "ingress-nginx" chart repository
...Successfully got an update from the "cert-manager-webhook-pdns" chart repository
...Successfully got an update from the "hashicorp" chart repository
...Successfully got an update from the "seldon-charts" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "istio" chart repository
...Successfully got an update from the "argo" chart repository
...Successfully got an update from the "grafana" chart repository
...Successfully got an update from the "wandb" chart repository
...Successfully got an update from the "prometheus-community" chart repository
...Successfully got an update from the "flyteorg" chart repository
...Successfully got an update from the "gitlab" chart repository
...Successfully got an update from the "datawire" chart repository
...Successfully got an update from the "bitnami" chart repository
Update Complete. _Happy Helming!_
Saving 14 charts
Downloading redis from repo https://charts.bitnami.com/bitnami
Downloading kafka from repo https://charts.bitnami.com/bitnami
Deleting outdated charts
```

Upgrade the deployment
```
helm upgrade \
>     --install wandb \
>     ./charts/operator-wandb -f wandb-app.yaml
Release "wandb" has been upgraded. Happy Helming!
NAME: wandb
LAST DEPLOYED: Thu Aug  1 14:24:34 2024
NAMESPACE: default
STATUS: deployed
REVISION: 4
TEST SUITE: None
```

Results: 

Before

```
Defaulted container "app" out of: app, init-db (init)
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/01_enable-services.sh...
*** Found custom SSL certifcates, updating root trust...
Updating certificates in /etc/ssl/certs...
rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
1 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
*** Enabling production mode
*** Enabling external weave server pool
*** Running /etc/my_init.d/02_load-settings.sh...
```

After

```
Defaulted container "app" out of: app, init-db (init)
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/01_enable-services.sh...
*** Found custom SSL certifcates, updating root trust...
Updating certificates in /etc/ssl/certs...
rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
rehash: warning: skipping customCA0.pem,it does not contain exactly one certificate or CRL
2 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
*** Enabling production mode
*** Enabling external weave server pool
*** Running /etc/my_init.d/02_load-settings.sh...
```

Internal test
```
 kubectl exec -ti wandb-app-db989bf67-tgqrd -- bash
Defaulted container "app" out of: app, init-db (init)

wandb@wandb-app-db989bf67-tgqrd:~$ curl -v https://git.home.lab
*   Trying 192.168.10.60:443...
* Connected to git.home.lab (192.168.10.60) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
[....]
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=*.home.lab
*  start date: Jul  9 15:56:40 2024 GMT
*  expire date: Jul  8 15:57:40 2029 GMT
*  subjectAltName: host "git.home.lab" matched cert's "*.home.lab"
*  issuer: O=HomeLab; CN=HomeLab Intermediate CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* Using Stream ID: 1 (easy handle 0x55f161a24eb0)
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
> GET / HTTP/2
> Host: git.home.lab
> user-agent: curl/7.81.0
``` 