### PR TITLE
fix: Bump resources and fix merge order

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,28 +1,28 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -46,10 +46,10 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: nginx
   repository: file://charts/nginx
   version: 0.1.0
@@ -61,24 +61,24 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.1
+  version: 0.8.2
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.1.0
-digest: sha256:2fdd4c8e8f2afdd350536be188a172a796657cb879658a8c3a6e7ec672d44421
-generated: "2025-08-13T12:15:22.882224-06:00"
+digest: sha256:f9602c99ef2b2d28201912dbb962b01ff2ba8cd4b0541c615dc8e1621f22a0df
+generated: "2025-08-14T17:21:50.36019-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.33.7
+version: 0.33.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -384,10 +384,10 @@ api:
     medium:
       resources:
         limits:
-          cpu: "4"
+          cpu: "6"
           memory: 16Gi
         requests:
-          cpu: "2"
+          cpu: "4"
           memory: 12Gi
       autoscaling:
         horizontal:
@@ -397,10 +397,10 @@ api:
     large:
       resources:
         limits:
-          cpu: "4"
+          cpu: "6"
           memory: 16Gi
         requests:
-          cpu: "3"
+          cpu: "4"
           memory: 12Gi
       autoscaling:
         horizontal:
@@ -410,10 +410,10 @@ api:
     xlarge:
       resources:
         limits:
-          cpu: "4"
+          cpu: "6"
           memory: 16Gi
         requests:
-          cpu: "3"
+          cpu: "4"
           memory: 12Gi
       autoscaling:
         horizontal:
@@ -423,10 +423,10 @@ api:
     xxlarge:
       resources:
         limits:
-          cpu: "4"
+          cpu: "6"
           memory: 16Gi
         requests:
-          cpu: "3"
+          cpu: "4"
           memory: 12Gi
       autoscaling:
         horizontal:
@@ -1271,42 +1271,42 @@ glue:
       resources:
         limits:
           cpu: "2"
-          memory: 4Gi
+          memory: 6Gi
         requests:
           cpu: "1"
-          memory: 1Gi
+          memory: 2Gi
     medium:
       resources:
         limits:
-          cpu: "2"
-          memory: 4Gi
+          cpu: "4"
+          memory: 8Gi
         requests:
-          cpu: "1"
-          memory: 2Gi
+          cpu: "3"
+          memory: 6Gi
     large:
       resources:
         limits:
-          cpu: "2"
-          memory: 4Gi
+          cpu: "4"
+          memory: 8Gi
         requests:
-          cpu: "1"
-          memory: 2Gi
+          cpu: "3"
+          memory: 6Gi
     xlarge:
       resources:
         limits:
-          cpu: "2"
-          memory: 4Gi
+          cpu: "4"
+          memory: 8Gi
         requests:
-          cpu: "1"
-          memory: 2Gi
+          cpu: "3"
+          memory: 6Gi
     xxlarge:
       resources:
         limits:
-          cpu: "2"
-          memory: 4Gi
+          cpu: "4"
+          memory: 8Gi
         requests:
-          cpu: "1"
-          memory: 2Gi
+          cpu: "3"
+          memory: 6Gi
 
 metric-observer:
   install: false
@@ -1657,6 +1657,9 @@ weave:
         - python
         - weave-public/weave_query/scripts/clear_cache.py
       resources:
+        limits:
+          cpu: 4
+          memory: 12Gi
         requests:
           cpu: 100m
           memory: 128Mi

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.8.1
+version: 0.8.2
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/_containers.tpl
+++ b/charts/wandb-base/templates/_containers.tpl
@@ -14,7 +14,7 @@
     {{- $_ = set $container "root" $.root }}
     {{- if eq $.source "containers" }}
       {{/* Merge in resources from .Values.resources to support legacy chart values */}}
-      {{- $_ = set $container "resources" (merge (default (dict) ($.root.Values.resources)) (default (dict) ($container.resources))) }}
+      {{- $_ = set $container "resources" (merge (default (dict) ($container.resources)) (default (dict) ($.root.Values.resources))) }}
 
       {{- $sizingInfo := fromYaml (include "wandb-base.sizingInfo" $.root) }}
       {{- if $sizingInfo  }}

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -118,7 +118,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -144,7 +144,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -202,7 +202,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1120,7 +1120,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1152,7 +1152,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1194,7 +1194,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1207,7 +1207,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1400,7 +1400,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1533,7 +1533,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1688,7 +1688,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1751,7 +1751,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1839,7 +1839,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1883,7 +1883,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1913,7 +1913,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1999,7 +1999,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2157,7 +2157,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2319,7 +2319,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2337,7 +2337,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2793,7 +2793,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2810,7 +2810,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2895,7 +2895,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2914,7 +2914,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3347,7 +3347,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3364,7 +3364,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3748,7 +3748,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3761,7 +3761,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -3986,7 +3986,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -3436,6 +3436,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -3704,6 +3704,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.1
+    helm.sh/chart: executor-0.8.2
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -123,7 +123,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -136,7 +136,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +149,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.1
+    helm.sh/chart: executor-0.8.2
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -175,7 +175,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -233,7 +233,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1151,7 +1151,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1183,7 +1183,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1225,7 +1225,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1238,7 +1238,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1431,7 +1431,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1564,7 +1564,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1719,7 +1719,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1782,7 +1782,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1870,7 +1870,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1914,7 +1914,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1944,7 +1944,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2030,7 +2030,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2188,7 +2188,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2350,7 +2350,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2368,7 +2368,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2824,7 +2824,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2841,7 +2841,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2926,7 +2926,7 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: executor-0.8.1
+    helm.sh/chart: executor-0.8.2
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2944,7 +2944,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.8.1
+        helm.sh/chart: executor-0.8.2
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3163,7 +3163,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3182,7 +3182,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3615,7 +3615,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3632,7 +3632,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4016,7 +4016,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4029,7 +4029,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -4254,7 +4254,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.1
+    helm.sh/chart: filestream-0.8.2
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.1
+    helm.sh/chart: flat-run-fields-updater-0.8.2
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -123,7 +123,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -141,7 +141,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.1
+    helm.sh/chart: metric-observer-0.8.2
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -195,7 +195,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -208,7 +208,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -221,7 +221,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -234,7 +234,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.1
+    helm.sh/chart: filestream-0.8.2
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -247,7 +247,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.1
+    helm.sh/chart: flat-run-fields-updater-0.8.2
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -260,7 +260,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -273,7 +273,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.1
+    helm.sh/chart: metric-observer-0.8.2
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -299,7 +299,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -357,7 +357,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1275,7 +1275,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1307,7 +1307,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1349,7 +1349,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1362,7 +1362,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1555,7 +1555,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1688,7 +1688,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1843,7 +1843,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1906,7 +1906,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1934,7 +1934,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1962,7 +1962,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1990,7 +1990,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.1
+    helm.sh/chart: metric-observer-0.8.2
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2075,7 +2075,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2095,7 +2095,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2115,7 +2115,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2135,7 +2135,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.1
+    helm.sh/chart: metric-observer-0.8.2
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2179,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2201,7 +2201,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2231,7 +2231,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2317,7 +2317,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2475,7 +2475,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2637,7 +2637,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2655,7 +2655,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3277,7 +3277,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3295,7 +3295,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3795,7 +3795,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3812,7 +3812,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3919,7 +3919,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: filestream-0.8.1
+    helm.sh/chart: filestream-0.8.2
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3937,7 +3937,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.8.1
+        helm.sh/chart: filestream-0.8.2
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4180,7 +4180,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.1
+    helm.sh/chart: flat-run-fields-updater-0.8.2
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4198,7 +4198,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.8.1
+        helm.sh/chart: flat-run-fields-updater-0.8.2
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4429,7 +4429,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4447,7 +4447,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5020,7 +5020,7 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.1
+    helm.sh/chart: metric-observer-0.8.2
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5038,7 +5038,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: metric-observer-0.8.1
+        helm.sh/chart: metric-observer-0.8.2
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5217,8 +5217,8 @@ spec:
             cpu: 1000m
             memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 250m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /usr/local/share/ca-certificates/inline
           name: wandb-ca-certs
@@ -5274,7 +5274,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5293,7 +5293,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5748,7 +5748,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5765,7 +5765,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5927,7 +5927,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.1
+    helm.sh/chart: metric-observer-0.8.2
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6225,7 +6225,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6238,7 +6238,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6485,7 +6485,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -5881,6 +5881,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -5342,6 +5342,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -63,7 +63,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -81,7 +81,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -99,7 +99,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.1
+    helm.sh/chart: flat-run-fields-updater-0.8.2
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -156,7 +156,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -174,7 +174,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -192,7 +192,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -210,7 +210,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -223,7 +223,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -249,7 +249,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -276,7 +276,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.1
+    helm.sh/chart: flat-run-fields-updater-0.8.2
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -289,7 +289,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -315,7 +315,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -373,7 +373,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1358,7 +1358,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1390,7 +1390,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1432,7 +1432,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1445,7 +1445,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1638,7 +1638,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1771,7 +1771,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1926,7 +1926,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1989,7 +1989,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2017,7 +2017,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2045,7 +2045,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2133,7 +2133,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2153,7 +2153,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2173,7 +2173,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2217,7 +2217,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2239,7 +2239,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2295,7 +2295,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2449,7 +2449,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2607,7 +2607,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2769,7 +2769,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2787,7 +2787,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3373,7 +3373,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3391,7 +3391,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3867,7 +3867,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3884,7 +3884,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3979,7 +3979,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.1
+    helm.sh/chart: flat-run-fields-updater-0.8.2
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3997,7 +3997,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.8.1
+        helm.sh/chart: flat-run-fields-updater-0.8.2
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4216,7 +4216,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4234,7 +4234,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4771,7 +4771,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4790,7 +4790,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5233,7 +5233,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5250,7 +5250,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5954,7 +5954,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5967,7 +5967,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6202,7 +6202,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -4944,6 +4944,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.1
+    helm.sh/chart: filemeta-0.8.2
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -123,7 +123,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -141,7 +141,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.1
+    helm.sh/chart: filemeta-0.8.2
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -237,7 +237,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -295,7 +295,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1213,7 +1213,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1245,7 +1245,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1287,7 +1287,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1300,7 +1300,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1493,7 +1493,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1626,7 +1626,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1781,7 +1781,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1844,7 +1844,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1872,7 +1872,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1900,7 +1900,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1988,7 +1988,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2008,7 +2008,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2028,7 +2028,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2072,7 +2072,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2094,7 +2094,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2124,7 +2124,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2210,7 +2210,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2368,7 +2368,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2530,7 +2530,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2548,7 +2548,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3104,7 +3104,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3122,7 +3122,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3582,7 +3582,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3599,7 +3599,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3684,7 +3684,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.1
+    helm.sh/chart: filemeta-0.8.2
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3702,7 +3702,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.8.1
+        helm.sh/chart: filemeta-0.8.2
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3878,7 +3878,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3896,7 +3896,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4403,7 +4403,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4422,7 +4422,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4855,7 +4855,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4872,7 +4872,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5256,7 +5256,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5269,7 +5269,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5494,7 +5494,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -123,7 +123,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -141,7 +141,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -167,7 +167,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -264,7 +264,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1182,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1214,7 +1214,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1256,7 +1256,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1269,7 +1269,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1462,7 +1462,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1595,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1750,7 +1750,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1813,7 +1813,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1841,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1869,7 +1869,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1957,7 +1957,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1977,7 +1977,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1997,7 +1997,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2041,7 +2041,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,7 +2063,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2093,7 +2093,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2179,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2337,7 +2337,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2499,7 +2499,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2517,7 +2517,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3073,7 +3073,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3547,7 +3547,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3564,7 +3564,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3649,7 +3649,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3667,7 +3667,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4174,7 +4174,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4193,7 +4193,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4626,7 +4626,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4643,7 +4643,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5027,7 +5027,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5040,7 +5040,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5265,7 +5265,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -4715,6 +4715,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -123,7 +123,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -141,7 +141,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -167,7 +167,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -264,7 +264,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1182,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1214,7 +1214,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1256,7 +1256,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1269,7 +1269,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1462,7 +1462,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1595,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1750,7 +1750,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1813,7 +1813,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1841,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1869,7 +1869,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1957,7 +1957,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1977,7 +1977,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1997,7 +1997,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2041,7 +2041,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,7 +2063,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2093,7 +2093,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2179,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2337,7 +2337,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2499,7 +2499,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2517,7 +2517,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3073,7 +3073,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3547,7 +3547,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3564,7 +3564,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3649,7 +3649,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3667,7 +3667,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4174,7 +4174,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4193,7 +4193,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4626,7 +4626,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4643,7 +4643,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5029,7 +5029,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5042,7 +5042,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5267,7 +5267,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -4715,6 +4715,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -4683,6 +4683,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -51,7 +51,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -87,7 +87,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -123,7 +123,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -141,7 +141,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -154,7 +154,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -167,7 +167,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -264,7 +264,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1150,7 +1150,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1224,7 +1224,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1237,7 +1237,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1430,7 +1430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1563,7 +1563,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1718,7 +1718,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1781,7 +1781,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1809,7 +1809,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1837,7 +1837,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1925,7 +1925,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1945,7 +1945,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1965,7 +1965,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2009,7 +2009,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2031,7 +2031,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2061,7 +2061,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2147,7 +2147,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2305,7 +2305,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2467,7 +2467,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2485,7 +2485,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3041,7 +3041,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3059,7 +3059,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3515,7 +3515,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3532,7 +3532,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3617,7 +3617,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3635,7 +3635,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4142,7 +4142,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4161,7 +4161,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4594,7 +4594,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4611,7 +4611,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4995,7 +4995,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5008,7 +5008,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5233,7 +5233,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -128,7 +128,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -146,7 +146,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -212,7 +212,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -251,7 +251,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -269,7 +269,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -287,7 +287,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.1
+    helm.sh/chart: weave-trace-worker-0.8.2
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -305,7 +305,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -341,7 +341,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -354,7 +354,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -395,7 +395,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -422,7 +422,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -448,7 +448,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -506,7 +506,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.1
+    helm.sh/chart: weave-trace-worker-0.8.2
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -519,7 +519,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -532,7 +532,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1611,7 +1611,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1643,7 +1643,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1685,7 +1685,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1698,7 +1698,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1891,7 +1891,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2024,7 +2024,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2179,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2257,7 +2257,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2285,7 +2285,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2313,7 +2313,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2401,7 +2401,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2421,7 +2421,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2441,7 +2441,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2485,7 +2485,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2507,7 +2507,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2724,7 +2724,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2878,7 +2878,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3036,7 +3036,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3058,7 +3058,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3224,7 +3224,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3242,7 +3242,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3798,7 +3798,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3816,7 +3816,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4272,7 +4272,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4289,7 +4289,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4374,7 +4374,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4392,7 +4392,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4899,7 +4899,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4918,7 +4918,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5351,7 +5351,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.1
+    helm.sh/chart: weave-trace-worker-0.8.2
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5369,7 +5369,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.8.1
+        helm.sh/chart: weave-trace-worker-0.8.2
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5453,7 +5453,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5471,7 +5471,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.8.1
+        helm.sh/chart: weave-trace-0.8.2
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5617,7 +5617,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5634,7 +5634,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6669,7 +6669,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6682,7 +6682,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6981,7 +6981,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7009,7 +7009,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -5706,6 +5706,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -5330,6 +5330,9 @@ spec:
         image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -98,7 +98,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -116,7 +116,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -182,7 +182,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -200,7 +200,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -218,7 +218,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -236,7 +236,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -254,7 +254,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -272,7 +272,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -285,7 +285,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -313,7 +313,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -326,7 +326,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -352,7 +352,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -410,7 +410,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -423,7 +423,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1435,7 +1435,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1467,7 +1467,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1509,7 +1509,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1522,7 +1522,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1715,7 +1715,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1848,7 +1848,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2003,7 +2003,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2081,7 +2081,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2109,7 +2109,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2137,7 +2137,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2225,7 +2225,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2245,7 +2245,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2265,7 +2265,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2309,7 +2309,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2331,7 +2331,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2522,7 +2522,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2608,7 +2608,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2766,7 +2766,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2788,7 +2788,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2950,7 +2950,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.1
+    helm.sh/chart: api-0.8.2
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2968,7 +2968,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.1
+        helm.sh/chart: api-0.8.2
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3524,7 +3524,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.1
+    helm.sh/chart: app-0.8.2
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3542,7 +3542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.1
+        helm.sh/chart: app-0.8.2
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3998,7 +3998,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.1
+    helm.sh/chart: console-0.8.2
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4015,7 +4015,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.1
+        helm.sh/chart: console-0.8.2
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4100,7 +4100,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.1
+    helm.sh/chart: glue-0.8.2
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4118,7 +4118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.1
+        helm.sh/chart: glue-0.8.2
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4625,7 +4625,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4644,7 +4644,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.1
+        helm.sh/chart: parquet-0.8.2
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5077,7 +5077,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.1
+    helm.sh/chart: weave-trace-0.8.2
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5095,7 +5095,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.8.1
+        helm.sh/chart: weave-trace-0.8.2
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5241,7 +5241,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.1
+    helm.sh/chart: weave-0.8.2
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5258,7 +5258,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.1
+        helm.sh/chart: weave-0.8.2
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5989,7 +5989,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.1
+    helm.sh/chart: parquet-0.8.2
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6002,7 +6002,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.1
+            helm.sh/chart: parquet-0.8.2
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6301,7 +6301,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6329,7 +6329,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.7
+    helm.sh/chart: operator-wandb-0.33.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CPU and memory limits for the weave cache-clear job.
- Improvements
  - Increased default CPU/memory requests and limits for API and Glue sizes to better accommodate workloads.
  - Global resource settings now take precedence over container-specific settings when both are provided.
- Chores
  - Bumped operator chart version to 0.33.8.
  - Bumped base chart version to 0.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->