### PR TITLE
fix: Set host for email team invites

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.26.3
+version: 0.26.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -487,6 +487,8 @@ glue:
   service:
     enabled: false
   env:
+    GORILLA_FRONTEND_HOST:
+      value: '{{ .Values.global.host }}'
     GORILLA_LICENSE_CERT_PATH:
       value: "/jwks.json"
     REDIS:
@@ -660,6 +662,8 @@ api:
         protocol: TCP
         name: http
   env:
+    GORILLA_FRONTEND_HOST:
+      value: '{{ .Values.global.host }}'
     GORILLA_LICENSE_CERT_PATH:
       value: "/jwks.json"
     REDIS:


### PR DESCRIPTION
This change fixes a bug where the api pod doesn't generate correct team level invites. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the deployment package to version 0.26.4.
- **New Features**
	- Introduced a new configuration setting that enables dynamic assignment of the frontend host for improved integration of key components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->