### PR TITLE
fix: Move priorityclasses permissions out of the leader election role

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "1.0.0"
 maintainers:
   - name: wandb

--- a/charts/operator/templates/leader-election-role.yaml
+++ b/charts/operator/templates/leader-election-role.yaml
@@ -18,18 +18,6 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - scheduling.k8s.io
-  resources:
-  - priorityclasses
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -201,6 +201,18 @@ role:
         - update
         - watch
         - patch
+    - apiGroups:
+        - scheduling.k8s.io
+      resources:
+        - priorityclasses
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
 resources:
   limits:
     cpu: 1000m


### PR DESCRIPTION
- Permissions for priority classes was erroneously added to the wrong role.  Move it the correct location.