### PR TITLE
Fix: add support for hostNetwork

### DIFF
--- a/charts/operator-wandb/charts/app/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/app/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ include "wandb.podHostNetwork" . }}
       initContainers:
         - name: init-db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/operator-wandb/charts/app/values.yaml
+++ b/charts/operator-wandb/charts/app/values.yaml
@@ -20,6 +20,8 @@ autoscaling:
     minReplicas: 1
     maxReplicas: 1
 
+podHostNetwork: true
+
 # Tolerations for pod scheduling
 tolerations: []
 

--- a/charts/operator-wandb/templates/_pods.tpl
+++ b/charts/operator-wandb/templates/_pods.tpl
@@ -88,3 +88,6 @@ securityContext:
 {{- end }}
 {{- end }}
 
+{{- define "wandb.podHostNetwork" }}
+hostNetwork: {{ .Values.podHostNetwork }}
+{{- end }}


### PR DESCRIPTION
Adding hostNetwork to app, buffstream, console, executor, filestream, flat-run-fields-updater, parquet, stackdriver, weave, weave-trace, and yace pods.