### PR TITLE
fix: Bucket postfix trailing slash

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.23.6
+version: 0.23.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -30,18 +30,42 @@ secretKey: {{ $secretKey }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}
 secretName: {{ include "wandb.bucket.secret" . }}
+{{- if eq $path "" -}}
+
+{{- if eq $provider "az" -}}
+{{- $url = "az://$(BUCKET_NAME)" -}}
+{{- end -}}
+
+{{- if eq $provider "gcs" -}}
+{{- $url = "gs://$(BUCKET_NAME)" -}}
+{{- end -}}
+
+{{- if eq $provider "s3" -}}
+{{- if or (and $accessKey $secretKey) .Values.global.bucket.secret.secretName -}}
+{{- $url = "s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)" -}}
+{{- else -}}
+{{- $url = "s3://$(BUCKET_NAME)" -}}
+{{- end -}}
+{{- end -}}
+
+{{- else -}}
+
 {{- if eq $provider "az" -}}
 {{- $url = "az://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
 {{- end -}}
+
 {{- if eq $provider "gcs" -}}
 {{- $url = "gs://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
 {{- end -}}
+
 {{- if eq $provider "s3" -}}
 {{- if or (and $accessKey $secretKey) .Values.global.bucket.secret.secretName -}}
 {{- $url = "s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
 {{- else -}}
 {{- $url = "s3://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
 {{- end -}}
+{{- end -}}
+
 {{- end -}}
 {{- $url = trimSuffix "/" $url }}
 url: {{ $url }}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -30,29 +30,43 @@ secretKey: {{ $secretKey }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}
 secretName: {{ include "wandb.bucket.secret" . }}
-
-{{- $bucketAndPath := "" -}}
 {{- if eq $path "" -}}
-{{- $bucketAndPath = "$(BUCKET_NAME)" -}}
-{{- else -}}
-{{- $bucketAndPath = "$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
-{{- end -}}
 
 {{- if eq $provider "az" -}}
-{{- $url = printf "az://%s" $bucketAndPath -}}
+{{- $url = "az://$(BUCKET_NAME)" -}}
 {{- end -}}
 
 {{- if eq $provider "gcs" -}}
-{{- $url = printf "gs://%s" $bucketAndPath -}}
+{{- $url = "gs://$(BUCKET_NAME)" -}}
 {{- end -}}
 
 {{- if eq $provider "s3" -}}
 {{- if or (and $accessKey $secretKey) .Values.global.bucket.secret.secretName -}}
-{{- $url = printf "s3://%s:%s@%s" $accessKey $secretKey $bucketAndPath -}}
+{{- $url = "s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)" -}}
 {{- else -}}
-{{- $url = printf "s3://%s" $bucketAndPath -}}
+{{- $url = "s3://$(BUCKET_NAME)" -}}
 {{- end -}}
 {{- end -}}
 
+{{- else -}}
+
+{{- if eq $provider "az" -}}
+{{- $url = "az://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
+{{- end -}}
+
+{{- if eq $provider "gcs" -}}
+{{- $url = "gs://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
+{{- end -}}
+
+{{- if eq $provider "s3" -}}
+{{- if or (and $accessKey $secretKey) .Values.global.bucket.secret.secretName -}}
+{{- $url = "s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
+{{- else -}}
+{{- $url = "s3://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
+{{- end -}}
+{{- end -}}
+
+{{- end -}}
+{{- $url = trimSuffix "/" $url }}
 url: {{ $url }}
 {{- end -}}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -30,43 +30,29 @@ secretKey: {{ $secretKey }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}
 secretName: {{ include "wandb.bucket.secret" . }}
+
+{{- $bucketAndPath := "" -}}
 {{- if eq $path "" -}}
+{{- $bucketAndPath = "$(BUCKET_NAME)" -}}
+{{- else -}}
+{{- $bucketAndPath = "$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
+{{- end -}}
 
 {{- if eq $provider "az" -}}
-{{- $url = "az://$(BUCKET_NAME)" -}}
+{{- $url = printf "az://%s" $bucketAndPath -}}
 {{- end -}}
 
 {{- if eq $provider "gcs" -}}
-{{- $url = "gs://$(BUCKET_NAME)" -}}
+{{- $url = printf "gs://%s" $bucketAndPath -}}
 {{- end -}}
 
 {{- if eq $provider "s3" -}}
 {{- if or (and $accessKey $secretKey) .Values.global.bucket.secret.secretName -}}
-{{- $url = "s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)" -}}
+{{- $url = printf "s3://%s:%s@%s" $accessKey $secretKey $bucketAndPath -}}
 {{- else -}}
-{{- $url = "s3://$(BUCKET_NAME)" -}}
+{{- $url = printf "s3://%s" $bucketAndPath -}}
 {{- end -}}
 {{- end -}}
 
-{{- else -}}
-
-{{- if eq $provider "az" -}}
-{{- $url = "az://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
-{{- end -}}
-
-{{- if eq $provider "gcs" -}}
-{{- $url = "gs://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
-{{- end -}}
-
-{{- if eq $provider "s3" -}}
-{{- if or (and $accessKey $secretKey) .Values.global.bucket.secret.secretName -}}
-{{- $url = "s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
-{{- else -}}
-{{- $url = "s3://$(BUCKET_NAME)/$(BUCKET_PATH)" -}}
-{{- end -}}
-{{- end -}}
-
-{{- end -}}
-{{- $url = trimSuffix "/" $url }}
 url: {{ $url }}
 {{- end -}}


### PR DESCRIPTION
This solves an issue where there is a trailing `/` in the bucket if path is not set. 

Before:
```yaml
            - name: BUCKET
              value: "gs://$(BUCKET_NAME)/$(BUCKET_PATH)"
```

After
```yaml
            - name: BUCKET
              value: "gs://$(BUCKET_NAME)"
```

The problem is that then the bucket will be

Before
```bash
BUCKET=gs://wandb-qa-local-whole-crow/
```

After
```bash
BUCKET=gs://wandb-qa-local-whole-crow
```

Which can lead to issues with the application. 