### PR TITLE
fix: unrevert private WANDB_BASE_URL for weave

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.17.8
+version: 0.17.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: WEAVE_LOCAL_ARTIFACT_DIR
               value: /vol/weave/cache
             - name: WANDB_BASE_URL
-              value: {{ .Values.global.host }}
+              value: http://{{ .Release.Name }}-app:8080/
             - name: WEAVE_SERVER_NUM_WORKERS
               value: "4"
 


### PR DESCRIPTION
un reverts https://github.com/wandb/helm-charts/pull/185
which reverted https://github.com/wandb/helm-charts/pull/161

We reverted the initial change because we had a weave error in artifacts, that while we triaged it was safer to revert, now we need this change back in.