### PR TITLE
feat: Add gcp Security Policy to wandb-base

### DIFF
--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.4.0
+version: 0.4.1
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/service.yaml
+++ b/charts/wandb-base/templates/service.yaml
@@ -8,9 +8,9 @@ metadata:
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.ingress.gcpSecurityPolicy }}
+  {{- if .Values.global.gcpSecurityPolicy }}
   securityPolicy:
-    name: {{ .Values.ingress.gcpSecurityPolicy }}
+    name: {{ .Values.global.gcpSecurityPolicy }}
   {{- end }}
   timeoutSec: 120
 {{- end }}

--- a/charts/wandb-base/templates/service.yaml
+++ b/charts/wandb-base/templates/service.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.service.enabled }}
-{{- if .Values.global.createGCPLoadBalancerBackend }}
 {{- if eq .Values.global.cloudProvider "gcp" }}
 ---
 apiVersion: cloud.google.com/v1
@@ -9,8 +8,11 @@ metadata:
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.ingress.gcpSecurityPolicy }}
+  securityPolicy:
+    name: {{ .Values.ingress.gcpSecurityPolicy }}
+  {{- end }}
   timeoutSec: 120
-{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -176,9 +176,6 @@ service:
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
-  # GCP only value: a CloudArmor policy to be attached to the gce LoadBalancer via a BackendConfig.
-  # https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#cloud_armor
-  gcpSecurityPolicy: ""
   enabled: false
   className: ""
   annotations:

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -176,6 +176,9 @@ service:
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
+  # GCP only value: a CloudArmor policy to be attached to the gce LoadBalancer via a BackendConfig.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#cloud_armor
+  gcpSecurityPolicy: ""
   enabled: false
   className: ""
   annotations:


### PR DESCRIPTION
ref INFRA-392

follow up changes for `console`/`app` required since they don't yet use `wandb-base`.