### PR TITLE
fix: Enable to slow rollout of additional api ingress routes

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.29.0
+version: 0.29.1
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_ingress.tpl
+++ b/charts/operator-wandb/templates/_ingress.tpl
@@ -73,6 +73,87 @@ It expects a dictionary with two entries:
       name: {{ $.Release.Name }}-api
       port: 
         number: 8081
+{{- if .Values.global.api.additionalPaths.analytics }}
+- pathType: Prefix
+  path: /analytics
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.oidc }}
+- pathType: Prefix
+  path: /oidc
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.proxy }}
+- pathType: Prefix
+  path: /proxy
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.files }}
+- pathType: Prefix
+  path: /files
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.debug }}
+- pathType: Prefix
+  path: /debug
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.service_redirect }}
+- pathType: Prefix
+  path: /service-redirect
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.service_dangerzone }}
+- pathType: Prefix
+  path: /service-dangerzone
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.scim }}
+- pathType: Prefix
+  path: /scim
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
+{{- if .Values.global.api.additionalPaths.admin }}
+- pathType: Prefix
+  path: /admin/audit_logs
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
 {{- end }}
 - pathType: Prefix
   path: /console

--- a/charts/operator-wandb/templates/_ingress.tpl
+++ b/charts/operator-wandb/templates/_ingress.tpl
@@ -154,6 +154,15 @@ It expects a dictionary with two entries:
       port:
         number: 8081
 {{- end }}
+{{- if .Values.global.api.additionalPaths.artifacts }}
+- pathType: Prefix
+  path: /artifacts
+  backend:
+    service:
+      name: {{ $.Release.Name }}-api
+      port:
+        number: 8081
+{{- end }}
 {{- end }}
 - pathType: Prefix
   path: /console

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -206,6 +206,18 @@ global:
 
   api:
     enabled: false
+    additionalPaths:
+      proxy: false
+      files: false
+      debug: false
+      service_redirect: false
+      service_dangerzone: false
+      artifacts: false
+      oidc: false
+      analytics: false
+      scim: false
+      admin: false
+
   glue:
     enabled: false
 


### PR DESCRIPTION
ref: INFRA-888
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added configurable options to enable additional API path prefixes (such as analytics, oidc, proxy, files, debug, service_redirect, service_dangerzone, scim, and admin) for ingress routing.
- **Chores**
  - Updated the Helm chart version to 0.29.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->