### PR TITLE
fix: Add missing env to API

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.15
+version: 0.28.16
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -784,6 +784,10 @@ api:
       value: '{{ (include "wandb.bucket" . | fromYaml).url }}'
     GORILLA_STORAGE_BUCKET:
       value: '{{ (include "wandb.bucket" . | fromYaml).url }}'
+    GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE:
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
     GORILLA_RUN_UPDATE_SHADOW_QUEUE:
       value: >
         {


### PR DESCRIPTION
closes: INFRA-755
closes: INFRA-744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Helm chart version to the latest release.

- **New Features**
  - Introduced a new configuration option for the API that dynamically detects the Kubernetes deployment namespace, enhancing deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->