### PR TITLE
feat: backfiller exports on executor, lower backfiller concurrency limits

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.21
+version: 0.28.23
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.28.22
+version: 0.28.21
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/parquet/templates/_helpers.tpl
@@ -1,3 +1,5 @@
+{{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -150,24 +152,3 @@ mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATA
     name: {{ $key }}
 {{ end }}
 {{- end }}
-
-{{- define "parquet.export.parallelism" -}}
-{{- if .Values.cronJob.exportHistoryToParquet.parallism }}
-  {{- print .Values.cronJob.exportHistoryToParquet.parallism }}
-{{- else }}
-    {{- if eq .Values.global.size "xxlarge" }}
-      {{- print "250" }}
-    {{- else if eq .Values.global.size "xlarge" }}
-      {{- print "80" }}
-    {{- else if eq .Values.global.size "large" }}
-      {{- print "40" }}
-    {{- else if eq .Values.global.size "medium" }}
-      {{- print "20" }}
-    {{- else if eq .Values.global.size "small" }}
-      {{- print "10" }}
-    {{- else }}
-      {{- print "10" }}
-    {{- end }}
-{{- end -}}
-{{- end -}}
-

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -120,8 +120,7 @@ spec:
                   value: "{{ include "wandb.redis.parametersQuery" . | trim }}"
                 - name: REDIS
                   value: "{{ include "wandb.redis.connectionString" . | trim }}"
-                - name: GORILLA_EXPORT_PQ_PARALLELISM
-                  value: "{{ include "parquet.export.parallelism" . }}"
+
                 - name: GORILLA_SETTINGS_CACHE
                   value: "{{ include "wandb.redis.connectionString" . | trim }}"
 

--- a/charts/operator-wandb/charts/parquet/templates/cron.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/cron.yaml
@@ -125,6 +125,15 @@ spec:
                 - name: GORILLA_SETTINGS_CACHE
                   value: "{{ include "wandb.redis.connectionString" . | trim }}"
 
+                {{- if .Values.global.executor.enabled }}
+                - name: GORILLA_TASK_QUEUE
+                  value: "{{ include "wandb.redis.connectionString" . | trim }}"
+                - name: GORILLA_TASK_QUEUE_WORKER_ENABLED
+                  value: "false"
+                - name: GORILLA_CLEAR_TASK_DEDUPE_KEY_ENABLED
+                  value: "false"
+                {{- end }}
+
                 - name: GORILLA_PARQUET_ARROW_BUFFER_SIZE
                   value: "2147483648" # 2GB
 

--- a/charts/operator-wandb/charts/parquet/values.yaml
+++ b/charts/operator-wandb/charts/parquet/values.yaml
@@ -37,7 +37,6 @@ common:
 deployment: {}
 cronJob:
   exportHistoryToParquet:
-    parallelism: ""
     enabled: false
     schedule: "11 * * * *"
 serviceAccount:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -25,10 +25,6 @@ global:
 
   cloudProvider: ""
 
-  # Rough size of the deployment, in our terms this value comes from terraform, expected values:
-  # small, medium, large, xlarge, xxlarge
-  size: ""
-
   storageClass: ""
 
   banners:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Helm chart version for the operator-wandb application.
- **Refactor**
	- Removed configuration options related to parallelism and deployment sizing from the chart values.
	- Eliminated the parallelism template and related environment variable for Parquet export jobs.
	- Added conditional environment variables for task queue configuration when the executor is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->