### PR TITLE
chore(dev): enable kafka jmx metrics

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.18.10
+version: 0.18.11
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -321,3 +321,6 @@ kafka:
   kraft:
     # This field is a UUID. It is *strongly* recommended to supply a new UUID yourself for production installs.
     clusterId: "ffFF1H3AQKGdBnsqAbJKew"
+  metrics:
+    jmx:
+      enabled: true


### PR DESCRIPTION
Enable jmx metrics from kafka instances. Daniel got this working for Google QA: https://deploy.wandb.ai/v2/admin/channels/8524aba0-2e34-42e7-a359-d451af023304