### PR TITLE
Remove setting replica & max message size from bufstream connection string 

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.32.4
+version: 0.32.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/app/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/app/templates/_helpers.tpl
@@ -112,9 +112,9 @@ app deployments.
 {{- if .Values.global.pubSub.enabled -}}
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}
 {{- else if .Values.global.beta.bufstream.enabled -}}
-kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- else -}}
-kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- end -}}
 {{- end -}}
 

--- a/charts/operator-wandb/charts/executor/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/executor/templates/_helpers.tpl
@@ -161,9 +161,9 @@ mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATA
 {{- if .Values.global.pubSub.enabled -}}
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}
 {{- else if .Values.global.beta.bufstream.enabled -}}
-kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- else -}}
-kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- end -}}
 {{- end -}}
 

--- a/charts/operator-wandb/templates/_kafka.tpl
+++ b/charts/operator-wandb/templates/_kafka.tpl
@@ -98,9 +98,9 @@ pubsub://{{ .Values.global.pubSub.host }}/{{ .Values.global.pubSub.project }}/{{
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}
   {{- end -}}
 {{- else if .Values.global.beta.bufstream.enabled -}}
-kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater
 {{- else -}}
-kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)
 {{- end -}}
 {{- end -}}
 
@@ -115,9 +115,9 @@ pubsub://{{ .Values.global.pubSub.host }}/{{ .Values.global.pubSub.project }}/{{
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}/{{ .Values.pubSub.subscription }}
   {{- end -}}
 {{- else if .Values.global.beta.bufstream.enabled -}}
-kafka://$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- else -}}
-kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3
+kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- end -}}
 {{- end -}}
 

--- a/charts/operator-wandb/templates/_kafka.tpl
+++ b/charts/operator-wandb/templates/_kafka.tpl
@@ -98,9 +98,9 @@ pubsub://{{ .Values.global.pubSub.host }}/{{ .Values.global.pubSub.project }}/{{
 pubsub:/{{ .Values.global.pubSub.project }}/{{ .Values.global.pubSub.runUpdateShadowTopic }}
   {{- end -}}
 {{- else if .Values.global.beta.bufstream.enabled -}}
-kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater
+kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- else -}}
-kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)
+kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
 {{- end -}}
 {{- end -}}
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -188,7 +188,7 @@ global:
     runUpdatesShadowTopic: ""
     # This value will only apply upon initial topic creation.
     # If the topic already exists, then changing the number of partitions is not possible.
-    runUpdatesShadowNumPartitions: 12
+    runUpdatesShadowNumPartitions: 100
 
   # To provide custom CA certificates, you can use either:
   # 1. `customCACerts`: a list of certificates provided directly within this Helm chart.

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2168,7 +2168,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -1025,7 +1025,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1190,7 +1190,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2158,7 +2158,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -3100,7 +3100,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -1038,7 +1038,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1203,7 +1203,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2171,7 +2171,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -2181,7 +2181,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE
@@ -2510,7 +2510,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -3303,7 +3303,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -2181,7 +2181,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
             }
 
         - name: GORILLA_SETTINGS_CACHE
@@ -2520,7 +2520,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_HISTORY_STORE

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -2181,7 +2181,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -1103,7 +1103,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1268,7 +1268,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -4918,7 +4918,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -1230,7 +1230,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1395,7 +1395,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2504,7 +2504,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2648,7 +2648,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2791,7 +2791,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -3089,7 +3089,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -3099,7 +3099,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE
@@ -3452,7 +3452,7 @@ spec:
                 "prefix": "wandb-overflow"
               },
               "subscriptions": {
-                "flatRunFieldsUpdater": "kafka://$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+                "flatRunFieldsUpdater": "kafka://$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
               }
             }
         - name: GORILLA_SETTINGS_CACHE
@@ -5201,7 +5201,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -1064,7 +1064,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1229,7 +1229,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2172,7 +2172,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2316,7 +2316,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2459,7 +2459,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2757,7 +2757,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -2767,7 +2767,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE
@@ -4334,7 +4334,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -2767,7 +2767,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -2767,7 +2767,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
             }
 
         - name: GORILLA_SETTINGS_CACHE

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -1051,7 +1051,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1216,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2137,7 +2137,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2281,7 +2281,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2424,7 +2424,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2722,7 +2722,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -2732,7 +2732,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE
@@ -4148,7 +4148,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -1067,7 +1067,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1232,7 +1232,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2237,7 +2237,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2381,7 +2381,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2524,7 +2524,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2822,7 +2822,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -2832,7 +2832,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE
@@ -4339,7 +4339,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -2700,7 +2700,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -1019,7 +1019,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1184,7 +1184,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2105,7 +2105,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2249,7 +2249,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2392,7 +2392,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(A_KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
         - name: GORILLA_SETTINGS_CACHE
           value: 'redis://:$(A_REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
@@ -2690,7 +2690,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -4117,7 +4117,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -2708,7 +2708,7 @@ spec:
                 "name": "wandb",
                 "prefix": "wandb-overflow"
               },
-              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?producer_batch_bytes=1048576&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)&replication_factor=3"
+              "addr": "kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)"
             }
 
         - name: GORILLA_SETTINGS_CACHE

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -1275,7 +1275,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1441,7 +1441,7 @@ data:
   KAFKA_BROKER_PORT: "9092"
   KAFKA_CLIENT_USER: ""
   KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
-  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "12"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
 ---
 # Source: operator-wandb/templates/mysql.yaml
 apiVersion: v1
@@ -2698,7 +2698,7 @@ spec:
         - name: KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE
           value: chartsnap-run-updates-shadow
         - name: KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS
-          value: "12"
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE
           value: >
             {
@@ -4341,7 +4341,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4369,7 +4369,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.32.7
+    helm.sh/chart: operator-wandb-0.32.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION
- remove `producer_batch_size` & `replication_factor` parameters from the connection string
- `producer_batch_size` —  "ProducerBatchMaxBytes upper bounds the size of a record batch, overriding the default 1,000,012 bytes. This mirrors Kafka's max.message.bytes." previously set to ~1MB but this needs to be higher (~10MB to accommodate the largest message) but we will set this value from the application level. 
- `replication_factor` — bufstream is leaderless and the replica config doesn't really exist. hardcoded in the application and removing from here as well. 
- increase the num_partitions to 100 per [bufstream suggestion](https://weightsandbiases.slack.com/archives/C081DJ4NFSN/p1752095948843079)

before
<img width="1365" height="343" alt="Screenshot 2025-07-23 at 8 09 17 PM" src="https://github.com/user-attachments/assets/d7504bed-3b96-475d-8a90-931f80f4fbe3" />
after
<img width="1346" height="335" alt="Screenshot 2025-07-23 at 8 16 38 PM" src="https://github.com/user-attachments/assets/bffee9b2-8d23-4ca9-b993-0e3eb63731a1" />

doesn't increase the partition if the topic already exists.
<img width="300" height="178" alt="Screenshot 2025-07-23 at 8 20 28 PM" src="https://github.com/user-attachments/assets/9c7d1473-97ac-4619-a867-ec2b49d0bbb6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart version for operator-wandb.
  * Increased the default number of Kafka partitions for run updates shadow topics from 12 to 100.

* **Refactor**
  * Simplified Kafka connection URLs by removing producer batch size and replication factor parameters, leaving only the number of partitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->