### PR TITLE
fix: Task Queue Templating

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.23.7
+version: 0.23.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/gorilla.yaml
+++ b/charts/operator-wandb/templates/gorilla.yaml
@@ -80,7 +80,6 @@ data:
   GORILLA_GLUE_TASK_PROVIDER: "memory://"
   GORILLA_DEFAULT_REGION: "{{ default .Values.global.cloudProvider "minio" }}-{{ (include "wandb.bucket" . | fromYaml).region }}"
   {{- if .Values.global.executor.enabled }}
-  GORILLA_TASK_QUEUE: "{{ include "app.redis" . | trim }}"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   {{- else }}
   GORILLA_TASK_QUEUE: "noop://"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -645,6 +645,8 @@ api:
       value: '{{ include "wandb.redis" . | trim }}'
     GORILLA_FILE_METADATA_SOURCE:
       value: '{{ include "wandb.redis" . | trim }}'
+    GORILLA_TASK_QUEUE:
+      value: '{{ include "wandb.redis" . | trim }}'
     GORILLA_GLUE_TASK_STRATEGY_STORE:
       value: '{{ include "wandb.mysql" . | trim }}'
     GORILLA_GLUE_TASK_METADATA_STORE:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -482,6 +482,8 @@ glue:
       value: '{{ include "wandb.redis" . | trim }}'
     GORILLA_FILE_METADATA_SOURCE:
       value: '{{ include "wandb.redis" . | trim }}'
+    GORILLA_TASK_QUEUE:
+      value: '{{ include "wandb.redis" . | trim }}'
     GORILLA_GLUE_TASK_STRATEGY_STORE:
       value: '{{ include "wandb.mysql" . | trim }}'
     GORILLA_GLUE_TASK_METADATA_STORE:


### PR DESCRIPTION
Fix a templating issue where it was producing the raw string of 

```bash
"redis://$(REDIS_HOST):$(REDIS_PORT)"
```

in the configmap which is invalid.