### PR TITLE
fix: Prefix the OIDC envvars for gorilla apps to find them

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.2
+version: 0.28.3
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/gorilla.yaml
+++ b/charts/operator-wandb/templates/gorilla.yaml
@@ -16,7 +16,7 @@ stringData:
   GORILLA_LICENSE: {{ .Values.global.license }}
   {{- end }}
   {{- if ne .Values.global.auth.oidc.clientId ""  }}
-  OIDC_CLIENT_SECRET: {{ .Values.global.auth.oidc.secret }}
+  GORILLA_OIDC_CLIENT_SECRET: {{ .Values.global.auth.oidc.secret }}
   {{- end }}
 ---
 apiVersion: v1
@@ -30,9 +30,9 @@ data:
   OPERATOR_ENABLED: 'true'
   LOGGING_ENABLED: 'true'
   {{- if ne .Values.global.auth.oidc.clientId ""  }}
-  OIDC_CLIENT_ID: {{ .Values.global.auth.oidc.clientId }}
-  OIDC_AUTH_METHOD: {{ .Values.global.auth.oidc.authMethod }}
-  OIDC_ISSUER: {{ .Values.global.auth.oidc.issuer }}
+  GORILLA_OIDC_CLIENT_ID: {{ .Values.global.auth.oidc.clientId }}
+  GORILLA_OIDC_AUTH_METHOD: {{ .Values.global.auth.oidc.authMethod }}
+  GORILLA_OIDC_ISSUER: {{ .Values.global.auth.oidc.issuer }}
   {{- end }}
   GORILLA_SESSION_LENGTH: "{{ .Values.global.auth.sessionLengthHours }}h"
   {{- if and .Values.global .Values.global.observability }}


### PR DESCRIPTION
These are used in the API when generating invite links and need to be properly prefixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment configuration version to 0.28.3, enhancing overall consistency and ensuring smoother updates.
  - Standardized authentication environment settings for improved clarity and integration.
  - These updates contribute to a more reliable platform experience and streamlined operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->