### PR TITLE
refactor: bucket template helpers

### DIFF
--- a/charts/operator-wandb/charts/app/templates/_deployment.tpl
+++ b/charts/operator-wandb/charts/app/templates/_deployment.tpl
@@ -209,7 +209,7 @@ spec:
             {{- end }}
             {{- end }}
             - name: BUCKET
-              value: {{ include "app.bucket" . | quote}}
+              value: {{ include "wandb.resolved.bucket" .url | quote}}
             - name: AWS_REGION
               value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID
@@ -239,7 +239,7 @@ spec:
               value: "otlp+grpc://{{ .Release.Name }}-otel-daemonset:4317?trace_ratio={{ .Values.traceRatio }}"
             {{- end }}
             - name: OVERFLOW_BUCKET_ADDR
-              value: {{ include "app.bucket" . | quote }}
+              value: {{ include "wandb.resolved.bucket" .url | quote }}
             {{- if not .Values.global.pubSub.enabled}}
             - name: KAFKA_BROKER_HOST
               value: "{{ include "wandb.kafka.brokerHost" . }}"
@@ -261,7 +261,7 @@ spec:
               value: >
                 {
                   "overflow-bucket": {
-                    "store": {{ include "app.bucket" . | quote}},
+                    "store": {{ include "wandb.resolved.bucket" .url | quote}},
                     "name": "wandb",
                     "prefix": "wandb-overflow"
                   },

--- a/charts/operator-wandb/charts/app/templates/_deployment.tpl
+++ b/charts/operator-wandb/charts/app/templates/_deployment.tpl
@@ -211,9 +211,9 @@ spec:
             - name: BUCKET
               value: {{ include "app.bucket" . | quote}}
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+              value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
+              value: "{{ include "wandb.resolved.bucket" .kmsKey }}"
             - name: OPERATOR_ENABLED
               value: 'true'
             - name: LOGGING_ENABLED
@@ -222,7 +222,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ include "wandb.bucket.secret" . }}"
-                  key: {{ .Values.global.bucket.accessKeyName }}
+                  key: {{ include "wandb.resolved.bucket" .accessKeyName }}
                   optional: true
             - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
               valueFrom:

--- a/charts/operator-wandb/charts/app/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/app/templates/_helpers.tpl
@@ -111,10 +111,7 @@ app deployments.
 {{- end }}
 
 {{- define "app.bucket" -}}
-{{- $bucketValues := .Values.global.defaultBucket }}
-{{- if .Values.global.bucket.provider }}
-{{- $bucketValues = .Values.global.bucket }}
-{{- end }}
+{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
 {{- $bucket := "" -}} 
 {{- if eq $bucketValues.provider "az" -}}
 {{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}

--- a/charts/operator-wandb/charts/app/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/app/templates/_helpers.tpl
@@ -110,25 +110,6 @@ app deployments.
 {{- end }}
 {{- end }}
 
-{{- define "app.bucket" -}}
-{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
-{{- $bucket := "" -}} 
-{{- if eq $bucketValues.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "s3" -}}
-{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name (default "" $bucketValues.path) -}}
-{{- else -}}
-{{- $bucket = printf "s3://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- end -}}
-{{- trimSuffix "/" $bucket -}}
-{{- end -}}
-
 {{- define "app.internalJWTMap" -}}
 '{
 {{- range $value := .Values.internalJWTMap -}}

--- a/charts/operator-wandb/charts/executor/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/executor/templates/_helpers.tpl
@@ -106,25 +106,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "executor.bucket" -}}
-{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
-{{- $bucket := "" -}}
-{{- if eq $bucketValues.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "s3" -}}
-{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name (default "" $bucketValues.path) -}}
-{{- else -}}
-{{- $bucket = printf "s3://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- end -}}
-{{- trimSuffix "/" $bucket -}}
-{{- end -}}
-
 {{- define "executor.historyStore" -}}
 {{- $historyStore := printf "http://%s-parquet:8087/_goRPC_" .Release.Name -}}
 {{- if .Values.global.bigTable.enabled -}}

--- a/charts/operator-wandb/charts/executor/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/executor/templates/_helpers.tpl
@@ -107,10 +107,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "executor.bucket" -}}
-{{- $bucketValues := .Values.global.defaultBucket }}
-{{- if .Values.global.bucket.provider }}
-{{- $bucketValues = .Values.global.bucket }}
-{{- end }}
+{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
 {{- $bucket := "" -}}
 {{- if eq $bucketValues.provider "az" -}}
 {{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -117,14 +117,14 @@ spec:
             - name: BUCKET
               value: "{{ include "executor.bucket" . }}"
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+              value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
+              value: "{{ include "wandb.resolved.bucket" .kmsKey }}"
             - name: AZURE_STORAGE_KEY
               valueFrom:
                 secretKeyRef:
                   name: "{{ include "wandb.bucket.secret" . }}"
-                  key: {{ .Values.global.bucket.accessKeyName }}
+                  key: {{ include "wandb.resolved.bucket" .accessKeyName }}
                   optional: true
 
             - name: G_HOST_IP

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
               value: {{ include "executor.fileStreamStore" . | quote }}
 
             - name: BUCKET
-              value: "{{ include "executor.bucket" . }}"
+              value: "{{ include "wandb.resolved.bucket" .url }}"
             - name: AWS_REGION
               value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID

--- a/charts/operator-wandb/charts/filestream/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/filestream/templates/_helpers.tpl
@@ -107,10 +107,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "filestream.bucket" -}}
-{{- $bucketValues := .Values.global.defaultBucket }}
-{{- if .Values.global.bucket.provider }}
-{{- $bucketValues = .Values.global.bucket }}
-{{- end }}
+{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
 {{- $bucket := "" -}}
 {{- if eq $bucketValues.provider "az" -}}
 {{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}

--- a/charts/operator-wandb/charts/filestream/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/filestream/templates/_helpers.tpl
@@ -106,25 +106,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "filestream.bucket" -}}
-{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
-{{- $bucket := "" -}}
-{{- if eq $bucketValues.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "s3" -}}
-{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name (default "" $bucketValues.path) -}}
-{{- else -}}
-{{- $bucket = printf "s3://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- end -}}
-{{- trimSuffix "/" $bucket -}}
-{{- end -}}
-
 {{- define "filestream.fileStreamWorkerSource" -}}
 {{- if .Values.global.pubSub.enabled -}}
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.filestreamTopic }}/{{ .Values.pubSub.subscription }}

--- a/charts/operator-wandb/charts/filestream/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/filestream/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ include "wandb.bucket.secret" . }}"
-                  key: {{ .Values.global.bucket.accessKeyName }}
+                  key: {{ include "wandb.resolved.bucket" .accessKeyName }}
                   optional: true
             - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
               valueFrom:
@@ -109,9 +109,9 @@ spec:
             - name: BUCKET
               value: "{{ include "filestream.bucket" .}}"
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+              value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
+              value: "{{ include "wandb.resolved.bucket" .kmsKey }}"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/operator-wandb/charts/filestream/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/filestream/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: MYSQL
               value: "mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)"
             - name: BUCKET
-              value: "{{ include "filestream.bucket" .}}"
+              value: "{{ include "wandb.resolved.bucket" .url }}"
             - name: AWS_REGION
               value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
@@ -107,10 +107,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "flat-run-fields-updater.bucket" -}}
-{{- $bucketValues := .Values.global.defaultBucket }}
-{{- if .Values.global.bucket.provider }}
-{{- $bucketValues = .Values.global.bucket }}
-{{- end }}
+{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
 {{- $bucket := "" -}}
 {{- if eq $bucketValues.provider "az" -}}
 {{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/_helpers.tpl
@@ -106,25 +106,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "flat-run-fields-updater.bucket" -}}
-{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
-{{- $bucket := "" -}}
-{{- if eq $bucketValues.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "s3" -}}
-{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name (default "" $bucketValues.path) -}}
-{{- else -}}
-{{- $bucket = printf "s3://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- end -}}
-{{- trimSuffix "/" $bucket -}}
-{{- end -}}
-
 {{- define "flat-run-fields-updater.runUpdateShadowQueue" -}}
 {{- if .Values.global.pubSub.enabled -}}
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}/{{ .Values.pubSub.subscription }}

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -124,7 +124,7 @@ spec:
               value: "{{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}"
             {{- end }}
             - name: BUCKET
-              value: "{{ include "flat-run-fields-updater.bucket" .}}"
+              value: "{{ include "wandb.resolved.bucket" .url }}"
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
               value: >
                 {

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ include "wandb.bucket.secret" . }}"
-                  key: {{ .Values.global.bucket.accessKeyName }}
+                  key: {{ include "wandb.resolved.bucket" .accessKeyName }}
                   optional: true
             - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
               valueFrom:
@@ -138,9 +138,9 @@ spec:
                   }
                 }
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+              value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
+              value: "{{ include "wandb.resolved.bucket" .kmsKey }}"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -110,24 +110,6 @@ app deployments.
 {{- end }}
 {{- end -}}
 
-{{- define "parquet.bucket" -}}
-{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
-{{- $bucket := "" -}}
-{{- if eq $bucketValues.provider "az" -}}
-{{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "gcs" -}}
-{{- $bucket = printf "gs://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- if eq $bucketValues.provider "s3" -}}
-{{- if and $bucketValues.accessKey $bucketValues.secretKey -}}
-{{- $bucket = printf "s3://%s:%s@%s/%s" $bucketValues.accessKey $bucketValues.secretKey $bucketValues.name (default "" $bucketValues.path) -}}
-{{- else -}}
-{{- $bucket = printf "s3://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}
-{{- end -}}
-{{- end -}}
-{{- trimSuffix "/" $bucket -}}
-{{- end -}}
 
 {{- define "parquet.historyStore" -}}
 {{- $historyStore := printf "http://%s-parquet:8087/_goRPC_" .Release.Name -}}

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -111,10 +111,7 @@ app deployments.
 {{- end -}}
 
 {{- define "parquet.bucket" -}}
-{{- $bucketValues := .Values.global.defaultBucket }}
-{{- if .Values.global.bucket.provider }}
-{{- $bucketValues = .Values.global.bucket }}
-{{- end }}
+{{- $bucketValues := ( include "wandb.resolved.bucket" . ) }}
 {{- $bucket := "" -}}
 {{- if eq $bucketValues.provider "az" -}}
 {{- $bucket = printf "az://%s/%s" $bucketValues.name (default "" $bucketValues.path) -}}

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -130,7 +130,7 @@ spec:
                   value: 'true'
 
                 - name: BUCKET
-                  value: "{{ include "parquet.bucket" . }}"
+                  value: "{{ include "wandb.resolved.bucket" .url }}"
                 - name: AWS_REGION
                   value: {{ include "wandb.resolved.bucket" .region }}
                 - name: AWS_S3_KMS_ID

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -132,17 +132,17 @@ spec:
                 - name: BUCKET
                   value: "{{ include "parquet.bucket" . }}"
                 - name: AWS_REGION
-                  value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+                  value: {{ include "wandb.resolved.bucket" .region }}
                 - name: AWS_S3_KMS_ID
-                  value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
+                  value: "{{ include "wandb.resolved.bucket" .kmsKey }}"
 
                 - name: AZURE_STORAGE_KEY
                   valueFrom:
                     secretKeyRef:
                       name: "{{ include "wandb.bucket.secret" . }}"
-                      key: {{ .Values.global.bucket.accessKeyName }}
+                      key: {{ include "wandb.resolved.bucket" .accessKeyName }}
                       optional: true
-                
+
                 - name: G_HOST_IP
                   valueFrom:
                     fieldRef:

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -130,21 +130,21 @@ spec:
             - name: BUCKET
               value: "{{ include "parquet.bucket" . }}"
             - name: AWS_REGION
-              value: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+              value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID
-              value: "{{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}"
+              value: "{{ include "wandb.resolved.bucket" .kmsKey }}"
             - name: AZURE_STORAGE_KEY
               valueFrom:
                 secretKeyRef:
                   name: "{{ include "wandb.bucket.secret" . }}"
-                  key: {{ .Values.global.bucket.accessKeyName }}
+                  key: {{ include "wandb.resolved.bucket" .accessKeyName }}
                   optional: true
 
             - name: G_HOST_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            
+
             {{- if ne .Values.global.email.smtp.host "" }}
             - name: GORILLA_EMAIL_SINK
               value: "smtp://{{ .Values.global.email.smtp.user }}:{{ .Values.global.email.smtp.password }}@{{ .Values.global.email.smtp.host }}:{{ .Values.global.email.smtp.port }}"

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
               value: {{ include "parquet.fileStreamStore" . | quote }}
 
             - name: BUCKET
-              value: "{{ include "parquet.bucket" . }}"
+              value: {{ include "wandb.resolved.bucket" .url | quote }}
             - name: AWS_REGION
               value: {{ include "wandb.resolved.bucket" .region }}
             - name: AWS_S3_KMS_ID

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -2,8 +2,10 @@
   Assorted bucket related helpers.
 */}}
 {{- define "wandb.bucket.secret" -}}
-{{- if include "wandb.resolved.bucket" .secretName -}}
-  {{ include "wandb.resolved.bucket" .secretName  }}
+{{- if .Values.global.bucket.secretName -}}
+  {{ .Values.global.bucket.secretName }}
+{{- else if .Values.global.defaultBucket.secretName -}}
+  {{ .Values.global.defaultBucket.secretName }}
 {{- else }}
   {{- print .Release.Name "-bucket" -}}
 {{- end -}}
@@ -11,14 +13,35 @@
 
 
 {{- define "wandb.resolved.bucket" -}}
-provider: {{ .Values.global.bucket.provider | default .Values.global.defaultBucket.provider}}
-name: {{ .Values.global.bucket.name | default .Values.global.defaultBucket.name }}
-path: {{ .Values.global.bucket.path | default .Values.global.defaultBucket.path }}
+{{- $url := "" -}} 
+{{- $provider := .Values.global.bucket.provider | default .Values.global.defaultBucket.provider -}}
+provider: {{ $provider }}
+{{- $name := .Values.global.bucket.name | default .Values.global.defaultBucket.name -}}
+name: {{ $name }}
+{{- $path := .Values.global.bucket.path | default (default "" .Values.global.defaultBucket.path) -}} 
+path: {{ $path }}
 region: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
 kmsKey: {{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}
-accessKey: {{- b64enc "test" -}}
+{{- $accessKey:= .Values.global.bucket.accessKey | default .Values.global.defaultBucket.accessKey -}}
+accessKey: {{ $accessKey }}
+{{- $secretKey:= .Values.global.bucket.secretKey | default .Values.global.defaultBucket.secretKey -}}
+secretKey: {{ $secretKey }}
 accessKeyName: {{ .Values.global.bucket.accessKeyName | default .Values.global.defaultBucket.accessKeyName }}
-secretKey: {{- b64enc "test" -}}
 secretAccessKeyName: {{ .Values.global.bucket.secretAccessKeyName | default .Values.global.defaultBucket.secretAccessKeyName }}
 secretName: {{ .Value.global.bucket.secretName | default .Values.global.defaultBucket.secretName }}
+{{- if eq $provider "az" -}}
+{{- $url = printf "az://%s/%s" $name $path -}}
+{{- end -}}
+{{- if eq $provider "gcs" -}}
+{{- $url = printf "gs://%s/%s" $name $path -}}
+{{- end -}}
+{{- if eq $provider "s3" -}}
+{{- if and $accessKey $secretKey -}}
+{{- $url = printf "s3://%s:%s@%s/%s" $accessKey $secretKey $name $path -}}
+{{- else -}}
+{{- $url = printf "s3://%s/%s" $name $path -}}
+{{- end -}}
+{{- end -}}
+{{- trimSuffix "/" $url -}}
+url: {{ $url }}
 {{- end -}}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -1,12 +1,24 @@
 {{/*
-Return the bucket credentials secret name
+  Assorted bucket related helpers.
 */}}
 {{- define "wandb.bucket.secret" -}}
-{{- if .Values.global.bucket.secretName -}}
-  {{ .Values.global.bucket.secretName }}
-{{- else if .Values.global.defaultBucket.secretName -}}
-  {{ .Values.global.defaultBucket.secretName }}
+{{- if include "wandb.resolved.bucket" .secretName -}}
+  {{ include "wandb.resolved.bucket" .secretName  }}
 {{- else }}
   {{- print .Release.Name "-bucket" -}}
 {{- end -}}
 {{- end }}
+
+
+{{- define "wandb.resolved.bucket" -}}
+provider: {{ .Values.global.bucket.provider | default .Values.global.defaultBucket.provider}}
+name: {{ .Values.global.bucket.name | default .Values.global.defaultBucket.name }}
+path: {{ .Values.global.bucket.path | default .Values.global.defaultBucket.path }}
+region: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
+kmsKey: {{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}
+accessKey: {{- b64enc "test" -}}
+accessKeyName: {{ .Values.global.bucket.accessKeyName | default .Values.global.defaultBucket.accessKeyName }}
+secretKey: {{- b64enc "test" -}}
+secretAccessKeyName: {{ .Values.global.bucket.secretAccessKeyName | default .Values.global.defaultBucket.secretAccessKeyName }}
+secretName: {{ .Value.global.bucket.secretName | default .Values.global.defaultBucket.secretName }}
+{{- end -}}

--- a/charts/operator-wandb/templates/bucket.yaml
+++ b/charts/operator-wandb/templates/bucket.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.bucket.secretName }}
+{{- if not (include "wandb.resolved.bucket" .secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
-  ACCESS_KEY: {{ .Values.global.bucket.accessKey | default .Values.global.defaultBucket.accessKey | b64enc }}
-  SECRET_KEY: {{ .Values.global.bucket.secretKey | default .Values.global.defaultBucket.secretKey | b64enc }}
+  ACCESS_KEY: {{ include "wandb.resolved.bucket" .accessKey }}
+  SECRET_KEY: {{ include "wandb.resolved.bucket" .secretKey }}
 {{- end }}

--- a/charts/operator-wandb/templates/bucket.yaml
+++ b/charts/operator-wandb/templates/bucket.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
-  ACCESS_KEY: {{ include "wandb.resolved.bucket" .accessKey }}
-  SECRET_KEY: {{ include "wandb.resolved.bucket" .secretKey }}
+  ACCESS_KEY: {{ include "wandb.resolved.bucket" .accessKey | b64enc }}
+  SECRET_KEY: {{ include "wandb.resolved.bucket" .secretKey | b64enc }}
 {{- end }}


### PR DESCRIPTION
It should functionally create the exact same helm charts as before.

context:
- [origin](https://weightsandbiases.slack.com/archives/C07PG6N066T/p1732559145129699)
- [disscusion](https://weightsandbiases.slack.com/archives/C07749DG7L2/p1732705160234929)

changes:
- creates a singular `wandb.resolved.bucket` reference for templates to utilize consolidating the `bucket.{} | default defaultBucket.{}` logic to a single place
- consolidates logic for constructing the "s3 compatible URL" to a single place.