### PR TITLE
fix: Add custom ca for executor

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.32.4
+version: 0.32.5
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -57,6 +57,17 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
             {{- end }}
+            {{- if .Values.global.caCertsConfigMap }}
+            - name: wandb-ca-certs-user
+              mountPath: /usr/local/share/ca-certificates/
+            {{- end }}
+            {{- if .Values.global.customCACerts }}
+            {{- range $index, $v := .Values.global.customCACerts }}
+            - name: wandb-ca-certs
+              mountPath: /usr/local/share/ca-certificates/customCA{{$index}}.crt
+              subPath: customCA{{$index}}.crt
+            {{- end }}
+            {{- end }}
           envFrom:
           {{- if .Values.envFrom }}
             {{- tpl (include "executor.envFrom" . ) . | nindent 12 }}
@@ -204,6 +215,16 @@ spec:
             items:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
+        {{- end }}
+        {{- if .Values.global.caCertsConfigMap }}
+        - name: wandb-ca-certs-user
+          configMap:
+            name: {{ .Values.global.caCertsConfigMap }}
+        {{- end }}
+        {{- if .Values.global.customCACerts }}
+        - name: wandb-ca-certs
+          configMap:
+            name: {{ include "parquet.fullname" . }}-ca-certs
         {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/operator-wandb/charts/executor/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/executor/templates/deployment.yaml
@@ -224,7 +224,7 @@ spec:
         {{- if .Values.global.customCACerts }}
         - name: wandb-ca-certs
           configMap:
-            name: {{ include "parquet.fullname" . }}-ca-certs
+            name: {{ include "executor.fullname" . }}-ca-certs
         {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/snapshots.sh
+++ b/snapshots.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash 
 set -euo pipefail
 
+# helm plugin install https://github.com/origranot/helm-cascade
+# helm plugin install https://github.com/jlandowner/helm-chartsnap
+# helm cascade build ./charts/operator-wandb/
+
 function main() {
   local chart="operator-wandb"
   local values_dir="test-configs"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -1025,7 +1025,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3100,7 +3100,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -1038,7 +1038,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3303,7 +3303,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -1103,7 +1103,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4918,7 +4918,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -1230,7 +1230,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5201,7 +5201,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -1064,7 +1064,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4334,7 +4334,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -1051,7 +1051,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4148,7 +4148,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -1067,7 +1067,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4339,7 +4339,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -1019,7 +1019,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4117,7 +4117,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -1275,7 +1275,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4341,7 +4341,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4369,7 +4369,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.32.6
+    helm.sh/chart: operator-wandb-0.32.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mounting additional CA certificates into the deployment via Helm values, allowing for both a global ConfigMap and individual custom CA certificates.

* **Chores**
  * Updated the Helm chart version to 0.32.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->