### PR TITLE
fix: exclude job pods from the PDB

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,28 +1,28 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -46,10 +46,10 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: nginx
   repository: file://charts/nginx
   version: 0.1.0
@@ -61,24 +61,24 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.2
+  version: 0.8.3
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.1.0
-digest: sha256:f9602c99ef2b2d28201912dbb962b01ff2ba8cd4b0541c615dc8e1621f22a0df
-generated: "2025-08-14T17:21:50.36019-07:00"
+digest: sha256:1ffb5383affc56d2e3262d8f35300e4d8c69f41f9f4ea8919c06eb6f59a9c4bc
+generated: "2025-08-14T18:01:23.667686-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.33.8
+version: 0.33.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.8.2
+version: 0.8.3
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/pdb.yaml
+++ b/charts/wandb-base/templates/pdb.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   selector:
+    matchExpressions:
+      - key: batch.kubernetes.io/job-name
+        operator: DoesNotExist
     matchLabels:
       {{- include "wandb-base.selectorLabels" . | nindent 6 }}
   {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -105,7 +117,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -118,7 +130,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -144,7 +156,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -202,7 +214,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1120,7 +1132,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1152,7 +1164,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1194,7 +1206,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1207,7 +1219,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1400,7 +1412,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1533,7 +1545,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1688,7 +1700,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1751,7 +1763,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1839,7 +1851,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1883,7 +1895,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1913,7 +1925,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1999,7 +2011,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2157,7 +2169,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2319,7 +2331,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2337,7 +2349,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2793,7 +2805,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2810,7 +2822,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2895,7 +2907,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2914,7 +2926,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3347,7 +3359,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3364,7 +3376,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3748,7 +3760,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3761,7 +3773,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -3986,7 +3998,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.2
+    helm.sh/chart: executor-0.8.3
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: executor
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -105,13 +117,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -123,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -136,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.2
+    helm.sh/chart: executor-0.8.3
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -175,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -233,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1151,7 +1166,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1183,7 +1198,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1225,7 +1240,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1238,7 +1253,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1431,7 +1446,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1564,7 +1579,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1719,7 +1734,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1782,7 +1797,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1870,7 +1885,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1914,7 +1929,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1944,7 +1959,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2030,7 +2045,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2188,7 +2203,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2350,7 +2365,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2368,7 +2383,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2824,7 +2839,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2841,7 +2856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2926,7 +2941,7 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: executor-0.8.2
+    helm.sh/chart: executor-0.8.3
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2944,7 +2959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.8.2
+        helm.sh/chart: executor-0.8.3
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3163,7 +3178,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3182,7 +3197,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3615,7 +3630,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3632,7 +3647,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4016,7 +4031,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4029,7 +4044,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -4254,7 +4269,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.2
+    helm.sh/chart: filestream-0.8.3
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: filestream
       app.kubernetes.io/instance: chartsnap
@@ -105,13 +117,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.2
+    helm.sh/chart: flat-run-fields-updater-0.8.3
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: flat-run-fields-updater
       app.kubernetes.io/instance: chartsnap
@@ -123,13 +138,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -141,13 +159,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.2
+    helm.sh/chart: metric-observer-0.8.3
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: metric-observer
       app.kubernetes.io/instance: chartsnap
@@ -159,13 +180,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -177,13 +201,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -195,7 +222,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -208,7 +235,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -221,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -234,7 +261,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.2
+    helm.sh/chart: filestream-0.8.3
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -247,7 +274,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.2
+    helm.sh/chart: flat-run-fields-updater-0.8.3
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -260,7 +287,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -273,7 +300,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.2
+    helm.sh/chart: metric-observer-0.8.3
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -299,7 +326,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -357,7 +384,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1275,7 +1302,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1307,7 +1334,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1349,7 +1376,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1362,7 +1389,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1555,7 +1582,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1688,7 +1715,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1843,7 +1870,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1906,7 +1933,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1934,7 +1961,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1962,7 +1989,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1990,7 +2017,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.2
+    helm.sh/chart: metric-observer-0.8.3
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2075,7 +2102,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2095,7 +2122,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2115,7 +2142,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2135,7 +2162,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.2
+    helm.sh/chart: metric-observer-0.8.3
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2206,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2201,7 +2228,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2231,7 +2258,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2317,7 +2344,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2475,7 +2502,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2637,7 +2664,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2655,7 +2682,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3277,7 +3304,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3295,7 +3322,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3795,7 +3822,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3812,7 +3839,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3919,7 +3946,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: filestream-0.8.2
+    helm.sh/chart: filestream-0.8.3
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3937,7 +3964,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.8.2
+        helm.sh/chart: filestream-0.8.3
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4180,7 +4207,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.2
+    helm.sh/chart: flat-run-fields-updater-0.8.3
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4198,7 +4225,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.8.2
+        helm.sh/chart: flat-run-fields-updater-0.8.3
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4429,7 +4456,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4447,7 +4474,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5020,7 +5047,7 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.2
+    helm.sh/chart: metric-observer-0.8.3
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5038,7 +5065,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: metric-observer-0.8.2
+        helm.sh/chart: metric-observer-0.8.3
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5274,7 +5301,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5293,7 +5320,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5748,7 +5775,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5765,7 +5792,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5927,7 +5954,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.2
+    helm.sh/chart: metric-observer-0.8.3
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6225,7 +6252,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6238,7 +6265,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6485,7 +6512,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -63,13 +63,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -81,13 +84,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -99,13 +105,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -138,13 +147,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.2
+    helm.sh/chart: flat-run-fields-updater-0.8.3
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: flat-run-fields-updater
       app.kubernetes.io/instance: chartsnap
@@ -156,13 +168,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -174,13 +189,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -192,13 +210,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -210,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -223,7 +244,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -249,7 +270,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -276,7 +297,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.2
+    helm.sh/chart: flat-run-fields-updater-0.8.3
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -289,7 +310,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -315,7 +336,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -373,7 +394,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1358,7 +1379,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1390,7 +1411,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1432,7 +1453,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1445,7 +1466,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1638,7 +1659,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1771,7 +1792,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1926,7 +1947,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1989,7 +2010,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2017,7 +2038,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2045,7 +2066,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2133,7 +2154,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2153,7 +2174,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2173,7 +2194,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2217,7 +2238,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2239,7 +2260,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2295,7 +2316,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2449,7 +2470,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2607,7 +2628,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2769,7 +2790,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2787,7 +2808,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3373,7 +3394,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3391,7 +3412,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3867,7 +3888,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3884,7 +3905,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3979,7 +4000,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.2
+    helm.sh/chart: flat-run-fields-updater-0.8.3
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3997,7 +4018,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.8.2
+        helm.sh/chart: flat-run-fields-updater-0.8.3
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4216,7 +4237,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4234,7 +4255,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4771,7 +4792,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4790,7 +4811,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5233,7 +5254,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5250,7 +5271,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5954,7 +5975,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5967,7 +5988,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6202,7 +6223,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.2
+    helm.sh/chart: filemeta-0.8.3
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: filemeta
       app.kubernetes.io/instance: chartsnap
@@ -105,13 +117,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -123,13 +138,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -141,13 +159,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -159,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.2
+    helm.sh/chart: filemeta-0.8.3
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -211,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -237,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -295,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1213,7 +1234,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1245,7 +1266,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1287,7 +1308,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1300,7 +1321,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1493,7 +1514,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1626,7 +1647,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1781,7 +1802,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1844,7 +1865,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1872,7 +1893,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1900,7 +1921,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1988,7 +2009,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2008,7 +2029,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2028,7 +2049,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2072,7 +2093,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2094,7 +2115,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2124,7 +2145,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2210,7 +2231,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2368,7 +2389,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2530,7 +2551,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2548,7 +2569,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3104,7 +3125,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3122,7 +3143,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3582,7 +3603,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3599,7 +3620,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3684,7 +3705,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.2
+    helm.sh/chart: filemeta-0.8.3
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3702,7 +3723,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.8.2
+        helm.sh/chart: filemeta-0.8.3
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3878,7 +3899,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3896,7 +3917,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4403,7 +4424,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4422,7 +4443,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4855,7 +4876,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4872,7 +4893,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5256,7 +5277,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5269,7 +5290,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5494,7 +5515,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -105,13 +117,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -123,13 +138,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -141,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -154,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -167,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -264,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1182,7 +1200,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1214,7 +1232,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1256,7 +1274,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1269,7 +1287,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1462,7 +1480,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1613,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1750,7 +1768,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1813,7 +1831,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1859,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1869,7 +1887,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1957,7 +1975,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1977,7 +1995,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1997,7 +2015,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2041,7 +2059,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,7 +2081,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2093,7 +2111,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2197,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2337,7 +2355,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2499,7 +2517,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2517,7 +2535,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3073,7 +3091,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3091,7 +3109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3547,7 +3565,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3564,7 +3582,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3649,7 +3667,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3667,7 +3685,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4174,7 +4192,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4193,7 +4211,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4626,7 +4644,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4643,7 +4661,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5027,7 +5045,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5040,7 +5058,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5265,7 +5283,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -105,13 +117,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -123,13 +138,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -141,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -154,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -167,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -264,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1182,7 +1200,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1214,7 +1232,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1256,7 +1274,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1269,7 +1287,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1462,7 +1480,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1613,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1750,7 +1768,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1813,7 +1831,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1859,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1869,7 +1887,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1957,7 +1975,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1977,7 +1995,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1997,7 +2015,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2041,7 +2059,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,7 +2081,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2093,7 +2111,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2197,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2337,7 +2355,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2499,7 +2517,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2517,7 +2535,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3073,7 +3091,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3091,7 +3109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3547,7 +3565,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3564,7 +3582,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3649,7 +3667,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3667,7 +3685,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4174,7 +4192,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4193,7 +4211,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4626,7 +4644,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4643,7 +4661,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5029,7 +5047,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5042,7 +5060,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5267,7 +5285,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -33,13 +33,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -51,13 +54,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -69,13 +75,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -87,13 +96,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -105,13 +117,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -123,13 +138,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -141,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -154,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -167,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -264,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1150,7 +1168,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1200,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1224,7 +1242,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1237,7 +1255,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1430,7 +1448,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1563,7 +1581,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1718,7 +1736,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1781,7 +1799,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1809,7 +1827,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1837,7 +1855,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1925,7 +1943,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1945,7 +1963,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1965,7 +1983,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2009,7 +2027,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2031,7 +2049,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2061,7 +2079,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2147,7 +2165,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2305,7 +2323,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2467,7 +2485,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2485,7 +2503,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3041,7 +3059,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3059,7 +3077,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3515,7 +3533,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3532,7 +3550,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3617,7 +3635,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3635,7 +3653,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4142,7 +4160,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4161,7 +4179,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4594,7 +4612,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4611,7 +4629,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4995,7 +5013,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5008,7 +5026,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5233,7 +5251,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -128,13 +128,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -146,13 +149,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -212,13 +218,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -251,13 +260,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -269,13 +281,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -287,13 +302,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.2
+    helm.sh/chart: weave-trace-worker-0.8.3
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave-trace-worker
       app.kubernetes.io/instance: chartsnap
@@ -305,13 +323,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave-trace
       app.kubernetes.io/instance: chartsnap
@@ -323,13 +344,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -341,7 +365,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -354,7 +378,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -395,7 +419,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -422,7 +446,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -448,7 +472,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -506,7 +530,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.2
+    helm.sh/chart: weave-trace-worker-0.8.3
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -519,7 +543,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -532,7 +556,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1611,7 +1635,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1643,7 +1667,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1685,7 +1709,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1698,7 +1722,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1891,7 +1915,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2024,7 +2048,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2179,7 +2203,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2257,7 +2281,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2285,7 +2309,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2313,7 +2337,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2401,7 +2425,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2421,7 +2445,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2441,7 +2465,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2485,7 +2509,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2507,7 +2531,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2724,7 +2748,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2878,7 +2902,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3036,7 +3060,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3058,7 +3082,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3224,7 +3248,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3242,7 +3266,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3798,7 +3822,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3816,7 +3840,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4272,7 +4296,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4289,7 +4313,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4374,7 +4398,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4392,7 +4416,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4899,7 +4923,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4918,7 +4942,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5351,7 +5375,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.2
+    helm.sh/chart: weave-trace-worker-0.8.3
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5369,7 +5393,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.8.2
+        helm.sh/chart: weave-trace-worker-0.8.3
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5453,7 +5477,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5471,7 +5495,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.8.2
+        helm.sh/chart: weave-trace-0.8.3
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5617,7 +5641,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5634,7 +5658,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6669,7 +6693,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6682,7 +6706,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6981,7 +7005,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7009,7 +7033,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -98,13 +98,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: api
       app.kubernetes.io/instance: chartsnap
@@ -116,13 +119,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: app
       app.kubernetes.io/instance: chartsnap
@@ -182,13 +188,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
       app.kubernetes.io/instance: chartsnap
@@ -200,13 +209,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
@@ -218,13 +230,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: parquet
       app.kubernetes.io/instance: chartsnap
@@ -236,13 +251,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave-trace
       app.kubernetes.io/instance: chartsnap
@@ -254,13 +272,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
@@ -272,7 +293,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -285,7 +306,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -313,7 +334,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -326,7 +347,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -352,7 +373,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -410,7 +431,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -423,7 +444,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1435,7 +1456,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1467,7 +1488,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1509,7 +1530,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1522,7 +1543,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1715,7 +1736,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1848,7 +1869,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2003,7 +2024,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2081,7 +2102,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2109,7 +2130,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2137,7 +2158,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2225,7 +2246,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2245,7 +2266,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2265,7 +2286,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2309,7 +2330,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2331,7 +2352,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2522,7 +2543,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2608,7 +2629,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2766,7 +2787,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2788,7 +2809,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2950,7 +2971,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.2
+    helm.sh/chart: api-0.8.3
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2968,7 +2989,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.2
+        helm.sh/chart: api-0.8.3
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3524,7 +3545,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.2
+    helm.sh/chart: app-0.8.3
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3542,7 +3563,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.2
+        helm.sh/chart: app-0.8.3
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3998,7 +4019,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.2
+    helm.sh/chart: console-0.8.3
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4015,7 +4036,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.2
+        helm.sh/chart: console-0.8.3
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4100,7 +4121,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.2
+    helm.sh/chart: glue-0.8.3
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4118,7 +4139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.2
+        helm.sh/chart: glue-0.8.3
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4625,7 +4646,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4644,7 +4665,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.2
+        helm.sh/chart: parquet-0.8.3
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5077,7 +5098,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.2
+    helm.sh/chart: weave-trace-0.8.3
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5095,7 +5116,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.8.2
+        helm.sh/chart: weave-trace-0.8.3
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5241,7 +5262,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.2
+    helm.sh/chart: weave-0.8.3
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5258,7 +5279,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.2
+        helm.sh/chart: weave-0.8.3
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5989,7 +6010,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.2
+    helm.sh/chart: parquet-0.8.3
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6002,7 +6023,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.2
+            helm.sh/chart: parquet-0.8.3
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6301,7 +6322,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6329,7 +6350,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.8
+    helm.sh/chart: operator-wandb-0.33.9
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated PodDisruptionBudget selector to exclude pods created by batch jobs, improving accuracy of disruption targeting.

- **Chores**
  - Bumped Helm chart version for operator components to 0.33.9.
  - Bumped base chart version to 0.8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->