### PR TITLE
fix: Use the same defaults

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.24.4
+version: 0.24.5
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -783,10 +783,10 @@ api:
         failureThreshold: 5
       resources:
         limits:
-          cpu: "2"
-          memory: 4Gi
+          cpu: "4"
+          memory: 8Gi
         requests:
-          cpu: "1"
+          cpu: 500m
           memory: 1Gi
       volumeMounts:
         - name: wandb-ca-certs


### PR DESCRIPTION
Api pod uses the same defaults as the app pod.