### PR TITLE
fix: frontend load global extraENV & setup script

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.31.5
+version: 0.31.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/frontend.yaml
+++ b/charts/operator-wandb/templates/frontend.yaml
@@ -7,6 +7,14 @@ metadata:
 data:
   02_patch_env_js.sh: |
     #!/bin/bash
+    function append_env_js() {
+      local key=$1
+      local value=$2
+      local env_js_path="$BUILD_DIR/env.js"
+      if [ -w "$env_js_path" ]; then
+        printf "Object.assign(window.CONFIG, {%s: %s});\n" "$key" "$value" >> "$env_js_path"
+      fi
+    }
     function extract_server_flags() {
       # This function builds a javascript string that gets appended to env.js
       # it defines a SERVER_FLAGS object maping env vars which start with "SERVER_FLAG_"

--- a/charts/operator-wandb/templates/frontend.yaml
+++ b/charts/operator-wandb/templates/frontend.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-frontend-configmap
+  labels:
+      {{- include "wandb.commonLabels" . | nindent 4 }}
+data:
+  02_patch_env_js.sh: |
+    #!/bin/bash
+    function extract_server_flags() {
+      # This function builds a javascript string that gets appended to env.js
+      # it defines a SERVER_FLAGS object maping env vars which start with "SERVER_FLAG_"
+      # where each key is the rest of that env var name and the value is that as a string.
+      local env_js_path="$BUILD_DIR/env.js"
+      local new_js=""
+      # define the object and open it with '{ '
+      # pad with a <space> incase no server flags are set
+      printf -v new_js "const SERVER_FLAGS = { "
+      for name in "${!SERVER_FLAG_@}"; do
+        # append the to the new_js bash variable the key/value pair
+        printf -v new_js '%s"%s": "%s",' "${new_js}" "${name:12}" "${!name}"
+      done
+      # remove the trailing comma and close the object
+      local length="${#new_js}"-1
+      printf "${new_js:0:length}};\n" >> "$env_js_path"
+      append_env_js "SERVER_FLAGS" "SERVER_FLAGS"
+     }
+
+    function known_additional_flags() {
+      if [ "$CI" == "1" ]; then
+        append_env_js "CI" "true"
+        echo "WARN: use REACT_APP_CI instead"
+      fi
+      if [ "$(echo "$DISABLE_TELEMETRY" | tr '[:lower:]')" == "true" ]; then
+        append_env_js "DISABLE_TELEMETRY" "true"
+        echo "WARN: use REACT_APP_DISABLE_TELEMETRY instead"
+      fi
+      if [ "$WEAVE_ENABLED" == "true" ]; then
+        echo "WARN: use REACT_APP_WEAVE_BACKEND_HOST instead"
+        append_env_js "WEAVE_BACKEND_HOST" \"/__weave\"
+      fi
+      if [ "$WEAVE_TRACES_ENABLED" == "true" ]; then
+        append_env_js "TRACE_BACKEND_BASE_URL" \"/traces\"
+      fi
+      if [ "$ENABLE_RBAC_UI" == "true" ]; then
+        append_env_js "ENABLE_RBAC_UI" "true"
+      fi
+      if [ "$OPERATOR_ENABLED" = "true" ]; then
+        append_env_js "OPERATOR_ENABLED" "true"
+      fi
+      # GORILLA_CUSTOMER_SECRET_STORE_SOURCE is populated by terraform in the global secrets map
+      # which determines ENABLE_SECRET_STORE
+      if [[ -n "$GORILLA_CUSTOMER_SECRET_STORE_SOURCE" && "$GORILLA_CUSTOMER_SECRET_STORE_SOURCE" != "noop://" ]]; then
+        append_env_js "ENABLE_SECRET_STORE" "true"
+      fi
+      if [ -n "$BANNERS" ]; then
+        append_env_js "BANNERS" "$BANNERS"
+      else
+        append_env_js "BANNERS" "{}"
+      fi
+      if [ "$ENABLE_REGISTRY_UI" == "true" ]; then
+        append_env_js "ENABLE_REGISTRY_UI" "true"
+      fi
+    }
+
+    function main() {
+      # Server flag templating
+      if ! grep -q 'const SERVER_FLAGS =' "$BUILD_DIR/env.js"; then
+        extract_server_flags
+        known_additional_flags
+      else
+        echo "WARN: Server Flag already completed."
+      fi
+    }
+    main "$@"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1157,7 +1157,8 @@ frontend:
       value: "true"
     REACT_APP_ANALYTICS_DISABLED:
       value: "true"
-  envFrom: {}
+  envFrom:
+    "{{ .Release.Name }}-global-secret": "secretRef"
   containers:
     frontend:
       env: {}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1139,6 +1139,9 @@ frontend:
     - name: wandb-setup-scripts
       configMap:
         name: "{{ .Release.Name }}-frontend-configmap"
+        items:
+          - key: 02_setup_script.sh
+            path: 02_setup_script.sh
         defaultMode: 0755
   service:
     enabled: true

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1145,6 +1145,8 @@ frontend:
         protocol: TCP
         name: http
   env:
+    OPERATOR_ENABLED:
+      value: "true"
     PUBLIC_URL:
       value: "{{ .Values.global.host }}"
     REACT_APP_GIT_TAG:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1135,6 +1135,11 @@ frontend:
   image:
     repository: wandb/frontend-nginx
     tag: latest
+  volumes:
+    - name: wandb-setup-scripts
+      configMap:
+        name: "{{ .Release.Name }}-frontend-configmap"
+        defaultMode: 0755
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -1169,6 +1174,10 @@ frontend:
         - name: frontend
           containerPort: 8080
           protocol: TCP
+      volumeMounts:
+        - name: wandb-setup-scripts
+          mountPath: /docker-entrypoint.d/02_setup_script.sh
+          subPath: 02_setup_script.sh
       resources:
         limits:
           cpu: 1000m

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1140,8 +1140,8 @@ frontend:
       configMap:
         name: "{{ .Release.Name }}-frontend-configmap"
         items:
-          - key: 02_setup_script.sh
-            path: 02_setup_script.sh
+          - key: 02_patch_env_js.sh
+            path: 02_patch_env_js.sh
         defaultMode: 0755
   service:
     enabled: true
@@ -1179,8 +1179,8 @@ frontend:
           protocol: TCP
       volumeMounts:
         - name: wandb-setup-scripts
-          mountPath: /docker-entrypoint.d/02_setup_script.sh
-          subPath: 02_setup_script.sh
+          mountPath: /docker-entrypoint.d/02_patch_env_js.sh
+          subPath: 02_patch_env_js.sh
       resources:
         limits:
           cpu: 1000m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The frontend now loads environment variables from a Kubernetes secret for enhanced configuration.
  - Added an environment variable to enable the operator in the frontend.
  - Introduced a setup script that dynamically updates frontend environment settings during build time.

- **Chores**
  - Updated the Helm chart version for operator-wandb to 0.31.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->