### PR TITLE
fix: pass a port number to glue that doesn't collide with nginx

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.24.1
+version: 0.24.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.24.0
+version: 0.24.1
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -115,6 +115,8 @@ spec:
             # - name: PROXY_PASS_BACKEND_HOST
             #   value: "$({{.Release.Name | upper | replace "-" "_" }}_API_SERVICE_HOST):$({{.Release.Name | upper | replace "-" "_" }}_API_SERVICE_PORT)"
             # {{- end }}
+            - name: GORILLA_GLUE_CONTAINER_PORT
+              value: "9173"
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -212,7 +214,7 @@ spec:
                   optional: true
             {{- end }}
             {{- if ne .Values.global.auth.oidc.clientId ""  }}
-            - name: OIDC_CLIENT_ID            
+            - name: OIDC_CLIENT_ID
               value: {{ .Values.global.auth.oidc.clientId }}
             - name: OIDC_AUTH_METHOD
               value: {{ .Values.global.auth.oidc.authMethod }}


### PR DESCRIPTION
currently we always pass an env var to the app pod that causes the glue process to try to bind to port 8080, which is already in use by nginx. it would be nice to avoid that