### PR TITLE
fix: Adding support for topologySpreadConstraints to wandb-base

### DIFF
--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.7.1
+version: 0.7.2
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/deployment.yaml
+++ b/charts/wandb-base/templates/deployment.yaml
@@ -60,4 +60,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
   {{- end }}

--- a/charts/wandb-base/templates/deployment.yaml
+++ b/charts/wandb-base/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.topologySpreadConstraints }}
+      {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}


### PR DESCRIPTION
Adding support for topologySpreadConstraints to wandb-base

This is a requirement for Ford Motor Co. to get onto the operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring pod topology spread constraints in deployments via Helm chart values.

- **Chores**
  - Updated Helm chart version to 0.7.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->