### PR TITLE
fix: Add topologySpreadConstraints

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.29.2
+version: 0.29.3
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.app.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/app/values.yaml
+++ b/charts/operator-wandb/charts/app/values.yaml
@@ -23,6 +23,8 @@ autoscaling:
 # Tolerations for pod scheduling
 tolerations: []
 
+topologySpreadConstraints: []
+
 traceRatio: 0
 
 extraEnv: {}

--- a/charts/operator-wandb/charts/bufstream/values.yaml
+++ b/charts/operator-wandb/charts/bufstream/values.yaml
@@ -159,7 +159,7 @@ observability:
     # Deprecated: set aggregation.partitions to true instead.
     # @ignored
     omitPartitionAttribute: false
-    # Whether to emit bufstream.internal.* metrics. 
+    # Whether to emit bufstream.internal.* metrics.
     # @ignored
     enableInternalMetrics: false
     # Allows changing the default temporality preference for OTLP metrics.
@@ -254,6 +254,8 @@ bufstream:
     affinity: {}
     # -- Bufstream Deployment Tolerations.
     tolerations: []
+    # -- Bufstream Deployment topologySpreadConstraints.
+    topologySpreadConstraints: []
     # -- Bufstream Deployment Extra environment variables for the bufstream container.
     extraEnv: []
     # -- Bufstream Deployment Extra volume mounts for the bufstream container.

--- a/charts/operator-wandb/charts/console/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/console/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.console.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/console/values.yaml
+++ b/charts/operator-wandb/charts/console/values.yaml
@@ -18,6 +18,8 @@ image:
 # Tolerations for pod scheduling
 tolerations: []
 
+topologySpreadConstraints: []
+
 extraEnv:
   BUCKET_ACCESS_IDENTITY: unknown
   TESTING: true

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -196,6 +196,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.executor.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if ne (include "wandb.redis.caCert" .) "" }}
         - name: {{ include "executor.fullname" . }}-redis-ca

--- a/charts/operator-wandb/charts/executor/values.yaml
+++ b/charts/operator-wandb/charts/executor/values.yaml
@@ -86,4 +86,6 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}

--- a/charts/operator-wandb/charts/filestream/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/filestream/templates/deployment.yaml
@@ -180,6 +180,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.filestream.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if ne (include "wandb.redis.caCert" .) "" }}
         - name: {{ include "filestream.fullname" . }}-redis-ca

--- a/charts/operator-wandb/charts/filestream/values.yaml
+++ b/charts/operator-wandb/charts/filestream/values.yaml
@@ -102,4 +102,6 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}

--- a/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
@@ -190,6 +190,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.flat-run-fields-updater.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if ne (include "wandb.redis.caCert" .) "" }}
         - name: {{ include "flat-run-fields-updater.fullname" . }}-redis-ca

--- a/charts/operator-wandb/charts/flat-run-fields-updater/values.yaml
+++ b/charts/operator-wandb/charts/flat-run-fields-updater/values.yaml
@@ -98,4 +98,6 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}

--- a/charts/operator-wandb/charts/mysql/templates/statefulset.yaml
+++ b/charts/operator-wandb/charts/mysql/templates/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.mysql.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/mysql/values.yaml
+++ b/charts/operator-wandb/charts/mysql/values.yaml
@@ -14,6 +14,8 @@ image:
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 extraEnv: {}
 extraEnvFrom: {}
 

--- a/charts/operator-wandb/charts/nginx/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/nginx/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.nginx.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "nginx.podSecurityContext" .Values.pod.securityContext | nindent 6 }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/operator-wandb/charts/nginx/values.yaml
+++ b/charts/operator-wandb/charts/nginx/values.yaml
@@ -11,6 +11,8 @@ image:
 # Tolerations for pod scheduling
 tolerations: []
 
+topologySpreadConstraints: []
+
 pod:
   securityContext:
     fsGroup: 0

--- a/charts/operator-wandb/charts/parquet/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/parquet/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.parquet.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/parquet/values.yaml
+++ b/charts/operator-wandb/charts/parquet/values.yaml
@@ -12,6 +12,8 @@ replicas: 1
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 traceRatio: 0
 
 fuse:

--- a/charts/operator-wandb/charts/stackdriver/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/stackdriver/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.stackdriver.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.stackdriver.serviceAccountSecret }}
         - name: stackdriver-service-account

--- a/charts/operator-wandb/charts/stackdriver/values.yaml
+++ b/charts/operator-wandb/charts/stackdriver/values.yaml
@@ -13,6 +13,8 @@ image:
 # Tolerations for pod scheduling
 tolerations: []
 
+topologySpreadConstraints: []
+
 restartPolicy: Always
 replicaCount: 1
 

--- a/charts/operator-wandb/charts/weave-trace/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave-trace/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.weave-trace.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/weave-trace/values.yaml
+++ b/charts/operator-wandb/charts/weave-trace/values.yaml
@@ -8,6 +8,8 @@ image:
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 extraEnv: {}
 extraEnvFrom: {}
 

--- a/charts/operator-wandb/charts/weave/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/weave/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.weave.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/weave/values.yaml
+++ b/charts/operator-wandb/charts/weave/values.yaml
@@ -17,6 +17,8 @@ image:
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 extraEnv: {}
 extraEnvFrom: {}
 

--- a/charts/operator-wandb/charts/yace/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/yace/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.yace.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- include "wandb.nodeSelector" . | nindent 6 }}
       {{- include "wandb.priorityClassName" . | nindent 6 }}
       {{- include "wandb.podSecurityContext" .Values.pod.securityContext | nindent 6 }}

--- a/charts/operator-wandb/charts/yace/values.yaml
+++ b/charts/operator-wandb/charts/yace/values.yaml
@@ -13,6 +13,8 @@ image:
 # Tolerations for pod scheduling
 tolerations: []
 
+topologySpreadConstraints: []
+
 extraEnv: {}
 extraEnvFrom: {}
 


### PR DESCRIPTION
Adding `topologySpreadConstraints` for the app, console, executor, filestream, flat-run-fields-updater, mysql, nginx, parquet, stackdriver, weave, weave-trace, and yace pods.