### PR TITLE
fix: enable flat run field updates in executor pod

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.23.1
+version: 0.23.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/executor/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/executor/templates/_helpers.tpl
@@ -152,7 +152,7 @@ mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATA
 {{- end -}}
 {{- end -}}
 
-{{- define "app.runUpdateShadowTopic" -}}
+{{- define "executor.runUpdateShadowTopic" -}}
 {{- if .Values.global.pubSub.enabled -}}
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}
 {{- else if .Values.global.beta.bufstream.enabled -}}

--- a/charts/operator-wandb/charts/executor/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/executor/templates/_helpers.tpl
@@ -152,6 +152,16 @@ mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATA
 {{- end -}}
 {{- end -}}
 
+{{- define "executor.runUpdateShadowQueue" -}}
+{{- if .Values.global.pubSub.enabled -}}
+pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}/{{ .Values.pubSub.subscription }}
+{{- else if .Values.global.beta.bufstream.enabled -}}
+kafka://$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=default-group&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+{{- else -}}
+kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=default-group&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+{{- end -}}
+{{- end -}}
+
 {{- define "executor.envFrom" -}}
 {{- range $key, $value := .Values.envFrom -}}
 - {{ $value }}:

--- a/charts/operator-wandb/charts/executor/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/executor/templates/_helpers.tpl
@@ -152,13 +152,13 @@ mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATA
 {{- end -}}
 {{- end -}}
 
-{{- define "executor.runUpdateShadowQueue" -}}
+{{- define "app.runUpdateShadowTopic" -}}
 {{- if .Values.global.pubSub.enabled -}}
-pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}/{{ .Values.pubSub.subscription }}
+pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}
 {{- else if .Values.global.beta.bufstream.enabled -}}
-kafka://$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=default-group&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
 {{- else -}}
-kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=default-group&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
 {{- end -}}
 {{- end -}}
 

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -126,6 +126,19 @@ spec:
               value: "{{ include "executor.redis" . | trim }}{{- if .Values.workerConcurrency }}&concurrency={{ .Values.workerConcurrency }}{{- end }}"
             - name: GORILLA_TASK_QUEUE_WORKER_ENABLED
               value: "true"
+            
+            - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
+              value: >
+                {
+                  "overflow-bucket": {
+                    "store": "$(BUCKET)",
+                    "name": "wandb",
+                    "prefix": "wandb-overflow"
+                  },
+                  "subscriptions": {
+                    "flatRunFieldsUpdater": {{ include "executor.runUpdateShadowQueue" . | quote }}
+                  }
+                }
 
             - name: GORILLA_HISTORY_STORE
               value: {{ include "executor.historyStore" . | quote }}

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -127,17 +127,27 @@ spec:
             - name: GORILLA_TASK_QUEUE_WORKER_ENABLED
               value: "true"
             
+            {{- if not .Values.global.pubSub.enabled}}
+            - name: KAFKA_CLIENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wandb.kafka.passwordSecret" . }}
+                  key: {{ include "wandb.kafka.passwordSecret.passwordKey" .}}
+                  optional: true
+            - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
+              value: {{ include "wandb.kafka.runUpdatesShadowTopic" .}}
+            - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
+              value: "{{ include "wandb.kafka.runUpdatesShadowNumPartitions" .}}"
+            {{- end }}
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
               value: >
                 {
                   "overflow-bucket": {
-                    "store": "$(BUCKET)",
+                    "store": {{ (include "wandb.bucket" . | fromYaml).url | quote}},
                     "name": "wandb",
                     "prefix": "wandb-overflow"
                   },
-                  "subscriptions": {
-                    "flatRunFieldsUpdater": {{ include "executor.runUpdateShadowQueue" . | quote }}
-                  }
+                  "addr": {{ include "app.runUpdateShadowTopic" . | quote }}
                 }
 
             - name: GORILLA_HISTORY_STORE

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
                     "name": "wandb",
                     "prefix": "wandb-overflow"
                   },
-                  "addr": {{ include "app.runUpdateShadowTopic" . | quote }}
+                  "addr": {{ include "executor.runUpdateShadowTopic" . | quote }}
                 }
 
             - name: GORILLA_HISTORY_STORE


### PR DESCRIPTION
The executor pod needs to be able to write to runs v2 (flat run fields) for moving runs, etc. 

Make sure it has the proper environment variables to know which queue to write to. 