### PR TITLE
feat: Add support to pull CA Certs from configMap

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -42,4 +42,4 @@ dependencies:
   repository: file://charts/yace
   version: 0.1.0
 digest: sha256:bca2b6781737da6806e4485605cf9ce87b1428944b14cb88f082024cc3500bbd
-generated: "2024-11-04T12:53:11.852112+05:30"
+generated: "2024-11-08T13:07:42.344971+05:30"

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -42,4 +42,4 @@ dependencies:
   repository: file://charts/yace
   version: 0.1.0
 digest: sha256:bca2b6781737da6806e4485605cf9ce87b1428944b14cb88f082024cc3500bbd
-generated: "2024-10-09T17:53:33.992+05:30"
+generated: "2024-11-04T12:53:11.852112+05:30"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.18.14
+version: 0.18.15
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/_deployment.tpl
+++ b/charts/operator-wandb/charts/app/templates/_deployment.tpl
@@ -73,10 +73,15 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
             {{- end }}
+            {{- if .Values.global.configMapName }}
+            - name: wandb-ca-certs
+              mountPath: /usr/local/share/ca-certificates/
+            {{- else if .Values.global.customCACerts }}
             {{- range $index, $v := .Values.global.customCACerts }}
             - name: wandb-ca-certs
               mountPath: /usr/local/share/ca-certificates/customCA{{$index}}.crt
               subPath: customCA{{$index}}.crt
+            {{- end }}
             {{- end }}
           ports:
             - name: http
@@ -300,7 +305,11 @@ spec:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
         {{- end }}
-        {{- if .Values.global.customCACerts }}
+        {{- if .Values.global.configMapName }}
+        - name: wandb-ca-certs
+          configMap:
+            name: {{ .Values.global.configMapName }}
+        {{- else if .Values.global.customCACerts }}
         - name: wandb-ca-certs
           configMap:
             name: {{ include "wandb.fullname" . }}-ca-certs

--- a/charts/operator-wandb/charts/app/templates/_deployment.tpl
+++ b/charts/operator-wandb/charts/app/templates/_deployment.tpl
@@ -73,10 +73,11 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
             {{- end }}
-            {{- if .Values.global.configMapName }}
-            - name: wandb-ca-certs
+            {{- if .Values.global.caCertsConfigMap }}
+            - name: wandb-ca-certs-user
               mountPath: /usr/local/share/ca-certificates/
-            {{- else if .Values.global.customCACerts }}
+            {{- end }}
+            {{- if .Values.global.customCACerts }}
             {{- range $index, $v := .Values.global.customCACerts }}
             - name: wandb-ca-certs
               mountPath: /usr/local/share/ca-certificates/customCA{{$index}}.crt
@@ -305,11 +306,12 @@ spec:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
         {{- end }}
-        {{- if .Values.global.configMapName }}
-        - name: wandb-ca-certs
+        {{- if .Values.global.caCertsConfigMap }}
+        - name: wandb-ca-certs-user
           configMap:
-            name: {{ .Values.global.configMapName }}
-        {{- else if .Values.global.customCACerts }}
+            name: {{ .Values.global.caCertsConfigMap }}
+        {{- end }}
+        {{- if .Values.global.customCACerts }}
         - name: wandb-ca-certs
           configMap:
             name: {{ include "wandb.fullname" . }}-ca-certs

--- a/charts/operator-wandb/charts/app/templates/configmap.yaml
+++ b/charts/operator-wandb/charts/app/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.customCACerts }}
+{{- if and (not .Values.global.configMapName) .Values.global.customCACerts }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/operator-wandb/charts/app/templates/configmap.yaml
+++ b/charts/operator-wandb/charts/app/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.global.configMapName) .Values.global.customCACerts }}
+{{- if .Values.global.customCACerts }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/operator-wandb/charts/parquet/templates/configmap.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.customCACerts }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "parquet.fullname" . }}-ca-certs
+  labels:
+    {{- include "wandb.labels" . | nindent 4 }}
+data:
+  {{- range $index, $pem := .Values.global.customCACerts }}
+  customCA{{$index}}.crt: |-
+    {{- range splitList "\n" $pem }}
+    {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -52,6 +52,17 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
             {{- end }}
+            {{- if .Values.global.caCertsConfigMap }}
+            - name: wandb-ca-certs-user
+              mountPath: /usr/local/share/ca-certificates/
+            {{- end }}
+            {{- if .Values.global.customCACerts }}
+            {{- range $index, $v := .Values.global.customCACerts }}
+            - name: wandb-ca-certs
+              mountPath: /usr/local/share/ca-certificates/customCA{{$index}}.crt
+              subPath: customCA{{$index}}.crt
+            {{- end }}
+            {{- end }}
           ports:
             - name: parquet
               containerPort: 8087
@@ -153,5 +164,15 @@ spec:
             items:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
+        {{- end }}
+        {{- if .Values.global.caCertsConfigMap }}
+        - name: wandb-ca-certs-user
+          configMap:
+            name: {{ .Values.global.caCertsConfigMap }}
+        {{- end }}
+        {{- if .Values.global.customCACerts }}
+        - name: wandb-ca-certs
+          configMap:
+            name: {{ include "parquet.fullname" . }}-ca-certs
         {{- end }}
 {{- end }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -129,7 +129,18 @@ global:
     # If the topic already exists then changing the number of partitions is not possible.
     runUpdatesShadowNumPartitions: 12
 
+# To provide custom CA certificates, you can use either:
+# 1. `customCACerts`: a list of certificates provided directly within this Helm chart.
+# 2. `configMapName`: the name of a ConfigMap containing CA certificates.
+#
+# Important:
+# - If using a ConfigMap, each key in the ConfigMap must end with `.crt` (e.g., `my-cert.crt`).
+# - This naming convention is required for `update-ca-certificates` to parse and add each
+#   certificate to the system CA store on Ubuntu-based systems.
+
+# List of custom CA certificates in PEM format.
   customCACerts: []
+# Name of ConfigMap containing .crt files for custom CA certificates.
   configMapName: ""
 
   weave-trace:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -140,8 +140,8 @@ global:
 
 # List of custom CA certificates in PEM format.
   customCACerts: []
-# Name of ConfigMap containing .crt files for custom CA certificates.
-  configMapName: ""
+# Name of a ConfigMap containing additional .crt files for CA certificates.
+  caCertsConfigMap: ""
 
   weave-trace:
     enabled: false

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -130,6 +130,7 @@ global:
     runUpdatesShadowNumPartitions: 12
 
   customCACerts: []
+  configMapName: ""
 
   weave-trace:
     enabled: false


### PR DESCRIPTION
Add support to pull the list of CA Certs from configMaps (W&B App)

Create configmap
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: custom-ca-certs
data:
  ca-cert1.crt: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
  ca-cert2.crt: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
```
values.yaml 
configMapName: "custom-ca-certs"
