### PR TITLE
Allow setting pod annotations on launch agent

### DIFF
--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         {{- if .Values.agent.labels }}
         {{- toYaml .Values.agent.labels | trim | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.agent.podAnnotations }}
+        {{- toYaml .Values.agent.podAnnotations | trim | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: wandb-launch-serviceaccount-{{ .Release.Name }}
       {{- if or .Values.sshAuthSecrets .Values.kanikoPvcName }}
@@ -164,7 +168,7 @@ spec:
         - name: git-ssh-key-secret-{{ $index }}
           secret:
             secretName: {{ $secret.name }}
-            items: 
+            items:
               - key: ssh-privatekey
                 path: id_repo{{ $index }}
         {{- end }}

--- a/charts/launch-agent/values.yaml
+++ b/charts/launch-agent/values.yaml
@@ -1,5 +1,8 @@
 agent:
+  # Labels to add to the deployment.
   labels: {}
+  # Annotations to add to the pods.
+  podAnnotations: {}
   # W&B API key.
   apiKey: ""
   # Providing API key can be done external to this chart


### PR DESCRIPTION
This lets you set annotations on the launch agent pods (which I am going to use to set up [datadog multiline log aggregation](https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=kubernetes#multi-line-aggregation))