### PR TITLE
feat: Differentiate between bucket settings provided as default and set explicitly by the user for wandb managed installs

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.16.2
+version: 0.17.0
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/app/templates/_helpers.tpl
@@ -111,18 +111,22 @@ app deployments.
 {{- end }}
 
 {{- define "app.bucket" -}}
+{{- $bucketValues := .Values.global.defaultBucket }}
+{{- if .Values.global.bucket.provider }}
+{{- $bucketValues := .Values.global.bucket }}
+{{- end }}
 {{- $bucket := "" -}} 
-{{- if eq .Values.global.bucket.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "az" -}}
+{{- $bucket = printf "az://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
-{{- if eq .Values.global.bucket.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "gcs" -}}
+{{- $bucket = printf "gs://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
-{{- if eq .Values.global.bucket.provider "s3" -}}
-{{- if and .Values.global.bucket.accessKey .Values.global.bucket.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" .Values.global.bucket.accessKey .Values.global.bucket.secretKey .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "s3" -}}
+{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
+{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name $bucketValues.path -}}
 {{- else -}}
-{{- $bucket = printf "s3://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- $bucket = printf "s3://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
 {{- end -}}
 {{- trimSuffix "/" $bucket -}}

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -189,9 +189,9 @@ spec:
             - name: BUCKET
               value: "{{ include "app.bucket" . }}"
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region }}
+              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey }}"
+              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
 
             - name: OPERATOR_ENABLED
               value: 'true'

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
@@ -107,18 +107,22 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "flat-run-fields-updater.bucket" -}}
-{{- $bucket := "" -}} 
-{{- if eq .Values.global.bucket.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- $bucketValues := .Values.global.defaultBucket }}
+{{- if .Values.global.bucket.provider }}
+{{- $bucketValues := .Values.global.bucket }}
+{{- end }}
+{{- $bucket := "" -}}
+{{- if eq $bucketValues.provider "az" -}}
+{{- $bucket = printf "az://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
-{{- if eq .Values.global.bucket.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "gcs" -}}
+{{- $bucket = printf "gs://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
-{{- if eq .Values.global.bucket.provider "s3" -}}
-{{- if and .Values.global.bucket.accessKey .Values.global.bucket.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" .Values.global.bucket.accessKey .Values.global.bucket.secretKey .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "s3" -}}
+{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
+{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name $bucketValues.path -}}
 {{- else -}}
-{{- $bucket = printf "s3://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- $bucket = printf "s3://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
 {{- end -}}
 {{- trimSuffix "/" $bucket -}}

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -121,9 +121,9 @@ spec:
             - name: BUCKET
               value: "{{ include "flat-run-fields-updater.bucket" .}}"
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region }}
+              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey }}"
+              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
               value: >
                 {

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -111,18 +111,22 @@ app deployments.
 {{- end -}}
 
 {{- define "parquet.bucket" -}}
-{{- $bucket := "" -}} 
-{{- if eq .Values.global.bucket.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- $bucketValues := .Values.global.defaultBucket }}
+{{- if .Values.global.bucket.provider }}
+{{- $bucketValues := .Values.global.bucket }}
+{{- end }}
+{{- $bucket := "" -}}
+{{- if eq $bucketValues.provider "az" -}}
+{{- $bucket = printf "az://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
-{{- if eq .Values.global.bucket.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "gcs" -}}
+{{- $bucket = printf "gs://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
-{{- if eq .Values.global.bucket.provider "s3" -}}
-{{- if and .Values.global.bucket.accessKey .Values.global.bucket.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" .Values.global.bucket.accessKey .Values.global.bucket.secretKey .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- if eq $bucketValues.provider "s3" -}}
+{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
+{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name $bucketValues.path -}}
 {{- else -}}
-{{- $bucket = printf "s3://%s/%s" .Values.global.bucket.name .Values.global.bucket.path -}}
+{{- $bucket = printf "s3://%s/%s" $bucketValues.name $bucketValues.path -}}
 {{- end -}}
 {{- end -}}
 {{- trimSuffix "/" $bucket -}}

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -119,9 +119,9 @@ spec:
                 - name: BUCKET
                   value: "{{ include "parquet.bucket" . }}"
                 - name: AWS_REGION
-                  value: {{ .Values.global.bucket.region }}
+                  value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
                 - name: AWS_S3_KMS_ID
-                  value: "{{ .Values.global.bucket.kmsKey }}"
+                  value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
 
                 - name: AZURE_STORAGE_KEY
                   valueFrom:

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -95,9 +95,9 @@ spec:
             - name: BUCKET
               value: "{{ include "parquet.bucket" . }}"
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region }}
+              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey }}"
+              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
             - name: AZURE_STORAGE_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/operator-wandb/templates/bucket.yaml
+++ b/charts/operator-wandb/templates/bucket.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
-  ACCESS_KEY: {{ .Values.global.bucket.accessKey | b64enc }}
-  SECRET_KEY: {{ .Values.global.bucket.secretKey | b64enc }}
+  ACCESS_KEY: {{ .Values.global.bucket.accessKey | default .Values.global.defaultBucket.accessKey | b64enc }}
+  SECRET_KEY: {{ .Values.global.bucket.secretKey | default .Values.global.defaultBucket.secretKey | b64enc }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -86,7 +86,8 @@ global:
       authMethod: ""
       issuer: ""
 
-  bucket:
+  # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
+  defaultBucket:
     # az, s3, gcs
     provider: "s3"
     name: ""
@@ -95,6 +96,9 @@ global:
     kmsKey: ""
     secretKey: ""
     accessKey: ""
+
+  # If specified the application will use this bucket for all storage operations, and will not be overridable by the user.
+  bucket: {}
 
   redis:
     host: ""


### PR DESCRIPTION
There are some scenarios where we want to provide setting for the storage bucket that are overwritten via console ui and this change should allow the console to know the source of the configuration