### PR TITLE
fix: Include local configmap for app pod

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.33.6
+version: 0.33.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -463,6 +463,7 @@ app:
     "{{ .Release.Name }}-gorilla-session-key": "secretRef"
     "{{ .Release.Name }}-frontend-configmap": "configMapRef"
     "{{ .Release.Name }}-app-configmap": "configMapRef"
+    "{{ .Release.Name }}-local-configmap": "configMapRef"
   envTpls:
     - '{{ include "wandb.downwardEnvs" . }}'
     - '{{ include "wandb.bucket.cwIdentity" . }}'

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -1120,7 +1120,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1152,7 +1152,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1194,7 +1194,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1207,7 +1207,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1400,7 +1400,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2325,7 +2325,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -2364,6 +2364,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -2591,6 +2593,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3979,7 +3983,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -1151,7 +1151,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1183,7 +1183,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1225,7 +1225,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1238,7 +1238,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1431,7 +1431,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2356,7 +2356,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -2395,6 +2395,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -2622,6 +2624,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -4247,7 +4251,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -1275,7 +1275,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1307,7 +1307,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1349,7 +1349,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1362,7 +1362,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1555,7 +1555,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3283,7 +3283,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3322,6 +3322,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3571,6 +3573,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -6478,7 +6482,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -1358,7 +1358,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1390,7 +1390,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1432,7 +1432,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1445,7 +1445,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1638,7 +1638,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3379,7 +3379,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3418,6 +3418,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3655,6 +3657,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -6195,7 +6199,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -1213,7 +1213,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1245,7 +1245,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1287,7 +1287,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1300,7 +1300,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1493,7 +1493,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3110,7 +3110,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3149,6 +3149,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3378,6 +3380,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -5487,7 +5491,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -1182,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1214,7 +1214,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1256,7 +1256,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1269,7 +1269,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1462,7 +1462,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3079,7 +3079,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3118,6 +3118,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3345,6 +3347,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -5258,7 +5262,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -1182,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1214,7 +1214,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1256,7 +1256,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1269,7 +1269,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1462,7 +1462,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3079,7 +3079,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3118,6 +3118,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3345,6 +3347,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -5260,7 +5264,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -1150,7 +1150,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1224,7 +1224,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1237,7 +1237,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1430,7 +1430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3047,7 +3047,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3086,6 +3086,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3313,6 +3315,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -5226,7 +5230,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -1611,7 +1611,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1643,7 +1643,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1685,7 +1685,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1698,7 +1698,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1891,7 +1891,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3804,7 +3804,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3843,6 +3843,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -4070,6 +4072,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -6974,7 +6978,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7002,7 +7006,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -1435,7 +1435,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1467,7 +1467,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1509,7 +1509,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1522,7 +1522,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1715,7 +1715,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -3530,7 +3530,7 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
+    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
     secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
@@ -3569,6 +3569,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -3796,6 +3798,8 @@ spec:
             name: chartsnap-gorilla-session-key
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
         - configMapRef:
             name: chartsnap-mysql-configmap
         - configMapRef:
@@ -6294,7 +6298,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6322,7 +6326,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.6
+    helm.sh/chart: operator-wandb-0.33.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support loading environment variables from an optional local ConfigMap, enabling easier environment-specific configuration without changing images or templates. No behavior change unless the ConfigMap is provided.
* **Chores**
  * Bumped Helm chart version to 0.33.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->