### PR TITLE
fix: Replica count from HPA, reloader annotations, merge order fixes

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,28 +1,28 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -46,10 +46,10 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: nginx
   repository: file://charts/nginx
   version: 0.1.0
@@ -61,24 +61,24 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.8.3
+  version: 0.8.4
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.1.0
-digest: sha256:1ffb5383affc56d2e3262d8f35300e4d8c69f41f9f4ea8919c06eb6f59a9c4bc
-generated: "2025-08-14T18:01:23.667686-07:00"
+digest: sha256:3203310676b7f4ca162bec6e40a9547969b78f6771de29b5290d5399b0158965
+generated: "2025-08-15T12:26:22.670966-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.33.10
+version: 0.33.11
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -287,8 +287,7 @@ api:
         targetPort: api
         protocol: TCP
         name: http
-  env:
-    TEST_ENV: "test"
+  env: {}
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-mysql-configmap": "configMapRef"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -287,7 +287,8 @@ api:
         targetPort: api
         protocol: TCP
         name: http
-  env: {}
+  env:
+    TEST_ENV: "test"
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-mysql-configmap": "configMapRef"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.8.3
+version: 0.8.4
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -71,7 +71,7 @@ Create the name of the service account to use
 {{- $size := default "" (coalesce .Values.size .Values.global.size) }}
 {{- $sizingInfo := default (dict) (get .Values.sizing $size) }}
 {{- $defaultSize := default (dict) (get .Values.sizing "default") }}
-{{- $mergedSize := merge $sizingInfo $defaultSize }}
+{{- $mergedSize := mergeOverwrite $defaultSize $sizingInfo }}
 
 {{- toYaml $mergedSize }}
 {{- end }}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -67,38 +67,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "wandb-base.reloaderAnnotations" -}}
-{{- $configmaps := "" }}
-{{- $secrets := "" }}
-{{- range $name, $type := .Values.envFrom }}
-{{- if eq $type "configMapRef" }}
-{{ $configmaps = printf "%s%s," $configmaps $name }}
-{{- end -}}
-{{- if eq $type "secretRef" }}
-{{ $secrets = printf "%s%s," $secrets $name }}
-{{- end -}}
-{{- end -}}
-
-{{- range .Values.containers }}
-{{- range $name, $type := .envFrom }}
-{{- if eq $type "configMapRef" }}
-{{ $configmaps = printf "%s%s," $configmaps $name }}
-{{- end -}}
-{{- if eq $type "secretRef" }}
-{{ $secrets = printf "%s%s," $secrets $name }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- if $configmaps }}
-configmap.reloader.stakater.com/reload: {{ $configmaps | trimSuffix "," }}
-{{- end }}
-{{- if $secrets }}
-secret.reloader.stakater.com/reload: {{ $secrets | trimSuffix "," }}
-{{- end }}
-reloader.stakater.com/auto: "true"
-{{- end }}
-
 {{- define "wandb-base.sizingInfo" }}
 {{- $size := default "" (coalesce .Values.size .Values.global.size) }}
 {{- $sizingInfo := default (dict) (get .Values.sizing $size) }}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -115,3 +115,14 @@ reloader.stakater.com/auto: "true"
   {{- end }}
 {{- toYaml $topologyConstraints }}
 {{- end }}
+
+{{- define "wandb-base.replicaCount" }}
+{{- $desiredReplicas := .Values.replicaCount }}
+{{- if .Values.autoscaling.horizontal.enabled }}
+  {{- $hpa := lookup "autoscaling/v2" "HorizontalPodAutoscaler" .Release.Namespace (include "wandb-base.fullname" .) }}
+    {{- if $hpa }}
+      {{- $desiredReplicas = $hpa.status.desiredReplicas }}
+    {{- end }}
+{{- end }}
+{{- print $desiredReplicas }}
+{{- end }}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -88,7 +88,7 @@ Create the name of the service account to use
 {{- $desiredReplicas := .Values.replicaCount }}
 {{- if .Values.autoscaling.horizontal.enabled }}
   {{- $hpa := lookup "autoscaling/v2" "HorizontalPodAutoscaler" .Release.Namespace (include "wandb-base.fullname" .) }}
-    {{- if $hpa }}
+    {{- if and $hpa (gt $hpa.status.desiredReplicas 0) }}
       {{- $desiredReplicas = $hpa.status.desiredReplicas }}
     {{- end }}
 {{- end }}

--- a/charts/wandb-base/templates/deployment.yaml
+++ b/charts/wandb-base/templates/deployment.yaml
@@ -11,9 +11,7 @@ metadata:
     {{- tpl (include "wandb-base.deploymentAnnotations" . | nindent 4) . }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: {{ include "wandb-base.replicaCount" . }}
   selector:
     matchLabels:
       {{- include "wandb-base.selectorLabels" . | nindent 6 }}

--- a/charts/wandb-base/templates/deployment.yaml
+++ b/charts/wandb-base/templates/deployment.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ include "wandb-base.fullname" . }}{{ include "wandb-base.deploymentPostfix" . }}
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
-  {{- if .Values.addReloaderAnnotations }}
+  {{- if (or .Values.addReloaderAnnotations (include "wandb-base.deploymentAnnotations" .)) }}
   annotations:
-    {{- tpl (include "wandb-base.reloaderAnnotations" . | nindent 4) . }}
+    {{- if .Values.addReloaderAnnotations }}
+    reloader.stakater.com/auto: "true"
+    {{- end }}
     {{- tpl (include "wandb-base.deploymentAnnotations" . | nindent 4) . }}
   {{- end }}
 spec:

--- a/charts/wandb-base/templates/hpa.yaml
+++ b/charts/wandb-base/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- $sizingInfo := fromYaml (include "wandb-base.sizingInfo" .) }}
-{{- $hpaSizing := merge .Values.autoscaling.horizontal $sizingInfo.autoscaling.horizontal }}
+{{- $hpaSizing := mergeOverwrite $sizingInfo.autoscaling.horizontal .Values.autoscaling.horizontal }}
 {{- if $hpaSizing.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/charts/wandb-base/templates/statefulset.yaml
+++ b/charts/wandb-base/templates/statefulset.yaml
@@ -11,9 +11,7 @@ metadata:
     {{- tpl (include "wandb-base.statefulsetAnnotations" . | nindent 4) . }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: {{ include "wandb-base.replicaCount" . }}
   selector:
     matchLabels:
       {{- include "wandb-base.selectorLabels" . | nindent 6 }}

--- a/charts/wandb-base/templates/statefulset.yaml
+++ b/charts/wandb-base/templates/statefulset.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ include "wandb-base.fullname" . }}
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
-  {{- if .Values.addReloaderAnnotations }}
+  {{- if (or .Values.addReloaderAnnotations (include "wandb-base.statefulsetAnnotations" .)) }}
   annotations:
-    {{- tpl (include "wandb-base.reloaderAnnotations" . | nindent 4) . }}
+    {{- if .Values.addReloaderAnnotations }}
+    reloader.stakater.com/auto: "true"
+    {{- end }}
     {{- tpl (include "wandb-base.statefulsetAnnotations" . | nindent 4) . }}
   {{- end }}
 spec:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -130,7 +130,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -156,7 +156,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -214,7 +214,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1132,7 +1132,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1164,7 +1164,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1206,7 +1206,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1219,7 +1219,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1413,7 +1413,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1546,7 +1546,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1701,7 +1701,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1764,7 +1764,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1852,7 +1852,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1896,7 +1896,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1926,7 +1926,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2012,7 +2012,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2170,7 +2170,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2332,14 +2332,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2350,7 +2348,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2806,13 +2804,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2823,7 +2820,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2908,14 +2905,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2927,7 +2922,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3360,13 +3355,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3377,7 +3371,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3761,7 +3755,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3774,7 +3768,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -3999,7 +3993,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.3
+    helm.sh/chart: executor-0.8.4
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.3
+    helm.sh/chart: executor-0.8.4
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -248,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1166,7 +1166,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1198,7 +1198,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1240,7 +1240,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1253,7 +1253,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1447,7 +1447,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1580,7 +1580,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1735,7 +1735,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1798,7 +1798,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1886,7 +1886,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1930,7 +1930,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1960,7 +1960,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2046,7 +2046,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2204,7 +2204,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2366,14 +2366,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2384,7 +2382,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2840,13 +2838,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2857,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2942,14 +2939,12 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: executor-0.8.3
+    helm.sh/chart: executor-0.8.4
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-executor-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2960,7 +2955,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.8.3
+        helm.sh/chart: executor-0.8.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3179,14 +3174,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3198,7 +3191,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3631,13 +3624,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3648,7 +3640,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4032,7 +4024,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4045,7 +4037,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -4270,7 +4262,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.3
+    helm.sh/chart: filestream-0.8.4
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.3
+    helm.sh/chart: flat-run-fields-updater-0.8.4
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.3
+    helm.sh/chart: metric-observer-0.8.4
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -222,7 +222,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -235,7 +235,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -248,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -261,7 +261,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.3
+    helm.sh/chart: filestream-0.8.4
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.3
+    helm.sh/chart: flat-run-fields-updater-0.8.4
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -287,7 +287,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -300,7 +300,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.3
+    helm.sh/chart: metric-observer-0.8.4
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -326,7 +326,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -384,7 +384,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1302,7 +1302,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1334,7 +1334,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1376,7 +1376,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1389,7 +1389,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1583,7 +1583,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1716,7 +1716,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1871,7 +1871,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1934,7 +1934,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1962,7 +1962,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1990,7 +1990,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2018,7 +2018,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.3
+    helm.sh/chart: metric-observer-0.8.4
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2103,7 +2103,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2123,7 +2123,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2143,7 +2143,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2163,7 +2163,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.3
+    helm.sh/chart: metric-observer-0.8.4
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2207,7 +2207,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2229,7 +2229,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2259,7 +2259,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2345,7 +2345,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2503,7 +2503,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2665,14 +2665,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2683,7 +2681,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3305,14 +3303,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3323,7 +3319,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3823,13 +3819,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3840,7 +3835,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3947,14 +3942,12 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: filestream-0.8.3
+    helm.sh/chart: filestream-0.8.4
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-filestream-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3965,7 +3958,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.8.3
+        helm.sh/chart: filestream-0.8.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4208,14 +4201,12 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.3
+    helm.sh/chart: flat-run-fields-updater-0.8.4
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-flat-run-fields-updater-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4226,7 +4217,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.8.3
+        helm.sh/chart: flat-run-fields-updater-0.8.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4457,14 +4448,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4475,7 +4464,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5048,14 +5037,12 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.3
+    helm.sh/chart: metric-observer-0.8.4
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-flat-run-fields-updater-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5066,7 +5053,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: metric-observer-0.8.3
+        helm.sh/chart: metric-observer-0.8.4
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5302,14 +5289,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5321,7 +5306,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5776,13 +5761,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5793,7 +5777,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5949,13 +5933,45 @@ spec:
           sizeLimit: '20Gi'
         name: cache
 ---
+# Source: operator-wandb/charts/api/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: api-0.8.4
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: chartsnap-api
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+---
 # Source: operator-wandb/charts/metric-observer/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.3
+    helm.sh/chart: metric-observer-0.8.4
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6253,7 +6269,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6266,7 +6282,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6513,7 +6529,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -5933,38 +5933,6 @@ spec:
           sizeLimit: '20Gi'
         name: cache
 ---
-# Source: operator-wandb/charts/api/templates/hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: api-0.8.4
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: chartsnap-api
-  minReplicas: 2
-  maxReplicas: 3
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 80
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
----
 # Source: operator-wandb/charts/metric-observer/templates/hpa.yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -63,7 +63,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -84,7 +84,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -147,7 +147,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.3
+    helm.sh/chart: flat-run-fields-updater-0.8.4
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -168,7 +168,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -189,7 +189,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -210,7 +210,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -231,7 +231,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -244,7 +244,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -270,7 +270,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -297,7 +297,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.3
+    helm.sh/chart: flat-run-fields-updater-0.8.4
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -310,7 +310,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -336,7 +336,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -394,7 +394,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1379,7 +1379,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1411,7 +1411,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1453,7 +1453,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1466,7 +1466,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1660,7 +1660,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1793,7 +1793,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1948,7 +1948,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2011,7 +2011,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2039,7 +2039,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2067,7 +2067,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2155,7 +2155,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2175,7 +2175,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2195,7 +2195,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2239,7 +2239,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2261,7 +2261,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2317,7 +2317,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2471,7 +2471,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2629,7 +2629,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2791,14 +2791,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2809,7 +2807,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3395,14 +3393,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3413,7 +3409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3889,13 +3885,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3906,7 +3901,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4001,14 +3996,12 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.3
+    helm.sh/chart: flat-run-fields-updater-0.8.4
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-flat-run-fields-updater-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4019,7 +4012,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.8.3
+        helm.sh/chart: flat-run-fields-updater-0.8.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4238,14 +4231,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4256,7 +4247,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4793,14 +4784,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4812,7 +4801,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5255,13 +5244,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5272,7 +5260,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5976,7 +5964,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5989,7 +5977,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6224,7 +6212,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.3
+    helm.sh/chart: filemeta-0.8.4
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.3
+    helm.sh/chart: filemeta-0.8.4
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -316,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1234,7 +1234,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1266,7 +1266,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1308,7 +1308,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1321,7 +1321,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1515,7 +1515,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1648,7 +1648,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1803,7 +1803,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1866,7 +1866,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1894,7 +1894,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1922,7 +1922,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2010,7 +2010,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2030,7 +2030,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2050,7 +2050,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2094,7 +2094,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2116,7 +2116,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2146,7 +2146,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2232,7 +2232,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2390,7 +2390,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2552,14 +2552,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2570,7 +2568,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3126,14 +3124,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3144,7 +3140,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3604,13 +3600,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3621,7 +3616,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3706,14 +3701,12 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.3
+    helm.sh/chart: filemeta-0.8.4
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3724,7 +3717,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.8.3
+        helm.sh/chart: filemeta-0.8.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3900,14 +3893,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3918,7 +3909,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4425,14 +4416,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4444,7 +4433,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4877,13 +4866,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4894,7 +4882,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5278,7 +5266,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5291,7 +5279,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5516,7 +5504,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1200,7 +1200,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1232,7 +1232,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1274,7 +1274,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1287,7 +1287,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1481,7 +1481,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1614,7 +1614,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1769,7 +1769,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1832,7 +1832,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1860,7 +1860,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1888,7 +1888,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1976,7 +1976,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1996,7 +1996,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2016,7 +2016,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2060,7 +2060,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2082,7 +2082,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2112,7 +2112,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2198,7 +2198,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2356,7 +2356,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,14 +2518,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2536,7 +2534,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3092,14 +3090,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3110,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3566,13 +3562,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3583,7 +3578,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3668,14 +3663,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3686,7 +3679,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4193,14 +4186,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4212,7 +4203,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4645,13 +4636,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4662,7 +4652,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5046,7 +5036,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5059,7 +5049,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5284,7 +5274,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1200,7 +1200,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1232,7 +1232,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1274,7 +1274,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1287,7 +1287,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1481,7 +1481,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1614,7 +1614,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1769,7 +1769,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1832,7 +1832,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1860,7 +1860,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1888,7 +1888,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1976,7 +1976,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1996,7 +1996,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2016,7 +2016,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2060,7 +2060,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2082,7 +2082,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2112,7 +2112,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2198,7 +2198,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2356,7 +2356,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,14 +2518,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2536,7 +2534,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3092,14 +3090,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3110,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3566,13 +3562,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3583,7 +3578,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3668,14 +3663,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3686,7 +3679,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4193,14 +4186,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4212,7 +4203,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4645,13 +4636,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4662,7 +4652,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5048,7 +5038,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5061,7 +5051,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5286,7 +5276,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1168,7 +1168,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1200,7 +1200,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1242,7 +1242,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1255,7 +1255,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1449,7 +1449,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1582,7 +1582,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1737,7 +1737,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1800,7 +1800,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1828,7 +1828,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1856,7 +1856,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1944,7 +1944,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1964,7 +1964,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1984,7 +1984,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2028,7 +2028,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2050,7 +2050,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2080,7 +2080,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2166,7 +2166,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2324,7 +2324,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2486,14 +2486,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2504,7 +2502,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3060,14 +3058,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3078,7 +3074,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3534,13 +3530,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3551,7 +3546,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3636,14 +3631,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3654,7 +3647,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4161,14 +4154,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4180,7 +4171,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4613,13 +4604,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4630,7 +4620,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5014,7 +5004,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5027,7 +5017,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -5252,7 +5242,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -128,7 +128,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +149,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -218,7 +218,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -260,7 +260,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -281,7 +281,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -302,7 +302,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.3
+    helm.sh/chart: weave-trace-worker-0.8.4
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -365,7 +365,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -378,7 +378,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -419,7 +419,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -446,7 +446,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -472,7 +472,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -530,7 +530,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.3
+    helm.sh/chart: weave-trace-worker-0.8.4
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -543,7 +543,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -556,7 +556,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1635,7 +1635,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1667,7 +1667,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1709,7 +1709,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1722,7 +1722,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1916,7 +1916,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2049,7 +2049,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2204,7 +2204,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2282,7 +2282,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2310,7 +2310,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2338,7 +2338,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2426,7 +2426,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2446,7 +2446,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2466,7 +2466,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2510,7 +2510,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2532,7 +2532,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2749,7 +2749,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2903,7 +2903,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3061,7 +3061,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3083,7 +3083,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3249,14 +3249,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3267,7 +3265,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3823,14 +3821,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3841,7 +3837,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4297,13 +4293,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4314,7 +4309,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4399,14 +4394,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4417,7 +4410,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4924,14 +4917,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4943,7 +4934,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5376,14 +5367,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.3
+    helm.sh/chart: weave-trace-worker-0.8.4
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-clickhouse-configmap,chartsnap-weave-trace-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5394,7 +5383,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.8.3
+        helm.sh/chart: weave-trace-worker-0.8.4
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5478,14 +5467,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-clickhouse-configmap,chartsnap-global-configmap,chartsnap-weave-trace-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5496,7 +5483,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.8.3
+        helm.sh/chart: weave-trace-0.8.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5642,13 +5629,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5659,7 +5645,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6694,7 +6680,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6707,7 +6693,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -7006,7 +6992,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7034,7 +7020,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -98,7 +98,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -119,7 +119,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -188,7 +188,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -209,7 +209,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -230,7 +230,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -251,7 +251,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -272,7 +272,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -293,7 +293,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -306,7 +306,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -334,7 +334,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -347,7 +347,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -373,7 +373,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -431,7 +431,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -444,7 +444,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1456,7 +1456,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1488,7 +1488,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1530,7 +1530,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1543,7 +1543,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1737,7 +1737,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1870,7 +1870,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2025,7 +2025,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2103,7 +2103,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2131,7 +2131,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2159,7 +2159,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2247,7 +2247,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2267,7 +2267,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2287,7 +2287,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2331,7 +2331,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2353,7 +2353,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2544,7 +2544,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2630,7 +2630,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2788,7 +2788,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2810,7 +2810,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2972,14 +2972,12 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.3
+    helm.sh/chart: api-0.8.4
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -2990,7 +2988,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.8.3
+        helm.sh/chart: api-0.8.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3546,14 +3544,12 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.3
+    helm.sh/chart: app-0.8.4
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-api-configmap,chartsnap-app-configmap,chartsnap-bucket-configmap,chartsnap-frontend-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-local-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret,chartsnap-gorilla-session-key
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -3564,7 +3560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.8.3
+        helm.sh/chart: app-0.8.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4020,13 +4016,12 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.3
+    helm.sh/chart: console-0.8.4
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-console-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4037,7 +4032,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.8.3
+        helm.sh/chart: console-0.8.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4122,14 +4117,12 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.3
+    helm.sh/chart: glue-0.8.4
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-glue-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4140,7 +4133,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.8.3
+        helm.sh/chart: glue-0.8.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4647,14 +4640,12 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-bucket-configmap,chartsnap-global-configmap,chartsnap-kafka-configmap,chartsnap-mysql-configmap,chartsnap-parquet-configmap,chartsnap-redis-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -4666,7 +4657,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.8.3
+        helm.sh/chart: parquet-0.8.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5099,14 +5090,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.3
+    helm.sh/chart: weave-trace-0.8.4
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-clickhouse-configmap,chartsnap-global-configmap,chartsnap-weave-trace-configmap
-    secret.reloader.stakater.com/reload: chartsnap-global-secret
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5117,7 +5106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.8.3
+        helm.sh/chart: weave-trace-0.8.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5263,13 +5252,12 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.3
+    helm.sh/chart: weave-0.8.4
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    configmap.reloader.stakater.com/reload: chartsnap-weave-configmap
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -5280,7 +5268,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.8.3
+        helm.sh/chart: weave-0.8.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6011,7 +5999,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.3
+    helm.sh/chart: parquet-0.8.4
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6024,7 +6012,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.8.3
+            helm.sh/chart: parquet-0.8.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -6323,7 +6311,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6351,7 +6339,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.33.10
+    helm.sh/chart: operator-wandb-0.33.11
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/fmb.yaml
+++ b/test-configs/operator-wandb/fmb.yaml
@@ -65,10 +65,6 @@ metric-observer:
   install: true
   pubSub:
     subscription: "metric-observer"
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "128Mi"
 
 ingress:
   install: false


### PR DESCRIPTION
- Lookup desiredReplicas from the HPA if present and use that value for replicas if it is not 0
- Remove specific reloader annotations and just set auto
- Change merge type for HPA vars as merge doesn't respect false overriding true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Replicas now always set from a computed value and will auto-sync with HPA when autoscaling is enabled.
  - Annotations render when custom annotations are present; reloader annotation is only added when explicitly enabled.

- Refactor
  - Sizing merge behavior changed to prefer user-provided sizing values over defaults.

- Chores
  - Bumped operator-wandb chart to 0.33.11 and wandb-base chart to 0.8.4.

- Tests
  - Removed explicit resource requests for metric-observer in test config (now uses defaults).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->