### PR TITLE
feat: Set parquet reader fuse enabled too

### DIFF
--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -205,6 +205,8 @@ spec:
             {{- if .Values.fuse.enabled }}
             - name: GORILLA_PARQUET_FUSE_ENABLED
               value: "true"
+            - name: GORILLA_PARQUET_READER_FUSE_ENABLED
+              value: "true"
             {{- end }}
 
             - name: GORILLA_PARQUET_ARROW_BUFFER_SIZE


### PR DESCRIPTION
Follow-up to https://github.com/wandb/core/pull/28679

GORILLA_PARQUET_FUSE_ENABLED was updated to `GORILLA_PARQUET_READER_FUSE_ENABLED`

For now, we'll just add `GORILLA_PARQUET_READER_FUSE_ENABLED` as an env var as well. Then we'll follow-up with removing `GORILLA_PARQUET_FUSE_ENABLED`