### PR TITLE
chore: add more granular extraEnvs for parquet

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.17.3
+version: 0.17.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Returns the extraEnv keys and values to inject into the parquet deployment.
 Global values will override any chart-specific values.
 */}}
 {{- define "parquet.deploymentExtraEnv" -}}
-{{- $allExtraEnv := merge (default (dict) .local.deploymentExtraEnv) .global.extraEnv -}}
+{{- $allExtraEnv := default (dict) .local.deploymentExtraEnv -}}
 {{- range $key, $value := $allExtraEnv }}
 - name: {{ $key }}
   value: {{ $value | quote }}
@@ -108,7 +108,7 @@ Returns the extraEnv keys and values to inject into the parquet backfill cronjob
 Global values will override any chart-specific values.
 */}}
 {{- define "parquet.cronjobExtraEnv" -}}
-{{- $allExtraEnv := merge (default (dict) .local.cronjobExtraEnv) .global.extraEnv -}}
+{{- $allExtraEnv := default (dict) .local.cronjobExtraEnv -}}
 {{- range $key, $value := $allExtraEnv }}
 - name: {{ $key }}
   value: {{ $value | quote }}

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Returns the extraEnv keys and values to inject into the parquet deployment.
 Global values will override any chart-specific values.
 */}}
 {{- define "parquet.deploymentExtraEnv" -}}
-{{- $allExtraEnv := default (dict) .local.deploymentExtraEnv -}}
+{{- $allExtraEnv := default (dict) .local.deployment.extraEnv -}}
 {{- range $key, $value := $allExtraEnv }}
 - name: {{ $key }}
   value: {{ $value | quote }}
@@ -107,8 +107,8 @@ Returns the extraEnv keys and values to inject into the parquet backfill cronjob
 
 Global values will override any chart-specific values.
 */}}
-{{- define "parquet.cronjobExtraEnv" -}}
-{{- $allExtraEnv := default (dict) .local.cronjobExtraEnv -}}
+{{- define "parquet.cronJobExtraEnv" -}}
+{{- $allExtraEnv := default (dict) .local.cronJob.extraEnv -}}
 {{- range $key, $value := $allExtraEnv }}
 - name: {{ $key }}
   value: {{ $value | quote }}

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -87,6 +87,34 @@ Global values will override any chart-specific values.
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Returns the extraEnv keys and values to inject into the parquet deployment.
+
+Global values will override any chart-specific values.
+*/}}
+{{- define "parquet.deploymentExtraEnv" -}}
+{{- $allExtraEnv := merge (default (dict) .local.deploymentExtraEnv) .global.extraEnv -}}
+{{- range $key, $value := $allExtraEnv }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Returns the extraEnv keys and values to inject into the parquet backfill cronjob.
+
+Global values will override any chart-specific values.
+*/}}
+{{- define "parquet.cronjobExtraEnv" -}}
+{{- $allExtraEnv := merge (default (dict) .local.cronjobExtraEnv) .global.extraEnv -}}
+{{- range $key, $value := $allExtraEnv }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Returns a list of _common_ labels to be shared across all
 app deployments and other shared objects.

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -135,6 +135,7 @@ spec:
                     fieldRef:
                       fieldPath: status.hostIP
                 {{- include "parquet.extraEnv" (dict "global" $.Values.global "local" .Values) | nindent 16 }}
+                {{- include "parquet.cronjobExtraEnv" (dict "global" $.Values.global "local" .Values) | nindent 16 }}
                 {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 16 }}
           serviceAccountName: {{ include "parquet.serviceAccountName" . }}
           volumes:

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -135,7 +135,7 @@ spec:
                     fieldRef:
                       fieldPath: status.hostIP
                 {{- include "parquet.extraEnv" (dict "global" $.Values.global "local" .Values) | nindent 16 }}
-                {{- include "parquet.cronjobExtraEnv" (dict "global" $.Values.global "local" .Values) | nindent 16 }}
+                {{- include "parquet.cronJobExtraEnv" (dict "global" $.Values.global "local" .Values) | nindent 16 }}
                 {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 16 }}
           serviceAccountName: {{ include "parquet.serviceAccountName" . }}
           volumes:

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -116,6 +116,7 @@ spec:
             {{- end }}
 
             {{- include "parquet.extraEnv" (dict "global" .Values.global "local" .Values) | nindent 12 }}
+            {{- include "parquet.deploymentExtraEnv" (dict "global" $.Values.global "local" .Values) | nindent 12 }}
             {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
 
           livenessProbe:

--- a/charts/operator-wandb/charts/parquet/values.yaml
+++ b/charts/operator-wandb/charts/parquet/values.yaml
@@ -11,6 +11,8 @@ image:
 tolerations: []
 
 extraEnv: {}
+deploymentExtraEnv: {}
+cronjobExtraEnv: {}
 extraEnvFrom: {}
 
 extraCors: []

--- a/charts/operator-wandb/charts/parquet/values.yaml
+++ b/charts/operator-wandb/charts/parquet/values.yaml
@@ -11,19 +11,19 @@ image:
 tolerations: []
 
 extraEnv: {}
-deploymentExtraEnv: {}
-cronjobExtraEnv: {}
 extraEnvFrom: {}
 
 extraCors: []
 
 common:
   labels: {}
-deployment: {}
+deployment:
+  extraEnv: {}
 cronJob:
   exportHistoryToParquet:
     enabled: false
     schedule: "11 * * * *"
+  extraEnv: {}
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
Adds 2 extra "extraEnv" definitions:

1. `parquet.deployment.extraEnv` : Responsible for injecting environment variables into the parquet deployment *without* injecting them into the backfiller cronjob.
2. `parquet.cronjob.extraEnv` : Responsible for injecting environment variables into the parquet backfiller cronjob *without* injecting them into the deployment.

We still keep `parquet.extraEnv` around which is responsible for injecting env vars into both the deployment and the cronjob.