### PR TITLE
chore: Snapshots ignore chart versions

### DIFF
--- a/test-configs/operator-wandb/.chartsnap.yaml
+++ b/test-configs/operator-wandb/.chartsnap.yaml
@@ -1,4 +1,7 @@
 dynamicFields:
+  - jsonPath:
+    - /metadata/labels/helm.sh~1chart
+    value: '###CHART_VERSION###'
   - apiVersion: v1
     kind: Secret
     name: chartsnap-gorilla-session-key

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,6 +239,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -248,7 +249,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -361,7 +362,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -387,7 +388,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -638,7 +639,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -975,7 +976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1008,7 +1009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1116,7 +1117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1140,7 +1141,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1183,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1217,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1258,7 +1259,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1271,7 +1272,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1465,7 +1466,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1558,7 +1559,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1580,7 +1581,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1598,7 +1599,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1661,7 +1662,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1712,7 +1713,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1753,7 +1754,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1773,7 +1774,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1797,7 +1798,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1816,7 +1817,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1851,6 +1852,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1904,7 +1906,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1931,6 +1933,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1948,7 +1951,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1970,7 +1973,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2003,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2021,7 +2024,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2047,7 +2050,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2086,7 +2089,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2110,7 +2113,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2164,7 +2167,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2199,7 +2202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2222,7 +2225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2244,7 +2247,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2265,7 +2268,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2406,7 +2409,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2510,7 +2513,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2982,7 +2985,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3083,7 +3086,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3344,7 +3347,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3455,6 +3458,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3533,7 +3537,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3667,7 +3671,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3776,7 +3780,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -3933,7 +3937,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4171,7 +4175,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,6 +239,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -248,7 +249,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -361,7 +362,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -387,7 +388,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -638,7 +639,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -975,7 +976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1008,7 +1009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1116,7 +1117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1140,7 +1141,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1183,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1217,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1258,7 +1259,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1271,7 +1272,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1465,7 +1466,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1558,7 +1559,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1580,7 +1581,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1598,7 +1599,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1661,7 +1662,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1712,7 +1713,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1753,7 +1754,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1773,7 +1774,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1797,7 +1798,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1816,7 +1817,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1851,6 +1852,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1904,7 +1906,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1931,6 +1933,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1948,7 +1951,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1970,7 +1973,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2003,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2021,7 +2024,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2047,7 +2050,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2086,7 +2089,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2110,7 +2113,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2164,7 +2167,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2199,7 +2202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2222,7 +2225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2244,7 +2247,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2265,7 +2268,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2406,7 +2409,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2510,7 +2513,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2982,7 +2985,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3083,7 +3086,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3344,7 +3347,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3455,6 +3458,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3533,7 +3537,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3667,7 +3671,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3776,7 +3780,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -3933,7 +3937,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4171,7 +4175,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -258,7 +258,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -273,6 +273,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -282,7 +283,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -395,7 +396,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -421,7 +422,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -672,7 +673,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1009,7 +1010,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1042,7 +1043,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1150,7 +1151,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1174,7 +1175,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1217,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1250,7 +1251,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1292,7 +1293,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1305,7 +1306,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1499,7 +1500,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1592,7 +1593,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1614,7 +1615,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1632,7 +1633,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1695,7 +1696,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1746,7 +1747,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1787,7 +1788,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1807,7 +1808,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1831,7 +1832,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1850,7 +1851,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1885,6 +1886,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1938,7 +1940,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1965,6 +1967,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1982,7 +1985,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2004,7 +2007,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2034,7 +2037,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2055,7 +2058,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2081,7 +2084,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2120,7 +2123,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2144,7 +2147,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2168,7 +2171,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2198,7 +2201,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2233,7 +2236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2256,7 +2259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2278,7 +2281,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2299,7 +2302,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2440,7 +2443,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2544,7 +2547,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3016,7 +3019,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3117,7 +3120,7 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: executor-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3352,7 +3355,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3613,7 +3616,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3724,6 +3727,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3802,7 +3806,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3936,7 +3940,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -4045,7 +4049,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4202,7 +4206,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4440,7 +4444,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -222,7 +222,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -256,7 +256,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -269,7 +269,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -295,7 +295,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -321,7 +321,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -334,7 +334,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -347,7 +347,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -360,7 +360,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -376,7 +376,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -394,7 +394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -409,6 +409,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -418,7 +419,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -531,7 +532,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -557,7 +558,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -808,7 +809,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1145,7 +1146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1178,7 +1179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1286,7 +1287,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1310,7 +1311,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1352,7 +1353,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1386,7 +1387,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1428,7 +1429,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1441,7 +1442,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1635,7 +1636,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1728,7 +1729,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1750,7 +1751,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1768,7 +1769,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1831,7 +1832,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1882,7 +1883,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1923,7 +1924,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1943,7 +1944,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1967,7 +1968,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1986,7 +1987,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2014,7 +2015,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2042,7 +2043,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2070,7 +2071,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,6 +2103,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2155,7 +2157,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2175,7 +2177,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2195,7 +2197,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2215,7 +2217,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2242,6 +2244,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2259,7 +2262,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2281,7 +2284,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2303,7 +2306,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2333,7 +2336,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2354,7 +2357,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2380,7 +2383,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2419,7 +2422,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2443,7 +2446,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2467,7 +2470,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2497,7 +2500,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2532,7 +2535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2555,7 +2558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2577,7 +2580,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2598,7 +2601,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2739,7 +2742,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2865,7 +2868,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3503,7 +3506,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4019,7 +4022,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4142,7 +4145,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: filestream-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4401,7 +4404,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4648,7 +4651,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5273,7 +5276,7 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5537,7 +5540,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5820,7 +5823,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5931,6 +5934,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -6009,7 +6013,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6187,7 +6191,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6219,7 +6223,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6328,7 +6332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6485,7 +6489,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6745,7 +6749,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   podSelector:
@@ -41,7 +41,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -63,7 +63,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -84,7 +84,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -126,7 +126,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -152,7 +152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   minAvailable: 51%
@@ -168,7 +168,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -189,7 +189,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -210,7 +210,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -231,7 +231,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -252,7 +252,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -278,7 +278,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -292,7 +292,7 @@ metadata:
   name: bufstream-service-account
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -304,7 +304,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/flat-run-fields-updater/templates/serviceaccount.yaml
 apiVersion: v1
@@ -331,7 +331,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -357,7 +357,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -370,7 +370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -419,6 +419,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -428,7 +429,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -542,7 +543,7 @@ metadata:
   name: bufstream-config
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -608,7 +609,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -634,7 +635,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -885,7 +886,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1222,7 +1223,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1255,7 +1256,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1363,7 +1364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1387,7 +1388,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1429,7 +1430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1463,7 +1464,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1505,7 +1506,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1518,7 +1519,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1712,7 +1713,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1805,7 +1806,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1827,7 +1828,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1845,7 +1846,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1908,7 +1909,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1959,7 +1960,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2000,7 +2001,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2020,7 +2021,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2044,7 +2045,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2063,7 +2064,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2091,7 +2092,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2119,7 +2120,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2154,6 +2155,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2207,7 +2209,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2227,7 +2229,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2247,7 +2249,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2274,6 +2276,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2291,7 +2294,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2313,7 +2316,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2335,7 +2338,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2366,7 +2369,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -2391,7 +2394,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2417,7 +2420,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -2451,7 +2454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   type: ClusterIP
@@ -2480,7 +2483,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2506,7 +2509,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2545,7 +2548,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2569,7 +2572,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2593,7 +2596,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2623,7 +2626,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2658,7 +2661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2681,7 +2684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2703,7 +2706,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2724,7 +2727,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2865,7 +2868,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2979,7 +2982,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3581,7 +3584,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4073,7 +4076,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4184,7 +4187,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4419,7 +4422,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5008,7 +5011,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5279,7 +5282,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5390,6 +5393,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5468,7 +5472,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5623,7 +5627,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -5753,7 +5757,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   replicas: 3
@@ -5922,7 +5926,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6031,7 +6035,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6188,7 +6192,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6436,7 +6440,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -214,7 +214,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -227,7 +227,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -266,7 +266,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -279,7 +279,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -292,7 +292,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -326,7 +326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -341,6 +341,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -350,7 +351,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -463,7 +464,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -489,7 +490,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -740,7 +741,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1077,7 +1078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1110,7 +1111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1218,7 +1219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1242,7 +1243,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1284,7 +1285,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1318,7 +1319,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1360,7 +1361,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1373,7 +1374,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1567,7 +1568,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1660,7 +1661,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1682,7 +1683,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1700,7 +1701,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1763,7 +1764,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1814,7 +1815,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1855,7 +1856,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1875,7 +1876,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1899,7 +1900,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1918,7 +1919,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1946,7 +1947,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1974,7 +1975,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2009,6 +2010,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2062,7 +2064,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2082,7 +2084,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,7 +2104,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2129,6 +2131,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2146,7 +2149,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2168,7 +2171,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2190,7 +2193,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2220,7 +2223,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2241,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2267,7 +2270,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2306,7 +2309,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2330,7 +2333,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2354,7 +2357,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2384,7 +2387,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2419,7 +2422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2442,7 +2445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2464,7 +2467,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2485,7 +2488,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2626,7 +2629,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2730,7 +2733,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3302,7 +3305,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3778,7 +3781,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3879,7 +3882,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4071,7 +4074,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4630,7 +4633,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4891,7 +4894,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5002,6 +5005,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5080,7 +5084,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5214,7 +5218,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5323,7 +5327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5480,7 +5484,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5718,7 +5722,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,6 +307,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -316,7 +317,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -429,7 +430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -455,7 +456,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -706,7 +707,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1043,7 +1044,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1076,7 +1077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1184,7 +1185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1208,7 +1209,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1250,7 +1251,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1284,7 +1285,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1326,7 +1327,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1339,7 +1340,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1533,7 +1534,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1626,7 +1627,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1648,7 +1649,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1666,7 +1667,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1729,7 +1730,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1780,7 +1781,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1821,7 +1822,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1842,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1865,7 +1866,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1884,7 +1885,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1912,7 +1913,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1940,7 +1941,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1975,6 +1976,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2028,7 +2030,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2048,7 +2050,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2068,7 +2070,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2095,6 +2097,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2112,7 +2115,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2156,7 +2159,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2186,7 +2189,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2207,7 +2210,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2233,7 +2236,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2272,7 +2275,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2296,7 +2299,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2320,7 +2323,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2350,7 +2353,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2385,7 +2388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2408,7 +2411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2430,7 +2433,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2451,7 +2454,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2592,7 +2595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2696,7 +2699,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3268,7 +3271,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3740,7 +3743,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3841,7 +3844,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4400,7 +4403,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4661,7 +4664,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4772,6 +4775,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4850,7 +4854,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4984,7 +4988,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5093,7 +5097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5250,7 +5254,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5488,7 +5492,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,6 +307,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -316,7 +317,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -429,7 +430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -455,7 +456,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -706,7 +707,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1043,7 +1044,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1076,7 +1077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1184,7 +1185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1208,7 +1209,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1250,7 +1251,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1284,7 +1285,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1326,7 +1327,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1339,7 +1340,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1533,7 +1534,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1626,7 +1627,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1648,7 +1649,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1666,7 +1667,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1729,7 +1730,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1780,7 +1781,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1821,7 +1822,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1842,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1865,7 +1866,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1884,7 +1885,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1912,7 +1913,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1940,7 +1941,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1975,6 +1976,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2028,7 +2030,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2048,7 +2050,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2068,7 +2070,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2095,6 +2097,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2112,7 +2115,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2156,7 +2159,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2186,7 +2189,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2207,7 +2210,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2233,7 +2236,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2272,7 +2275,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2296,7 +2299,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2320,7 +2323,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2350,7 +2353,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2385,7 +2388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2408,7 +2411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2430,7 +2433,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2451,7 +2454,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2592,7 +2595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2696,7 +2699,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3268,7 +3271,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3740,7 +3743,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3841,7 +3844,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4400,7 +4403,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4661,7 +4664,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4772,6 +4775,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4850,7 +4854,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4984,7 +4988,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5095,7 +5099,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5252,7 +5256,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5490,7 +5494,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,6 +307,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -316,7 +317,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -397,7 +398,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -423,7 +424,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -674,7 +675,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1011,7 +1012,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1044,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1152,7 +1153,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1176,7 +1177,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1218,7 +1219,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1252,7 +1253,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1294,7 +1295,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1307,7 +1308,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1501,7 +1502,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1594,7 +1595,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1616,7 +1617,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1634,7 +1635,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1697,7 +1698,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1748,7 +1749,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1789,7 +1790,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1809,7 +1810,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1833,7 +1834,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1852,7 +1853,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1880,7 +1881,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1908,7 +1909,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1943,6 +1944,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1996,7 +1998,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2016,7 +2018,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2036,7 +2038,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,6 +2065,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2080,7 +2083,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,7 +2105,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2124,7 +2127,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2154,7 +2157,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2175,7 +2178,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2201,7 +2204,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2240,7 +2243,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2264,7 +2267,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2288,7 +2291,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2318,7 +2321,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2353,7 +2356,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2376,7 +2379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2398,7 +2401,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2419,7 +2422,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2560,7 +2563,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2664,7 +2667,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3236,7 +3239,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3708,7 +3711,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3809,7 +3812,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4368,7 +4371,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4629,7 +4632,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4740,6 +4743,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4818,7 +4822,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4952,7 +4956,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5061,7 +5065,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5218,7 +5222,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5456,7 +5460,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: keeper
 spec:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: clickhouse
 spec:
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   podSelector:
@@ -106,7 +106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -128,7 +128,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +149,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -170,7 +170,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -196,7 +196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -239,7 +239,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   minAvailable: 51%
@@ -281,7 +281,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -302,7 +302,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -365,7 +365,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -399,7 +399,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -412,7 +412,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -426,7 +426,7 @@ metadata:
   name: bufstream-service-account
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -443,7 +443,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
 automountServiceAccountToken: false
 ---
@@ -453,7 +453,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/glue/templates/serviceaccount.yaml
 apiVersion: v1
@@ -480,7 +480,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -493,7 +493,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -506,7 +506,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -555,6 +555,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -564,7 +565,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -577,7 +578,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -590,7 +591,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -704,7 +705,7 @@ metadata:
   name: bufstream-config
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -775,7 +776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -830,7 +831,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -863,7 +864,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -889,7 +890,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1140,7 +1141,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1477,7 +1478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1510,7 +1511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1618,7 +1619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1642,7 +1643,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1685,7 +1686,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1719,7 +1720,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1761,7 +1762,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1774,7 +1775,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1968,7 +1969,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2061,7 +2062,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2083,7 +2084,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2101,7 +2102,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2164,7 +2165,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2215,7 +2216,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2256,7 +2257,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2276,7 +2277,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2300,7 +2301,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2334,7 +2335,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2362,7 +2363,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2390,7 +2391,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2425,6 +2426,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2478,7 +2480,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2498,7 +2500,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,7 +2520,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2545,6 +2547,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2562,7 +2565,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2584,7 +2587,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2606,7 +2609,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2637,7 +2640,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -2667,7 +2670,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2712,7 +2715,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2745,7 +2748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2779,7 +2782,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2823,7 +2826,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2849,7 +2852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -2883,7 +2886,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   type: ClusterIP
@@ -2912,7 +2915,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2938,7 +2941,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2977,7 +2980,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3001,7 +3004,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3025,7 +3028,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3055,7 +3058,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3090,7 +3093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -3113,7 +3116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -3135,7 +3138,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3157,7 +3160,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3178,7 +3181,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3323,7 +3326,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3427,7 +3430,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3999,7 +4002,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4471,7 +4474,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4572,7 +4575,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5131,7 +5134,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5392,7 +5395,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5503,6 +5506,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5581,7 +5585,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: weave-trace-worker-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5681,7 +5685,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5843,7 +5847,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5978,7 +5982,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -6108,7 +6112,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -6270,7 +6274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -6455,7 +6459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   replicas: 3
@@ -6624,7 +6628,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6737,7 +6741,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6894,7 +6898,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -7133,6 +7137,8 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave
@@ -7206,7 +7212,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7234,7 +7240,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: keeper
 spec:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: clickhouse
 spec:
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -98,7 +98,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -119,7 +119,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -140,7 +140,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -166,7 +166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -209,7 +209,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -230,7 +230,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -251,7 +251,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -272,7 +272,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -293,7 +293,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -314,7 +314,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -327,7 +327,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -340,7 +340,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -358,7 +358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
 automountServiceAccountToken: false
 ---
@@ -368,7 +368,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -381,7 +381,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -394,7 +394,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -407,7 +407,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -456,6 +456,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -465,7 +466,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -478,7 +479,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -596,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -651,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -684,7 +685,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -710,7 +711,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -961,7 +962,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1298,7 +1299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1331,7 +1332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1439,7 +1440,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1463,7 +1464,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1506,7 +1507,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1540,7 +1541,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1582,7 +1583,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1596,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1789,7 +1790,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1882,7 +1883,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1904,7 +1905,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1922,7 +1923,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1985,7 +1986,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2036,7 +2037,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2077,7 +2078,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2097,7 +2098,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2121,7 +2122,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2155,7 +2156,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2183,7 +2184,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2211,7 +2212,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2246,6 +2247,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2299,7 +2301,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2319,7 +2321,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2339,7 +2341,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2366,6 +2368,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2383,7 +2386,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2405,7 +2408,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2427,7 +2430,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2462,7 +2465,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2507,7 +2510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2540,7 +2543,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2574,7 +2577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2618,7 +2621,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2639,7 +2642,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2665,7 +2668,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2704,7 +2707,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2728,7 +2731,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2752,7 +2755,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2782,7 +2785,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2817,7 +2820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2840,7 +2843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2862,7 +2865,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2884,7 +2887,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2905,7 +2908,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3046,7 +3049,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3150,7 +3153,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3722,7 +3725,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4194,7 +4197,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4295,7 +4298,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4854,7 +4857,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5115,7 +5118,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5226,6 +5229,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5304,7 +5308,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5466,7 +5470,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5605,7 +5609,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -5767,7 +5771,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -5947,7 +5951,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6056,7 +6060,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6213,7 +6217,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.8.6
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6452,6 +6456,8 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave
@@ -6525,7 +6531,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6553,7 +6559,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.34.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION
run `helm plugin update chartsnap` locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated snapshot configuration to include the Helm chart version label as a dynamic field, replacing it with a placeholder during tests. This reduces noise from version bumps, improves snapshot stability, and makes test results more reliable across releases. No user-facing behavior is changed.

* **Chores**
  * Maintained test config to better handle chart version updates in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->