### PR TITLE
fix: Set Default NodeOptions

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.17.7
+version: 0.17.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/console/Chart.yaml
+++ b/charts/operator-wandb/charts/console/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: console
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.16.0

--- a/charts/operator-wandb/charts/console/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/console/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: "http://{{ $.Release.Name }}-prometheus-server"
             - name: BANNERS
               value: {{ toJson .Values.global.banners | quote }}
+            - name: NODE_OPTIONS
+              value: {{ .Values.nodeOptions }}
 
             - name: G_HOST_IP
               valueFrom:

--- a/charts/operator-wandb/charts/console/values.yaml
+++ b/charts/operator-wandb/charts/console/values.yaml
@@ -40,6 +40,10 @@ service:
   annotations: {}
   labels: {}
 
+# This is 90% of the default limit for the console in MB
+# Adjust this value if you have a different limit set for the console
+nodeOptions: --max-old-space-size=472
+
 resources:
   # We usually recommend not to specify default resources and to leave this as a
   # conscious choice for the user. This also increases chances charts run on


### PR DESCRIPTION
Before:
<img width="1469" alt="Screen Shot 2024-08-28 at 1 32 04 PM" src="https://github.com/user-attachments/assets/9a3749be-7bb1-4a7b-a3b7-acbdd8900fb5">


After:
<img width="1482" alt="Screen Shot 2024-08-28 at 1 30 02 PM" src="https://github.com/user-attachments/assets/0a34d564-064f-4274-a01d-2c52be25e951">

Looks like this works, but we just need to actually bump the memory on the pod to take advantage of the 1GB. 

It is still good to have this flag if you set it over 1GB. 