### PR TITLE
fix: Switch between default bucket and bucket based on name

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.24.0
+version: 0.24.1
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -15,17 +15,30 @@
 
 {{- define "wandb.bucket" -}}
 {{- $url := "" -}}
-{{- $provider := .Values.global.bucket.provider | default .Values.global.defaultBucket.provider -}}
+{{- $path := "" -}}
+{{- $provider := "" -}}
+{{- $accessKey := "" -}}
+{{- $secretKey := "" -}}
+{{- if .Values.global.bucket.name -}}
+{{- $provider = .Values.global.bucket.provider -}}
+{{- $path = .Values.global.bucket.path -}}
+{{- $accessKey = default "" .Values.global.bucket.accessKey -}}
+{{- $secretKey = default "" .Values.global.bucket.secretKey -}}
+name: {{ .Values.global.bucket.name }}
+region: {{ .Values.global.bucket.region }}
+kmsKey: {{ .Values.global.bucket.kmsKey }}
+{{- else -}}
+{{- $provider = .Values.global.defaultBucket.provider -}}
+{{- $path = .Values.global.defaultBucket.path -}}
+{{- $accessKey = default "" .Values.global.defaultBucket.accessKey -}}
+{{- $secretKey = default "" .Values.global.defaultBucket.secretKey -}}
+name: {{ .Values.global.defaultBucket.name }}
+region: {{ .Values.global.defaultBucket.region }}
+kmsKey: {{ .Values.global.defaultBucket.kmsKey }}
+{{- end }}
 provider: {{ $provider }}
-{{- $name := .Values.global.bucket.name | default .Values.global.defaultBucket.name }}
-name: {{ $name }}
-{{- $path := .Values.global.bucket.path | default .Values.global.defaultBucket.path }}
 path: {{ $path }}
-region: {{ .Values.global.bucket.region | default .Values.global.defaultBucket.region }}
-kmsKey: {{ .Values.global.bucket.kmsKey | default .Values.global.defaultBucket.kmsKey }}
-{{- $accessKey := default "" (.Values.global.bucket.accessKey | default .Values.global.defaultBucket.accessKey) }}
 accessKey: {{ $accessKey }}
-{{- $secretKey := default "" (.Values.global.bucket.secretKey | default .Values.global.defaultBucket.secretKey) }}
 secretKey: {{ $secretKey }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}


### PR DESCRIPTION
ref INFRA-344

Essentially a user's configured bucket would inherit values from defaultBucket, really this should just be one or the other, if a bucket is set as determined by name then use all of the settings from bucket, otherwise use all of the settings from defaultBucket.