### PR TITLE
fix: Filestream does not need a specific image version

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.26.11
+version: 0.26.12
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -302,8 +302,8 @@ flat-run-fields-updater:
 filestream:
   install: false
   image:
-    repository: wandb/local-dev
-    tag: 0.63.0-danielpanzella-filestream-local.1
+    repository: wandb/local
+    tag: latest
   pubSub:
     subscription: ""
   envFrom:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bumped the release version for improved tracking.
  - Updated the configuration to use a more stable Docker image setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->