### PR TITLE
fix: Default GOMAXPROCS to the container's cpu limits

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.34.2
+version: 0.34.3
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -145,6 +145,10 @@ Global values will override any chart-specific values.
   valueFrom:
     resourceFieldRef:
       resource: limits.memory
+- name: GOMAXPROCS
+  valueFrom:
+    resourceFieldRef:
+      resource: limits.cpu
 - name: POD_NAME
   valueFrom:
     fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -2571,6 +2571,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2806,6 +2810,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3149,6 +3157,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3998,6 +4010,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2571,6 +2571,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2806,6 +2810,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3149,6 +3157,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3998,6 +4010,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -2605,6 +2605,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2840,6 +2844,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3182,6 +3190,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3418,6 +3430,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4267,6 +4283,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -2920,6 +2920,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3138,6 +3142,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3323,6 +3331,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3582,6 +3594,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3839,6 +3855,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4225,6 +4245,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4484,6 +4508,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4731,6 +4759,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4934,6 +4966,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5111,6 +5147,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5356,6 +5396,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5621,6 +5665,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -6568,6 +6616,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3034,6 +3034,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3240,6 +3244,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3413,6 +3421,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3660,6 +3672,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3905,6 +3921,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4267,6 +4287,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4502,6 +4526,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4693,6 +4721,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4858,6 +4890,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5092,6 +5128,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -6271,6 +6311,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -2785,6 +2785,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2981,6 +2985,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3144,6 +3152,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3381,6 +3393,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3618,6 +3634,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3958,6 +3978,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4154,6 +4178,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4335,6 +4363,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4490,6 +4522,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4714,6 +4750,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5563,6 +5603,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -2751,6 +2751,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2947,6 +2951,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3110,6 +3118,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3347,6 +3359,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3582,6 +3598,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3924,6 +3944,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4105,6 +4129,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4260,6 +4288,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4484,6 +4516,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5333,6 +5369,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -2751,6 +2751,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2947,6 +2951,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3110,6 +3118,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3347,6 +3359,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3582,6 +3598,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3924,6 +3944,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4105,6 +4129,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4260,6 +4288,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4484,6 +4516,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5335,6 +5371,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -2719,6 +2719,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2915,6 +2919,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3078,6 +3086,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3315,6 +3327,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3550,6 +3566,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3892,6 +3912,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4073,6 +4097,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4228,6 +4256,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4452,6 +4484,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5301,6 +5337,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3482,6 +3482,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3678,6 +3682,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3841,6 +3849,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4078,6 +4090,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4313,6 +4329,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4655,6 +4675,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4836,6 +4860,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4991,6 +5019,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -5215,6 +5247,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -6977,6 +7013,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3205,6 +3205,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3401,6 +3405,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3564,6 +3572,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3801,6 +3813,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4036,6 +4052,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4378,6 +4398,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4559,6 +4583,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4714,6 +4742,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -4938,6 +4970,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -6296,6 +6332,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatically tunes runtime concurrency to the container’s CPU limits, improving performance and resource efficiency out of the box.

* Chores
  * Bumped Helm chart version to 0.34.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->