### PR TITLE
chore(launch): Add projected sa volume capabilities

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: launch-agent
 icon: https://em-content.zobj.net/thumbs/240/apple/354/rocket_1f680.png
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.13.12
+version: 0.13.13
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
             - name: WANDB_LAUNCH_KANIKO_AUTH_SECRET
               value: {{ .Values.kanikoDockerConfigSecret }}
             {{- end }}
+            {{- if .Values.oidc.enabled }}
+            - name: WANDB_IDENTITY_TOKEN_FILE
+              value: {{ .Values.oidc.tokenPath }}
+            {{- end }}
           volumeMounts:
             - name: ssh-dir
               mountPath: /home/launch_agent/.ssh
@@ -151,6 +155,11 @@ spec:
             {{- if .Values.kanikoPvcName }}
             - name: kaniko-pvc
               mountPath: /home/launch_agent/kaniko
+            {{ end }}
+            {{- if .Values.oidc.enabled }}
+            - name: oidc-token
+              mountPath: {{ .Values.oidc.tokenPath }}
+              readOnly: true
             {{ end }}
       volumes:
         - name: ssh-dir
@@ -192,6 +201,17 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.kanikoPvcName }}
         {{- end }}
+        {{ if .Values.oidc.enabled }}
+        - name: oidc-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: oidc-token
+                expirationSeconds: {{ .Values.oidc.expirationSeconds }}
+                {{- if .Values.oidc.audience }}
+                audience: {{ .Values.oidc.audience }}
+                {{- end }}
+        {{ end }}
       nodeSelector:
         {{- toYaml .Values.agent.nodeSelector | nindent 8 }}
       tolerations:

--- a/charts/launch-agent/values.yaml
+++ b/charts/launch-agent/values.yaml
@@ -99,3 +99,14 @@ kanikoPvcName:
 # Name of a secret containing a docker config.json file to use with kaniko.
 # This secret will be mounted at /kaniko/.docker in the agent container.
 kanikoDockerConfigSecret:
+
+# OIDC JWT configuration for using cluster as JWT issuer
+oidc:
+  # Enable OIDC JWT token projection
+  enabled: false
+  # Service account token audience
+  audience: ""
+  # Token expiration time in seconds (default: 3600)
+  expirationSeconds: 3600
+  # Path where the token will be mounted
+  tokenPath: "/var/run/secrets/tokens/oidc-token"


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-26209

Heads up, this PR merges into the `dom/public-queue` branch which has the RBAC necessary for the launch agent to create resources for the vllm service.

This PR adds an `oidc` configuration to the chart so we can set the launch agent up as an approved launch agent (federated identity). When enabled, the `WANDB_IDENTITY_TOKEN_FILE` env var will be set to the projected service account token volume.