### PR TITLE
fix: Correctly enable fuse cache for parquet

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.6
+version: 0.28.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -233,7 +233,7 @@ spec:
               bucketName: {{ (include "wandb.bucket" . | fromYaml).name }}
               mountOptions: "implicit-dirs"
               fileCacheCapacity: "-1"
-              fileCacheForRangedRead: "true"
+              fileCacheForRangeRead: "true"
           {{- else }}
           emptyDir: {}
           {{- end }}


### PR DESCRIPTION
per [docs](https://cloud.google.com/kubernetes-engine/docs/reference/cloud-storage-fuse-csi-driver/volume-attr), correct a typo that was preventing fuse cache from working as intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the deployment package.
- **Bug Fixes**
	- Corrected a configuration setting for improved volume caching in deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->