### PR TITLE
chore: set GOMEMLIMIT in app, parquet

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.18.14
+version: 0.18.15
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/_deployment.tpl
+++ b/charts/operator-wandb/charts/app/templates/_deployment.tpl
@@ -89,6 +89,10 @@ spec:
               containerPort: 8125
               protocol: TCP
           env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
             - name: GLUE_ENABLED
               value: "{{ .glueSingletonEnabled }}"
             {{- if .onlyService }}

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -58,6 +58,10 @@ spec:
                   subPath: redis_ca.pem
                 {{- end }}
               env:
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
                 - name: GORILLA_GLUE_EXECUTE
                   value: "true"
                 - name: GORILLA_GLUE_EXECUTE_TASK_NAME

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
               containerPort: 8087
               protocol: TCP
           env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
             {{- if ne .Values.traceRatio 0.0 }}
             - name: GORILLA_TRACER
               value: "otlp+grpc://{{ .Release.Name }}-otel-daemonset:4317?trace_ratio={{ .Values.traceRatio }}"


### PR DESCRIPTION
The default [GOGC](https://pkg.go.dev/runtime#hdr-Environment_Variables) behavior is not great for many workloads, and it is especially bad for Parquet, because it is based entirely on the ratio between memory that survived the previous GC event and the amount of freshly allocated objects. By setting `GOMEMLIMIT`, we'll only trigger GC events when we're close to pod's limits. 