### PR TITLE
fix: Parquet service pod selector is not specific enough

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.17.5
+version: 0.17.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -6,6 +6,7 @@ kind: CronJob
 metadata:
   name: {{ include "parquet.fullname" . }}-backfill
   labels:
+    app.kubernetes.io/component: "backfill"
     {{- include "wandb.commonLabels" . | nindent 4 }}
     {{- include "parquet.commonLabels" . | nindent 4 }}
     {{- include "parquet.labels" . | nindent 4 }}
@@ -24,6 +25,7 @@ spec:
       template:
         metadata:
           labels:
+            app.kubernetes.io/component: "backfill"
             {{- include "wandb.podLabels" . | nindent 12 }}
             {{- include "parquet.commonLabels" . | nindent 12 }}
             {{- include "parquet.podLabels" . | nindent 12 }}

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   name: {{ include "parquet.fullname" . }}
   labels:
+    app.kubernetes.io/component: "service"
     {{- include "wandb.commonLabels" . | nindent 4 }}
     {{- include "parquet.commonLabels" . | nindent 4 }}
     {{- include "parquet.labels" . | nindent 4 }}
@@ -25,6 +26,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: "service"
         {{- include "wandb.podLabels" . | nindent 8 }}
         {{- include "parquet.commonLabels" . | nindent 8 }}
         {{- include "parquet.podLabels" . | nindent 8 }}

--- a/charts/operator-wandb/charts/parquet/templates/service.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/service.yaml
@@ -20,4 +20,5 @@ spec:
       protocol: TCP
       name: parquet
   selector:
+    app.kubernetes.io/component: "service"
     {{- include "parquet.labels" . | nindent 4 }}


### PR DESCRIPTION
The K8s Service for Parquet will also pickup the backfill job pods and add them as endpoints, this is not desirable. 