### PR TITLE
chore: serve files endpoints from API pod

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.29.0
+version: 0.29.1
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_ingress.tpl
+++ b/charts/operator-wandb/templates/_ingress.tpl
@@ -73,6 +73,13 @@ It expects a dictionary with two entries:
       name: {{ $.Release.Name }}-api
       port: 
         number: 8081
+- pathType: Prefix
+  path: /files
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port: 
+        number: 8081
 {{- end }}
 - pathType: Prefix
   path: /console


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `/files` path to the ingress configuration, allowing users to access file-related endpoints when the global API is enabled.
- **Chores**
  - Updated the application chart version to 0.29.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->