### PR TITLE
fix: Prevent recursive b64ing clickhouse passwords

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.31.7
+version: 0.31.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/clickhouse.yaml
+++ b/charts/operator-wandb/templates/clickhouse.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
 {{- if $secret }}
-  CLICKHOUSE_PASSWORD: {{ default ($secret.data.CLICKHOUSE_PASSWORD) .Values.global.clickhouse.password | b64enc }}
+  CLICKHOUSE_PASSWORD: {{ default ($secret.data.CLICKHOUSE_PASSWORD) (.Values.global.clickhouse.password | b64enc) }}
 {{- else }}
   CLICKHOUSE_PASSWORD: {{ default (randAlphaNum 64) .Values.global.clickhouse.password | b64enc }}
 {{- end }}


### PR DESCRIPTION
Right now we're seeing clickhouse passwords grow exponentially every time we deploy a new version of the helm chart. This stops that growth. Ref: INFRA-952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Helm chart version for the operator-wandb application to 0.31.8.

- **Bug Fixes**
	- Improved handling of the ClickHouse password in Kubernetes Secrets to ensure correct encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->