### PR TITLE
fix: Removing enableAdminAPI from wandb chart's values.yaml

### DIFF
--- a/charts/wandb/Chart.yaml
+++ b/charts/wandb/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: 0.60.0
 icon: https://wandb.ai/logo.svg
 maintainers:
-  - name: wandb
-    email: support@wandb.com
-    url: https://wandb.com
+- name: wandb
+  email: support@wandb.com
+  url: https://wandb.com

--- a/charts/wandb/templates/deployment.yaml
+++ b/charts/wandb/templates/deployment.yaml
@@ -82,15 +82,6 @@ spec:
             - name: GORILLA_DISABLE_SSO_PROVISIONING
               value: "{{ not .Values.sso.autoProvision }}"
             {{- end}}
-            {{- if .Values.enableAdminApi }}
-            - name: GLOBAL_ADMIN_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "wandb.fullname" . }}-secrets
-                  key: ADMIN_API_KEY
-            - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-              value: "true"
-            {{- end }}
             - name: WANDB_HELM_CHART
               value: {{ include "wandb.fullname" . }}:{{ .Chart.Version }}
             {{- if .Values.smtpServer }}

--- a/charts/wandb/values.yaml
+++ b/charts/wandb/values.yaml
@@ -7,8 +7,6 @@ image:
 
 # Required for production environments
 license:
-# If set to true we'll provision an admin user and allow admin api access
-enableAdminApi: false
 # If using S3 be sure the pod has valid IAM creds, if using minio
 # you can include the creds in the bucket url, i.e.
 # !!! Be sure to use the externally accessible host / ingress,
@@ -104,15 +102,14 @@ ldap:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: wandb.mycompany.net
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+  - host: wandb.mycompany.net
+    paths:
+    - path: /
+      pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Removing the `enableAdminAPI` key from the wandb chart's values.yaml file. Even being set to `false` currently this has tripped up customer installations as they are tempted to set it to `true`. This has caused customers to be unable to login after deploying the application, either requiring manual intervention to correct it or a fresh start to redeploy.