### PR TITLE
fix: Migrations don't block gorilla startup

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -63,4 +63,4 @@ dependencies:
   repository: file://../wandb-base
   version: 0.4.0
 digest: sha256:d9e104084992aaca36330a56d4a5b825fd20f0bdf995070bf93f46a883375169
-generated: "2025-01-24T13:27:40.057251-06:00"
+generated: "2025-01-29T12:38:09.214239-06:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.24.6
+version: 0.24.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -515,7 +515,7 @@ glue:
           key: '{{ (include "wandb.bucket" . | fromYaml).accessKeyName }}'
           optional: true
   envFrom:
-    "wandb-mysql": "secretRef"
+    "{{ .Release.Name }}-mysql": "secretRef"
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-mysql-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-secret": "secretRef"
@@ -566,7 +566,7 @@ glue:
         [
           "bash",
           "-c",
-          "./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE; ./megabinary migrate --db=$GORILLA_METADATA_STORE --usage-db=$GORILLA_USAGE_STORE",
+          "./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE || true; ./megabinary migrate --db=$GORILLA_METADATA_STORE --usage-db=$GORILLA_USAGE_STORE || true",
         ]
   containers:
     glue:
@@ -704,7 +704,7 @@ api:
           key: '{{ (include "wandb.bucket" . | fromYaml).accessKeyName }}'
           optional: true
   envFrom:
-    "wandb-mysql": "secretRef"
+    "{{ .Release.Name }}-mysql": "secretRef"
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-mysql-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-secret": "secretRef"
@@ -754,7 +754,7 @@ api:
         [
           "bash",
           "-c",
-          "./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE; ./megabinary migrate --db=$GORILLA_METADATA_STORE --usage-db=$GORILLA_USAGE_STORE",
+          "./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE || true; ./megabinary migrate --db=$GORILLA_METADATA_STORE --usage-db=$GORILLA_USAGE_STORE || true",
         ]
   containers:
     api:


### PR DESCRIPTION
This is the existing behaviour of the app pod.