### PR TITLE
feat: Support to pull Redis credentials from secrets in the CR

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -42,4 +42,4 @@ dependencies:
   repository: file://charts/yace
   version: 0.1.0
 digest: sha256:bca2b6781737da6806e4485605cf9ce87b1428944b14cb88f082024cc3500bbd
-generated: "2024-09-23T18:18:08.220787+05:30"
+generated: "2024-10-01T11:37:15.56997+05:30"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.18.3
+version: 0.18.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/redis.yaml
+++ b/charts/operator-wandb/templates/redis.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.redis.install }}
+{{- if not .Values.global.redis.secretName }}
 {{- $secretName := (include "wandb.redis.passwordSecret" .)  }}
 apiVersion: v1
 kind: Secret
@@ -9,4 +10,5 @@ metadata:
 data:
   REDIS_PASSWORD: {{ include "wandb.redis.password" . | b64enc }}
   REDIS_CA_CERT: {{ include "wandb.redis.caCert" . | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -112,6 +112,7 @@ global:
     password: ""
     parameters: {}
     caCert: ""
+    secretName: ""
 
   kafka:
     # The following values are anchored here, and referenced by alias later for


### PR DESCRIPTION
Added support to pull REDIS entire configuration from secrets from Secrets when deploying CRD from yaml file.
Secret should look like this :
```apiVersion: v1
kind: Secret
metadata:
  name: my-redis-secret
type: Opaque
data:
  REDIS_PASSWORD: bXlwYXNzd29yZA==   
  REDIS_CA_CERT: bXljYQ== 
  REDIS_PORT: NjM3OQ==
  REDIS_HOST: bXlyaWRpcy5leGFtcGxlLmNvbQ==
```
