### PR TITLE
fix: Enable airgapped and customCACerts to be configured at the same time

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: "1.0.0"
 maintainers:
   - name: wandb

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -64,30 +64,32 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.resources | nindent 10 }}
-        {{- if .Values.airgapped }}
+        {{- if or .Values.airgapped .Values.customCACerts }}
         volumeMounts:
-        - name: {{ include "name" . }}-charts
-          mountPath: /charts
-        {{- end }}
-        {{- if .Values.customCACerts }}
-        {{- range $index, $v := .Values.customCACerts }}
-        volumeMounts:
+          {{- if or .Values.airgapped }}
+          - name: {{ include "name" . }}-charts
+            mountPath: /charts
+          {{- end }}
+          {{- if .Values.customCACerts }}
+            {{- range $index, $v := .Values.customCACerts }}
           - name: wandb-ca-certs
             mountPath: /certs/customCA{{$index}}.crt
             subPath: customCA{{$index}}.crt
+            {{- end }}
+          {{- end }}
         {{- end }}
+      {{- if or .Values.airgapped .Values.customCACerts }}
+      volumes:
+        {{- if .Values.airgapped }}
+        - name: {{ include "name" . }}-charts
+          configMap:
+            name: {{ include "name" . }}-charts
         {{- end }}
-      {{- if .Values.airgapped }}
-      volumes:
-      - name: {{ include "name" . }}-charts
-        configMap:
-          name: {{ include "name" . }}-charts
-      {{- end }}
-      {{- if .Values.customCACerts }}
-      volumes:
-      - name: wandb-ca-certs
-        configMap:
-          name: {{ include "operator.fullname" . }}-ca-certs
+        {{- if .Values.customCACerts }}
+        - name: wandb-ca-certs
+          configMap:
+            name: {{ include "operator.fullname" . }}-ca-certs
+        {{- end }}
       {{- end }}
       serviceAccountName: {{ include "manager.serviceAccount.name" . }}
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The current `volumes` and `volumeMounts` logic would cause a conflict if both `airgapped` and `customCACerts` were enabled