### PR TITLE
feat: Default global.redis.external to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ license.txt
 test-values.yaml
 .DS_Store
 secret.*.yaml
+.idea/

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.26.9
+version: 0.26.10
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -39,6 +39,8 @@ By default, the W&B Server chart includes an in-cluster Redis deployment that is
 provided by bitnami/Redis. This deployment is for trial purposes only and not
 recommended for use in production.
 
+The `external` field should always remain `false`. It is for W&B internal use only.
+
 ## Use external stateful data
 
 You can configure the W&B Server Helm chart to point to external stateful

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -136,6 +136,7 @@ global:
     host: ""
     port: 6379
     password: ""
+    # external should remain false; it is for W&B internal use only.
     external: false
     parameters: {}
     caCert: ""

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -136,6 +136,7 @@ global:
     host: ""
     port: 6379
     password: ""
+    external: false
     parameters: {}
     caCert: ""
     secret:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chore**
  - Refined project configuration by excluding development-only environment settings.
- **New Features**
  - Introduced a new option to control the connectivity of our caching service, which now defaults to internal access.
  - Updated Helm chart version for deploying W&B to Kubernetes.
  - Added clarification in the README regarding the usage of the new `external` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->