### PR TITLE
fix: Tweak GCS Fuse settings for parquet

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.7
+version: 0.28.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -231,8 +231,8 @@ spec:
             readOnly: true
             volumeAttributes:
               bucketName: {{ (include "wandb.bucket" . | fromYaml).name }}
-              mountOptions: "implicit-dirs"
-              fileCacheCapacity: "-1"
+              mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true"
+              fileCacheCapacity: "{{ .Values.fuse.fileCacheCapacity }}"
               fileCacheForRangeRead: "true"
           {{- else }}
           emptyDir: {}

--- a/charts/operator-wandb/charts/parquet/values.yaml
+++ b/charts/operator-wandb/charts/parquet/values.yaml
@@ -24,6 +24,7 @@ fuse:
       cpu: 2
       memory: 2Gi
       ephemeral-storage: 10Gi
+  fileCacheCapacity: 9.5Gi
 
 envFrom: {}
 extraEnv: {}


### PR DESCRIPTION
- Correctly set fuse `fileCacheCapacity`
- Enable parallel downloads