### PR TITLE
add t-shirt size to app, parquet, api, glue, executor, and parquet-backfill

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.20
+version: 0.28.21
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -317,6 +317,9 @@ spec:
             - name: GORILLA_PARQUET_ARROW_BUFFER_SIZE
               value: "2147483648" # 2GB
 
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
+
             {{- if .Values.global.executor.enabled }}
             - name: GORILLA_TASK_QUEUE
               value: "{{ include "wandb.redis.connectionString" . | trim }}"

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -161,6 +161,9 @@ spec:
             - name: GORILLA_PARQUET_ARROW_BUFFER_SIZE
               value: "2147483648" # 2GB
 
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
+
             - name: AZURE_STORAGE_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/operator-wandb/charts/filestream/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/filestream/templates/deployment.yaml
@@ -166,6 +166,8 @@ spec:
               value: "{{ include "wandb.redis.connectionString" . | trim }}"
             - name: GORILLA_MYSQL
               value: {{ .Values.mysql | toJson | quote }}
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
             {{- include "filestream.extraEnv" (dict "global" $.Values.global "local" .Values) | nindent 12 }}
             {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
           resources:

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -176,6 +176,8 @@ spec:
               value: "0.0.0.0"
             {{- end }}
             {{- end }}
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
             {{- include "flat-run-fields-updater.extraEnv" (dict "global" $.Values.global "local" .Values) | nindent 12 }}
             {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
           resources:

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -74,6 +74,8 @@ spec:
                   value: "true"
                 - name: GORILLA_GLUE_EXECUTE_TASK_NAME
                   value: "EXPORTHISTORYTOPARQUET"
+                - name: GORILLA_TSHIRT_SIZE
+                  value: {{ .Values.global.size | quote }}
                 - name: BUCKET_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -153,6 +153,9 @@ spec:
             - name: GORILLA_METADATA_CACHE
               value: "{{ include "wandb.redis.connectionString" . | trim }}"
 
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
+
             {{- if .Values.global.executor.enabled }}
             - name: GORILLA_TASK_QUEUE
               value: "{{ include "wandb.redis.connectionString" . | trim }}"

--- a/charts/operator-wandb/charts/weave-trace/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave-trace/templates/deployment.yaml
@@ -85,6 +85,8 @@ spec:
               value: {{ .Values.global.host }}
             - name: WANDB_BASE_URL
               value: http://{{ .Release.Name }}-app:8080/
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
             - name: WF_TRACE_SERVER_URL
               value: "{{ .Values.global.host }}/traces"
             - name: WF_ENFORCE_PASSWORD_LENGTH

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
               value: http://{{ .Release.Name }}-app:8080/
             - name: WEAVE_SERVER_NUM_WORKERS
               value: "4"
+            - name: GORILLA_TSHIRT_SIZE
+              value: {{ .Values.global.size | quote }}
 
             {{- include "weave.extraEnv" (dict "global" .Values.global "local" .Values) | nindent 12 }}
             {{- include "wandb.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -558,8 +558,6 @@ glue:
         secretKeyRef:
           name: '{{ include "wandb.mysql.passwordSecret" . }}'
           key: "{{ .Values.global.mysql.passwordSecret.passwordKey }}"
-    GORILLA_TSHIRT_SIZE:
-      value: "{{ .Values.global.size }}"
     GORILLA_FRONTEND_HOST:
       value: "{{ .Values.global.host }}"
     GORILLA_LICENSE_CERT_PATH:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -765,8 +765,6 @@ api:
           name: '{{ include "wandb.kafka.passwordSecret" . }}'
           key: '{{ include "wandb.kafka.passwordSecret.passwordKey" . }}'
           optional: true
-    GORILLA_TSHIRT_SIZE:
-      value: "{{ .Values.global.size }}"
     GORILLA_FRONTEND_HOST:
       value: "{{ .Values.global.host }}"
     GORILLA_LICENSE_CERT_PATH:
@@ -792,7 +790,7 @@ api:
     GORILLA_GLUE_TASK_METADATA_STORE:
       value: '{{ include "wandb.mysql" . | trim }}'
     GORILLA_TSHIRT_SIZE:
-      value: '{{ .Values.global.size }}'  
+      value: '{{ .Values.global.size }}'
     GORILLA_USAGE_STORE:
       value: '{{ include "wandb.mysql" . | trim }}'
     GORILLA_METADATA_STORE:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -604,6 +604,8 @@ glue:
       value: '{{ (include "wandb.bucket" . | fromYaml).url }}'
     GORILLA_STORAGE_BUCKET:
       value: '{{ (include "wandb.bucket" . | fromYaml).url }}'
+    GORILLA_TSHIRT_SIZE:
+      value: '{{ .Values.global.size }}'
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-mysql-configmap": "configMapRef"
@@ -785,6 +787,8 @@ api:
       value: '{{ include "wandb.mysql" . | trim }}'
     GORILLA_GLUE_TASK_METADATA_STORE:
       value: '{{ include "wandb.mysql" . | trim }}'
+    GORILLA_TSHIRT_SIZE:
+      value: '{{ .Values.global.size }}'  
     GORILLA_USAGE_STORE:
       value: '{{ include "wandb.mysql" . | trim }}'
     GORILLA_METADATA_STORE:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -558,6 +558,8 @@ glue:
         secretKeyRef:
           name: '{{ include "wandb.mysql.passwordSecret" . }}'
           key: "{{ .Values.global.mysql.passwordSecret.passwordKey }}"
+    GORILLA_TSHIRT_SIZE:
+      value: "{{ .Values.global.size }}"
     GORILLA_FRONTEND_HOST:
       value: "{{ .Values.global.host }}"
     GORILLA_LICENSE_CERT_PATH:
@@ -763,6 +765,8 @@ api:
           name: '{{ include "wandb.kafka.passwordSecret" . }}'
           key: '{{ include "wandb.kafka.passwordSecret.passwordKey" . }}'
           optional: true
+    GORILLA_TSHIRT_SIZE:
+      value: "{{ .Values.global.size }}"
     GORILLA_FRONTEND_HOST:
       value: "{{ .Values.global.host }}"
     GORILLA_LICENSE_CERT_PATH:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new environment variable, GORILLA_TSHIRT_SIZE, to multiple components, reflecting the global deployment size setting.
- **Chores**
  - Updated the Helm chart version to 0.28.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->