### PR TITLE
fix: Fix indent for annotations block under `spec`

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -7,95 +7,95 @@ appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
 maintainers:
-- name: wandb
-  email: support@wandb.com
-  url: https://wandb.com
+  - name: wandb
+    email: support@wandb.com
+    url: https://wandb.com
 
 dependencies:
-- name: app
-  version: "*.*.*"
-  repository: file://charts/app
-  condition: app.install
-- name: wandb-base
-  alias: api
-  condition: global.beta.api.enabled
-  repository: file://../wandb-base
-  version: "*.*.*"
-- name: console
-  version: "*.*.*"
-  repository: file://charts/console
-  condition: console.install
-- name: weave
-  version: "*.*.*"
-  repository: file://charts/weave
-  condition: weave.install
-- name: weave-trace
-  version: "*.*.*"
-  repository: file://charts/weave-trace
-  condition: weave-trace.install
-- name: executor
-  version: "*.*.*"
-  repository: file://charts/executor
-  condition: executor.install
-- name: parquet
-  version: "*.*.*"
-  repository: file://charts/parquet
-  condition: parquet.install
-- name: mysql
-  version: "*.*.*"
-  repository: file://charts/mysql
-  condition: mysql.install
-- name: prometheus
-  version: "*.*.*"
-  repository: file://charts/prometheus
-  condition: prometheus.install
-- name: redis
-  version: "18.*.*"
-  condition: redis.install
-  repository: https://charts.bitnami.com/bitnami
-- name: kafka
-  version: "25.*.*"
-  condition: kafka.install
-  repository: https://charts.bitnami.com/bitnami
-- name: etcd
-  version: "10.*.*"
-  repository: oci://registry-1.docker.io/bitnamicharts
-  condition: bufstream.install
-- name: bufstream
-  version: "0.3.5"
-  repository: file://charts/bufstream
-  condition: global.beta.bufstream.enabled
-- name: otel
-  version: "*.*.*"
-  repository: file://charts/otel
-  condition: otel.install
-- name: flat-run-fields-updater
-  version: "*.*.*"
-  repository: file://charts/flat-run-fields-updater
-  condition: flat-run-fields-updater.install
-- name: filestream
-  version: "*.*.*"
-  repository: file://charts/filestream
-  condition: filestream.install
-- name: nginx
-  version: "*.*.*"
-  repository: file://charts/nginx
-  condition: nginx.install
-- name: stackdriver
-  version: "*.*.*"
-  repository: file://charts/stackdriver
-  condition: stackdriver.install
-- name: yace
-  version: "*.*.*"
-  repository: file://charts/yace
-  condition: yace.install
-- name: wandb-base
-  alias: glue
-  condition: global.beta.glue.enabled
-  repository: file://../wandb-base
-  version: "*.*.*"
-- name: wandb-base
-  alias: settingsMigrationJob
-  condition: settingsMigrationJob.install
-  repository: file://../wandb-base
-  version: "*.*.*"
+  - name: app
+    version: "*.*.*"
+    repository: file://charts/app
+    condition: app.install
+  - name: wandb-base
+    alias: api
+    condition: global.beta.api.enabled
+    repository: file://../wandb-base
+    version: "*.*.*"
+  - name: console
+    version: "*.*.*"
+    repository: file://charts/console
+    condition: console.install
+  - name: weave
+    version: "*.*.*"
+    repository: file://charts/weave
+    condition: weave.install
+  - name: weave-trace
+    version: "*.*.*"
+    repository: file://charts/weave-trace
+    condition: weave-trace.install
+  - name: executor
+    version: "*.*.*"
+    repository: file://charts/executor
+    condition: executor.install
+  - name: parquet
+    version: "*.*.*"
+    repository: file://charts/parquet
+    condition: parquet.install
+  - name: mysql
+    version: "*.*.*"
+    repository: file://charts/mysql
+    condition: mysql.install
+  - name: prometheus
+    version: "*.*.*"
+    repository: file://charts/prometheus
+    condition: prometheus.install
+  - name: redis
+    version: "18.*.*"
+    condition: redis.install
+    repository: https://charts.bitnami.com/bitnami
+  - name: kafka
+    version: "25.*.*"
+    condition: kafka.install
+    repository: https://charts.bitnami.com/bitnami
+  - name: etcd
+    version: "10.*.*"
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: bufstream.install
+  - name: bufstream
+    version: "0.3.5"
+    repository: file://charts/bufstream
+    condition: global.beta.bufstream.enabled
+  - name: otel
+    version: "*.*.*"
+    repository: file://charts/otel
+    condition: otel.install
+  - name: flat-run-fields-updater
+    version: "*.*.*"
+    repository: file://charts/flat-run-fields-updater
+    condition: flat-run-fields-updater.install
+  - name: filestream
+    version: "*.*.*"
+    repository: file://charts/filestream
+    condition: filestream.install
+  - name: nginx
+    version: "*.*.*"
+    repository: file://charts/nginx
+    condition: nginx.install
+  - name: stackdriver
+    version: "*.*.*"
+    repository: file://charts/stackdriver
+    condition: stackdriver.install
+  - name: yace
+    version: "*.*.*"
+    repository: file://charts/yace
+    condition: yace.install
+  - name: wandb-base
+    alias: glue
+    condition: global.beta.glue.enabled
+    repository: file://../wandb-base
+    version: "*.*.*"
+  - name: wandb-base
+    alias: settingsMigrationJob
+    condition: settingsMigrationJob.install
+    repository: file://../wandb-base
+    version: "*.*.*"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,100 +2,100 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.24.7
+version: 0.24.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
 maintainers:
-  - name: wandb
-    email: support@wandb.com
-    url: https://wandb.com
+- name: wandb
+  email: support@wandb.com
+  url: https://wandb.com
 
 dependencies:
-  - name: app
-    version: "*.*.*"
-    repository: file://charts/app
-    condition: app.install
-  - name: wandb-base
-    alias: api
-    condition: global.beta.api.enabled
-    repository: file://../wandb-base
-    version: "*.*.*"
-  - name: console
-    version: "*.*.*"
-    repository: file://charts/console
-    condition: console.install
-  - name: weave
-    version: "*.*.*"
-    repository: file://charts/weave
-    condition: weave.install
-  - name: weave-trace
-    version: "*.*.*"
-    repository: file://charts/weave-trace
-    condition: weave-trace.install
-  - name: executor
-    version: "*.*.*"
-    repository: file://charts/executor
-    condition: executor.install
-  - name: parquet
-    version: "*.*.*"
-    repository: file://charts/parquet
-    condition: parquet.install
-  - name: mysql
-    version: "*.*.*"
-    repository: file://charts/mysql
-    condition: mysql.install
-  - name: prometheus
-    version: "*.*.*"
-    repository: file://charts/prometheus
-    condition: prometheus.install
-  - name: redis
-    version: "18.*.*"
-    condition: redis.install
-    repository: https://charts.bitnami.com/bitnami
-  - name: kafka
-    version: "25.*.*"
-    condition: kafka.install
-    repository: https://charts.bitnami.com/bitnami
-  - name: etcd
-    version: "10.*.*"
-    repository: oci://registry-1.docker.io/bitnamicharts
-    condition: bufstream.install
-  - name: bufstream
-    version: "0.3.5"
-    repository: file://charts/bufstream
-    condition: global.beta.bufstream.enabled
-  - name: otel
-    version: "*.*.*"
-    repository: file://charts/otel
-    condition: otel.install
-  - name: flat-run-fields-updater
-    version: "*.*.*"
-    repository: file://charts/flat-run-fields-updater
-    condition: flat-run-fields-updater.install
-  - name: filestream
-    version: "*.*.*"
-    repository: file://charts/filestream
-    condition: filestream.install
-  - name: nginx
-    version: "*.*.*"
-    repository: file://charts/nginx
-    condition: nginx.install
-  - name: stackdriver
-    version: "*.*.*"
-    repository: file://charts/stackdriver
-    condition: stackdriver.install
-  - name: yace
-    version: "*.*.*"
-    repository: file://charts/yace
-    condition: yace.install
-  - name: wandb-base
-    alias: glue
-    condition: global.beta.glue.enabled
-    repository: file://../wandb-base
-    version: "*.*.*"
-  - name: wandb-base
-    alias: settingsMigrationJob
-    condition: settingsMigrationJob.install
-    repository: file://../wandb-base
-    version: "*.*.*"
+- name: app
+  version: "*.*.*"
+  repository: file://charts/app
+  condition: app.install
+- name: wandb-base
+  alias: api
+  condition: global.beta.api.enabled
+  repository: file://../wandb-base
+  version: "*.*.*"
+- name: console
+  version: "*.*.*"
+  repository: file://charts/console
+  condition: console.install
+- name: weave
+  version: "*.*.*"
+  repository: file://charts/weave
+  condition: weave.install
+- name: weave-trace
+  version: "*.*.*"
+  repository: file://charts/weave-trace
+  condition: weave-trace.install
+- name: executor
+  version: "*.*.*"
+  repository: file://charts/executor
+  condition: executor.install
+- name: parquet
+  version: "*.*.*"
+  repository: file://charts/parquet
+  condition: parquet.install
+- name: mysql
+  version: "*.*.*"
+  repository: file://charts/mysql
+  condition: mysql.install
+- name: prometheus
+  version: "*.*.*"
+  repository: file://charts/prometheus
+  condition: prometheus.install
+- name: redis
+  version: "18.*.*"
+  condition: redis.install
+  repository: https://charts.bitnami.com/bitnami
+- name: kafka
+  version: "25.*.*"
+  condition: kafka.install
+  repository: https://charts.bitnami.com/bitnami
+- name: etcd
+  version: "10.*.*"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  condition: bufstream.install
+- name: bufstream
+  version: "0.3.5"
+  repository: file://charts/bufstream
+  condition: global.beta.bufstream.enabled
+- name: otel
+  version: "*.*.*"
+  repository: file://charts/otel
+  condition: otel.install
+- name: flat-run-fields-updater
+  version: "*.*.*"
+  repository: file://charts/flat-run-fields-updater
+  condition: flat-run-fields-updater.install
+- name: filestream
+  version: "*.*.*"
+  repository: file://charts/filestream
+  condition: filestream.install
+- name: nginx
+  version: "*.*.*"
+  repository: file://charts/nginx
+  condition: nginx.install
+- name: stackdriver
+  version: "*.*.*"
+  repository: file://charts/stackdriver
+  condition: stackdriver.install
+- name: yace
+  version: "*.*.*"
+  repository: file://charts/yace
+  condition: yace.install
+- name: wandb-base
+  alias: glue
+  condition: global.beta.glue.enabled
+  repository: file://../wandb-base
+  version: "*.*.*"
+- name: wandb-base
+  alias: settingsMigrationJob
+  condition: settingsMigrationJob.install
+  repository: file://../wandb-base
+  version: "*.*.*"

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.pod.annotations -}}
-        {{-   toYaml .Values.pod.annotations | nindent 8 }}
+        {{-   toYaml .Values.pod.annotations | nindent 4 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.pod.annotations -}}
-        {{-   toYaml .Values.pod.annotations | nindent 4 }}
+        {{-   toYaml .Values.pod.annotations | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.pod.annotations -}}
-        {{-   toYaml .Values.pod.annotations | nindent 4 }}
+        {{-   toYaml .Values.pod.annotations | nindent 8 }}
         {{- end }}
     spec:
       {{- if .tolerations }}


### PR DESCRIPTION
The ident for the annotations block under `spec` is 4 instead it should be 8. This is causing the annotations to be reconciled and reverted when user sets it directly in deployment.yaml.