### PR TITLE
chore(dev): Get statsig key from secret store

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.34.7
+version: 0.34.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -97,12 +97,14 @@ Global values will override any chart-specific values.
 {{- end -}}
 
 {{- define "wandb.statsigEnvs" -}}
+{{- if eq .Values.global.statsig.apiKey "" }}
 - name: GORILLA_STATSIG_KEY
   valueFrom:
     secretKeyRef:
       name: "gorilla-statsig"
       key: "GORILLA_STATSIG_KEY"
       optional: true
+{{- end }}
 {{- end -}}
 
 {{- define "wandb.mysqlEnvs" -}}

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -97,11 +97,11 @@ Global values will override any chart-specific values.
 {{- end -}}
 
 {{- define "wandb.statsigEnvs" -}}
-- name: STATSIG_API_KEY
+- name: GORILLA_STATSIG_KEY
   valueFrom:
     secretKeyRef:
       name: "gorilla-statsig"
-      key: "STATSIG_API_KEY"
+      key: "GORILLA_STATSIG_KEY"
       optional: true
 {{- end -}}
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -96,6 +96,15 @@ Global values will override any chart-specific values.
       optional: true
 {{- end -}}
 
+{{- define "wandb.statsigEnvs" -}}
+- name: STATSIG_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: "gorilla-statsig"
+      key: "STATSIG_API_KEY"
+      optional: true
+{{- end -}}
+
 {{- define "wandb.mysqlEnvs" -}}
 - name: MYSQL_PASSWORD
   valueFrom:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -311,6 +311,7 @@ api:
     - '{{ include "wandb.redisEnvs" . }}'
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   initContainers:
@@ -485,6 +486,7 @@ app:
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   service:
     enabled: true
@@ -788,6 +790,7 @@ executor:
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   containers:
     executor:
@@ -887,6 +890,7 @@ filemeta:
     - '{{ include "wandb.mysqlEnvs" . }}'
     - '{{ include "wandb.redisEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   containers:
     filemeta:
@@ -1045,6 +1049,7 @@ filestream:
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   env:
     GORILLA_FILE_STREAM_WORKER_SOURCE_ADDRESS:
@@ -1357,6 +1362,7 @@ glue:
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   initContainers:
     init-db:
@@ -1489,6 +1495,7 @@ metric-observer:
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   containers:
     metric-observer:
@@ -1575,6 +1582,7 @@ parquet:
     - '{{ include "wandb.queueEnvs" . }}'
     - '{{ include "wandb.historyStoreEnvs" . }}'
     - '{{ include "wandb.observabilityEnvs" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.license" . }}'
   podAnnotationsTpls:
     - '{{ include "wandb.gcsFuseAnnotations" . }}'
@@ -1734,6 +1742,7 @@ settingsMigrationJob:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
   envTpls:
     - '{{ include "wandb.bucket.cwIdentity" . }}'
+    - '{{ include "wandb.statsigEnvs" . }}'
     - '{{ include "wandb.bucketEnvs" . }}'
   kind: Job
   jobs:

--- a/snapshots.sh
+++ b/snapshots.sh
@@ -32,7 +32,6 @@ EOF
 function main() {
   local chart="operator-wandb"
   local values_dir="test-configs"
-  local chart_dir="charts/$chart"
 
   if [ $# -eq 0 ]; then
     usage

--- a/snapshots.sh
+++ b/snapshots.sh
@@ -16,9 +16,28 @@ if ! helm plugin list | grep -q "cascade"; then
   exit 1
 fi
 
+function usage() {
+  cat <<EOF
+A helper script for the helm-chartsnap plugin https://github.com/jlandowner/helm-chartsnap
+
+Usage: $0 [COMMAND]
+
+Commands:
+  build,    build the operator-wandb chart
+  update,   execute chartsnap to update the snapshots
+  run,      executes chartsnap to test helm changes
+EOF
+}
+
 function main() {
   local chart="operator-wandb"
   local values_dir="test-configs"
+  local chart_dir="charts/$chart"
+
+  if [ $# -eq 0 ]; then
+    usage
+    exit 1
+  fi
 
   local func="$1"
   case "$func" in
@@ -35,16 +54,8 @@ function main() {
       helm chartsnap -c "./charts/$chart" -f "./$values_dir/$chart"
       ;;
     *)
-      cat <<EOF
-A helper script for the helm-chartsnap plugin https://github.com/jlandowner/helm-chartsnap
-
-Usage: $0 [COMMAND]
-
-Commands:
-  build,    build the operator-wandb chart
-  update,   execute chartsnap to update the snapshots
-  run,      executes chartsnap to test helm changes
-EOF
+      usage
+      exit 1
       ;;
   esac
 }

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -2686,6 +2686,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -2925,6 +2931,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3284,6 +3296,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,7 +239,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -249,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -362,7 +361,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -388,7 +387,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -639,7 +638,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -976,7 +975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1009,7 +1008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1117,7 +1116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1141,7 +1140,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1183,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1217,7 +1216,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1259,7 +1258,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1272,7 +1271,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1466,7 +1465,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1559,7 +1558,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1581,7 +1580,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1599,7 +1598,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1662,7 +1661,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1713,7 +1712,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1754,7 +1753,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1774,7 +1773,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1798,7 +1797,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1817,7 +1816,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1852,7 +1851,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1906,7 +1904,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1933,7 +1931,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1951,7 +1948,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1973,7 +1970,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2003,7 +2000,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2024,7 +2021,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2050,7 +2047,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2089,7 +2086,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2113,7 +2110,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2137,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2167,7 +2164,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2202,7 +2199,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2225,7 +2222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2247,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2268,7 +2265,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2409,7 +2406,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,7 +2515,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2686,10 +2683,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -2931,10 +2928,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3027,7 +3024,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3133,7 +3130,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3296,10 +3293,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3409,7 +3406,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3520,7 +3517,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3599,7 +3595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3738,7 +3734,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3847,7 +3843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4004,7 +4000,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4021,7 +4017,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4041,8 +4037,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4098,7 +4092,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4124,7 +4118,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4148,7 +4142,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4172,7 +4166,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4196,7 +4190,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4224,7 +4218,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4308,7 +4302,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,6 +239,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -248,7 +249,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -361,7 +362,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -387,7 +388,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -638,7 +639,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -975,7 +976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1008,7 +1009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1116,7 +1117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1140,7 +1141,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1183,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1217,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1258,7 +1259,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1271,7 +1272,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1465,7 +1466,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1558,7 +1559,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1580,7 +1581,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1598,7 +1599,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1661,7 +1662,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1712,7 +1713,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1753,7 +1754,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1773,7 +1774,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1797,7 +1798,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1816,7 +1817,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1851,6 +1852,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1904,7 +1906,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1931,6 +1933,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1948,7 +1951,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1970,7 +1973,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2003,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2021,7 +2024,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2047,7 +2050,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2086,7 +2089,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2110,7 +2113,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2164,7 +2167,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2199,7 +2202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2222,7 +2225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2244,7 +2247,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2265,7 +2268,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2406,7 +2409,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2515,7 +2518,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3024,7 +3027,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3130,7 +3133,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3406,7 +3409,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3517,6 +3520,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3595,7 +3599,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3734,7 +3738,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3843,7 +3847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4000,7 +4004,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4017,7 +4021,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4037,6 +4041,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4092,7 +4098,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4118,7 +4124,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4142,7 +4148,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4166,7 +4172,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4190,7 +4196,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4218,7 +4224,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4302,7 +4308,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -248,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1598,7 +1598,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1753,7 +1753,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1816,7 +1816,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1904,7 +1904,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1948,7 +1948,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1970,7 +1970,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2000,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2086,7 +2086,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2244,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2406,7 +2406,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2427,7 +2427,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2515,7 +2515,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2536,7 +2536,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3024,7 +3024,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3045,7 +3045,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3130,7 +3130,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3152,7 +3152,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3595,7 +3595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3616,7 +3616,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4000,7 +4000,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4017,7 +4017,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4092,7 +4092,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4118,7 +4118,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4142,7 +4142,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4166,7 +4166,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4218,7 +4218,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4231,7 +4231,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -4302,7 +4302,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4315,7 +4315,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2686,6 +2686,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -2925,6 +2931,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3284,6 +3296,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,7 +239,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -249,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -362,7 +361,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -388,7 +387,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -639,7 +638,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -976,7 +975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1009,7 +1008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1117,7 +1116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1141,7 +1140,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1183,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1217,7 +1216,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1259,7 +1258,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1272,7 +1271,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1466,7 +1465,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1559,7 +1558,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1581,7 +1580,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1599,7 +1598,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1662,7 +1661,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1713,7 +1712,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1754,7 +1753,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1774,7 +1773,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1798,7 +1797,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1817,7 +1816,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1852,7 +1851,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1906,7 +1904,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1933,7 +1931,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1951,7 +1948,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1973,7 +1970,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2003,7 +2000,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2024,7 +2021,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2050,7 +2047,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2089,7 +2086,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2113,7 +2110,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2137,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2167,7 +2164,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2202,7 +2199,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2225,7 +2222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2247,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2268,7 +2265,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2409,7 +2406,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,7 +2515,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2686,10 +2683,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -2931,10 +2928,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3027,7 +3024,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3133,7 +3130,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3296,10 +3293,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3409,7 +3406,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3520,7 +3517,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3599,7 +3595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3738,7 +3734,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3847,7 +3843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4004,7 +4000,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4021,7 +4017,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4041,8 +4037,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4098,7 +4092,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4124,7 +4118,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4148,7 +4142,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4172,7 +4166,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4196,7 +4190,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4224,7 +4218,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4308,7 +4302,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -57,7 +57,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -83,7 +83,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -107,7 +107,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -131,7 +131,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -155,7 +155,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -171,7 +171,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -189,7 +189,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -207,7 +207,7 @@ metadata:
   labels:
     global-common-label: "global-common-label-value"
     global-common-label: "global-common-label-value"
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -220,7 +220,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -239,7 +239,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -257,7 +257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -272,6 +272,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -281,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -298,6 +299,7 @@ metadata:
   name: chartsnap-bucket
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ACCESS_KEY: bWluaW8=
   SECRET_KEY: dGVzdHBhc3N3b3Jk
@@ -311,6 +313,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   CLICKHOUSE_PASSWORD: '###DYNAMIC_FIELD###'
 ---
@@ -321,6 +324,7 @@ metadata:
   name: chartsnap-global-secret
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   GORILLA_STATSIG_KEY:
   GORILLA_EMAIL_SINK: aHR0cHM6Ly9hcGkud2FuZGIuYWkvZW1haWwvZGlzcGF0Y2g=
@@ -336,6 +340,7 @@ metadata:
   name: chartsnap-kafka
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   KAFKA_CLIENT_PASSWORD:
 ---
@@ -348,6 +353,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   license: ""
 ---
@@ -360,6 +366,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   MYSQL_ROOT_PASSWORD: '###DYNAMIC_FIELD###'
   MYSQL_PASSWORD: '###DYNAMIC_FIELD###'
@@ -371,6 +378,7 @@ metadata:
   name: chartsnap-parquet-secret
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
@@ -380,6 +388,7 @@ metadata:
   name: "chartsnap-redis-secret"
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   REDIS_PASSWORD:
   REDIS_CA_CERT:
@@ -393,6 +402,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 type: Opaque
 data:
   # Retrieve the secret data using lookup function and when not exists, return an empty dictionary / map as result
@@ -407,7 +417,7 @@ metadata:
   name: chartsnap-mysql-initdb
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -435,7 +445,7 @@ metadata:
   labels:
     global-common-label: "global-common-label-value"
     global-common-label: "global-common-label-value"
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -686,7 +696,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1023,7 +1033,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1056,7 +1066,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1164,7 +1174,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1188,7 +1198,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1205,6 +1215,7 @@ metadata:
   name: chartsnap-api-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   GORILLA_PORT: "8081"
   GORILLA_FRONTEND_HOST: "http://localhost:8080"
@@ -1231,7 +1242,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1253,6 +1264,7 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   BUCKET_NAME: "minio.minio.svc.cluster.local:9000/bucket"
   BUCKET_PATH: ""
@@ -1266,7 +1278,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1280,6 +1292,7 @@ metadata:
   name: chartsnap-clickhouse-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   WF_CLICKHOUSE_PORT: "8443"
   WF_CLICKHOUSE_HOST: "chartsnap-clickhouse-headless"
@@ -1294,6 +1307,7 @@ metadata:
   name: chartsnap-console-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   # ex: AWS("arn:aws:iam::{acc_number}:role/{customer_namespace}-node")
   BUCKET_ACCESS_IDENTITY: "unknown"
@@ -1310,7 +1324,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1323,7 +1337,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1337,6 +1351,7 @@ metadata:
   name: chartsnap-flat-run-fields-updater-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   GORILLA_FILE_HOST: "http://localhost:8080"
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
@@ -1350,6 +1365,7 @@ metadata:
   name: chartsnap-frontend-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   PUBLIC_URL: "http://localhost:8080"
   REACT_APP_GIT_TAG: "HEAD"
@@ -1369,6 +1385,7 @@ metadata:
   name: chartsnap-frontend-patch-env-js
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   02_patch_env_js.sh: |
     #!/bin/bash
@@ -1453,6 +1470,7 @@ metadata:
   name: chartsnap-global-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   # Statsd configuration (matches existing GORILLA_STATSD_PORT from gorilla.yaml)
   GORILLA_STATSD_PORT: "8125"
@@ -1468,6 +1486,7 @@ metadata:
   name: chartsnap-glue-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   # Basic service configuration
   GORILLA_GLUE_CONTAINER_PORT: "8080"
@@ -1510,6 +1529,7 @@ metadata:
   name: chartsnap-kafka-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   KAFKA_BROKER_HOST: ""
   KAFKA_BROKER_PORT: "9092"
@@ -1523,7 +1543,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1540,6 +1560,7 @@ metadata:
   name: chartsnap-mysql-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   MYSQL_PORT: "3306"
   MYSQL_HOST: "chartsnap-mysql"
@@ -1553,6 +1574,7 @@ metadata:
   name: chartsnap-parquet-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   # Port configuration
   GORILLA_PARQUET_PORT: "8087"
@@ -1572,6 +1594,7 @@ metadata:
   name: chartsnap-redis-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   REDIS_PORT: "6379"
   REDIS_HOST: "chartsnap-redis-master"
@@ -1584,6 +1607,7 @@ metadata:
   name: chartsnap-weave-trace-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   PORT: "8080"
   API_PATH_PREFIX: "/traces"
@@ -1604,6 +1628,7 @@ metadata:
   name: chartsnap-weave-configmap
   labels:
     global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   GORILLA_ONPREM: "true"
   PORT: "9994"
@@ -1622,7 +1647,7 @@ metadata:
   name: chartsnap-mysql-data
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1644,7 +1669,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1662,7 +1687,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1730,7 +1755,7 @@ metadata:
   labels:
     global-common-label: "global-common-label-value"
     global-common-label: "global-common-label-value"
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1781,7 +1806,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1822,7 +1847,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1847,7 +1872,7 @@ metadata:
   labels:
     global-common-label: "global-common-label-value"
     global-common-label: "global-common-label-value"
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1871,7 +1896,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1890,7 +1915,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1930,6 +1955,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1983,7 +2009,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2015,6 +2041,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2032,7 +2059,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2057,7 +2084,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2092,7 +2119,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2117,7 +2144,7 @@ metadata:
   name: chartsnap-mysql
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2144,7 +2171,7 @@ metadata:
   name: chartsnap-otel-daemonset
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2184,7 +2211,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2211,7 +2238,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2236,7 +2263,7 @@ metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2268,7 +2295,7 @@ metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2304,7 +2331,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2327,7 +2354,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2349,7 +2376,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2375,7 +2402,7 @@ metadata:
   labels:
     global-common-label: "global-common-label-value"
     global-common-label: "global-common-label-value"
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2520,7 +2547,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2638,7 +2665,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3164,7 +3191,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3279,7 +3306,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3563,7 +3590,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3674,6 +3701,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3752,7 +3780,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3901,7 +3929,7 @@ metadata:
   name: chartsnap-mysql
   labels:
     global-common-label: "global-common-label-value"
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -4011,7 +4039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4168,7 +4196,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4187,7 +4215,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4209,6 +4237,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4264,7 +4294,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4292,7 +4322,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4318,7 +4348,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4344,7 +4374,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4370,7 +4400,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4398,7 +4428,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4489,7 +4519,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -33,11 +33,14 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   selector:
     matchExpressions:
@@ -54,11 +57,16 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    app-common-label: "app-common-label-value"
+    global-common-label: "global-common-label-value"
+  annotations:
+    app-common-annotation: app-common-annotation-value
+    global-common-annotation: global-common-annotation-value
 spec:
   selector:
     matchExpressions:
@@ -75,11 +83,14 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   selector:
     matchExpressions:
@@ -96,11 +107,14 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   selector:
     matchExpressions:
@@ -117,11 +131,14 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   selector:
     matchExpressions:
@@ -138,11 +155,14 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/app/templates/serviceaccount.yaml
@@ -151,11 +171,16 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    app-common-label: "app-common-label-value"
+    global-common-label: "global-common-label-value"
+  annotations:
+    app-common-annotation: app-common-annotation-value
+    global-common-annotation: global-common-annotation-value
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -164,11 +189,14 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/serviceaccount.yaml
@@ -192,11 +220,14 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
@@ -250,11 +281,14 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/templates/bucket.yaml
@@ -1628,11 +1662,14 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 rules:
 - apiGroups:
   - ""
@@ -1785,11 +1822,14 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 subjects:
 - kind: ServiceAccount
   name: chartsnap-console
@@ -1850,11 +1890,16 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    app-common-label: "app-common-label-value"
+    global-common-label: "global-common-label-value"
+  annotations:
+    app-common-annotation: app-common-annotation-value
+    global-common-annotation: global-common-annotation-value
 rules:
 - apiGroups:
   - ""
@@ -1938,11 +1983,16 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    app-common-label: "app-common-label-value"
+    global-common-label: "global-common-label-value"
+  annotations:
+    app-common-annotation: app-common-annotation-value
+    global-common-annotation: global-common-annotation-value
 subjects:
 - kind: ServiceAccount
   name: chartsnap-app
@@ -1982,11 +2032,14 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   type: ClusterIP
   ports:
@@ -2004,11 +2057,16 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    app-common-label: "app-common-label-value"
+    global-common-label: "global-common-label-value"
+  annotations:
+    app-common-annotation: app-common-annotation-value
+    global-common-annotation: global-common-annotation-value
 spec:
   type: ClusterIP
   ports:
@@ -2034,11 +2092,14 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   type: ClusterIP
   ports:
@@ -2123,11 +2184,14 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   type: ClusterIP
   ports:
@@ -2285,11 +2349,14 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+  annotations:
+    global-common-annotation: global-common-annotation-value
 spec:
   type: ClusterIP
   ports:
@@ -2453,13 +2520,16 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+    global-deployment-label: "global-deployment-label-value"
   annotations:
     reloader.stakater.com/auto: "true"
+    global-common-annotation: global-common-annotation-value
     global-deployment-annotation: global-deployment-annotation-value
 spec:
   replicas: 1
@@ -2474,12 +2544,17 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        global-pod-annotation: global-pod-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        global-common-label: "global-common-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: anaconda2
@@ -2563,13 +2638,19 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    app-common-label: "app-common-label-value"
+    global-common-label: "global-common-label-value"
+    app-deployment-label: "app-deployment-label-value"
+    global-deployment-label: "global-deployment-label-value"
   annotations:
     reloader.stakater.com/auto: "true"
+    app-common-annotation: app-common-annotation-value
+    global-common-annotation: global-common-annotation-value
     app-deployment-annotation: app-deployment-annotation-value
     global-deployment-annotation: global-deployment-annotation-value
 spec:
@@ -2585,12 +2666,21 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        app-pod-annotation: app-pod-annotation-value
+        global-pod-annotation: global-pod-annotation-value
+        app-common-annotation: app-common-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        app-common-label: "app-common-label-value"
+        global-common-label: "global-common-label-value"
+        app-pod-label: "app-pod-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: app
@@ -3074,13 +3164,16 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+    global-deployment-label: "global-deployment-label-value"
   annotations:
     reloader.stakater.com/auto: "true"
+    global-common-annotation: global-common-annotation-value
     global-deployment-annotation: global-deployment-annotation-value
 spec:
   replicas: 1
@@ -3095,12 +3188,17 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        global-pod-annotation: global-pod-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        global-common-label: "global-common-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: console
@@ -3181,13 +3279,16 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+    global-deployment-label: "global-deployment-label-value"
   annotations:
     reloader.stakater.com/auto: "true"
+    global-common-annotation: global-common-annotation-value
     global-deployment-annotation: global-deployment-annotation-value
 spec:
   replicas: 1
@@ -3204,12 +3305,15 @@ spec:
     metadata:
       annotations:
         global-pod-annotation: global-pod-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        global-common-label: "global-common-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: parquet
@@ -3648,13 +3752,16 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
+    global-deployment-label: "global-deployment-label-value"
   annotations:
     reloader.stakater.com/auto: "true"
+    global-common-annotation: global-common-annotation-value
     global-deployment-annotation: global-deployment-annotation-value
 spec:
   replicas: 1
@@ -3669,12 +3776,17 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        global-pod-annotation: global-pod-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        global-common-label: "global-common-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: weave
@@ -4056,12 +4168,14 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "post-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
@@ -4073,12 +4187,14 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
@@ -4148,12 +4264,14 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "post-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
@@ -4174,12 +4292,14 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
@@ -4198,12 +4318,14 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "post-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
@@ -4222,12 +4344,14 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
@@ -4274,24 +4398,31 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "post-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:
+      annotations:
+        global-pod-annotation: global-pod-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
         app.kubernetes.io/managed-by: Helm
+        global-common-label: "global-common-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: app-rename-post-hook
@@ -4358,24 +4489,31 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
     app.kubernetes.io/managed-by: Helm
+    global-common-label: "global-common-label-value"
   annotations:
+    global-common-annotation: global-common-annotation-value
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:
+      annotations:
+        global-pod-annotation: global-pod-annotation-value
+        global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
         app.kubernetes.io/managed-by: Helm
+        global-common-label: "global-common-label-value"
+        global-pod-label: "global-pod-label-value"
     spec:
       containers:
       - name: app-rename-pre-hook

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: executor-0.10.0
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: executor-0.10.0
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -258,7 +258,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -273,7 +273,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -283,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -396,7 +395,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -422,7 +421,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -673,7 +672,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1010,7 +1009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1043,7 +1042,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1151,7 +1150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1175,7 +1174,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1217,7 +1216,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1251,7 +1250,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1293,7 +1292,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1306,7 +1305,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1500,7 +1499,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1593,7 +1592,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1615,7 +1614,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1633,7 +1632,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1696,7 +1695,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1747,7 +1746,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1788,7 +1787,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1808,7 +1807,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1832,7 +1831,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1851,7 +1850,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1886,7 +1885,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1940,7 +1938,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1967,7 +1965,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1985,7 +1982,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2007,7 +2004,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2037,7 +2034,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2058,7 +2055,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2084,7 +2081,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2123,7 +2120,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2147,7 +2144,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2171,7 +2168,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2201,7 +2198,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2236,7 +2233,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2259,7 +2256,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2281,7 +2278,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2302,7 +2299,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2443,7 +2440,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2552,7 +2549,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2720,10 +2717,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -2965,10 +2962,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3061,7 +3058,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3167,7 +3164,7 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: executor-0.10.0
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3326,10 +3323,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3414,7 +3411,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3577,10 +3574,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3690,7 +3687,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3801,7 +3798,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3880,7 +3876,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4019,7 +4015,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -4128,7 +4124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4285,7 +4281,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4302,7 +4298,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4322,8 +4318,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4379,7 +4373,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4405,7 +4399,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4429,7 +4423,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4453,7 +4447,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4477,7 +4471,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4505,7 +4499,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4589,7 +4583,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -211,7 +211,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -258,7 +258,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -273,6 +273,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -282,7 +283,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -395,7 +396,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -421,7 +422,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -672,7 +673,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1009,7 +1010,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1042,7 +1043,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1150,7 +1151,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1174,7 +1175,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1217,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1250,7 +1251,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1292,7 +1293,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1305,7 +1306,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1499,7 +1500,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1592,7 +1593,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1614,7 +1615,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1632,7 +1633,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1695,7 +1696,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1746,7 +1747,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1787,7 +1788,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1807,7 +1808,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1831,7 +1832,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1850,7 +1851,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1885,6 +1886,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1938,7 +1940,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1965,6 +1967,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1982,7 +1985,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2004,7 +2007,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2034,7 +2037,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2055,7 +2058,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2081,7 +2084,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2120,7 +2123,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2144,7 +2147,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2168,7 +2171,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2198,7 +2201,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2233,7 +2236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2256,7 +2259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2278,7 +2281,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2299,7 +2302,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2440,7 +2443,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2549,7 +2552,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3058,7 +3061,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3164,7 +3167,7 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: executor-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3411,7 +3414,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3687,7 +3690,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3798,6 +3801,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3876,7 +3880,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4015,7 +4019,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -4124,7 +4128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4281,7 +4285,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4298,7 +4302,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4318,6 +4322,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4373,7 +4379,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4399,7 +4405,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4423,7 +4429,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4447,7 +4453,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4471,7 +4477,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4499,7 +4505,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4583,7 +4589,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -2720,6 +2720,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -2959,6 +2965,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3314,6 +3326,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3559,6 +3577,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.10.0
+    helm.sh/chart: executor-0.10.1
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -172,7 +172,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -185,7 +185,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -198,7 +198,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-executor
   labels:
-    helm.sh/chart: executor-0.10.0
+    helm.sh/chart: executor-0.10.1
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -224,7 +224,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1632,7 +1632,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1787,7 +1787,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1850,7 +1850,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1938,7 +1938,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1982,7 +1982,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2004,7 +2004,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2034,7 +2034,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2120,7 +2120,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2278,7 +2278,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2440,7 +2440,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2461,7 +2461,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2549,7 +2549,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2570,7 +2570,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3058,7 +3058,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3079,7 +3079,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3164,7 +3164,7 @@ kind: Deployment
 metadata:
   name: chartsnap-executor-bc
   labels:
-    helm.sh/chart: executor-0.10.0
+    helm.sh/chart: executor-0.10.1
     app.kubernetes.io/name: executor
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3182,7 +3182,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.10.0
+        helm.sh/chart: executor-0.10.1
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3411,7 +3411,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3433,7 +3433,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3876,7 +3876,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3897,7 +3897,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4281,7 +4281,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4298,7 +4298,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4373,7 +4373,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4399,7 +4399,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4423,7 +4423,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4447,7 +4447,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4499,7 +4499,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4512,7 +4512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -4583,7 +4583,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4596,7 +4596,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: filestream-0.10.0
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: flat-run-fields-updater-0.10.0
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: metric-observer-0.10.0
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -222,7 +222,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -256,7 +256,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -269,7 +269,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -295,7 +295,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: filestream-0.10.0
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: flat-run-fields-updater-0.10.0
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -321,7 +321,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -334,7 +334,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: metric-observer-0.10.0
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -347,7 +347,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -360,7 +360,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -376,7 +376,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -394,7 +394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -409,7 +409,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -419,7 +418,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -532,7 +531,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -558,7 +557,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -809,7 +808,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1146,7 +1145,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1179,7 +1178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1287,7 +1286,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1311,7 +1310,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1353,7 +1352,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1387,7 +1386,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1429,7 +1428,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1442,7 +1441,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1636,7 +1635,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1729,7 +1728,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1751,7 +1750,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1769,7 +1768,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1832,7 +1831,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1883,7 +1882,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1924,7 +1923,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1944,7 +1943,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1968,7 +1967,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1987,7 +1986,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2015,7 +2014,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2043,7 +2042,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2071,7 +2070,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: metric-observer-0.10.0
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2103,7 +2102,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2157,7 +2155,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2177,7 +2175,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2197,7 +2195,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2217,7 +2215,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: metric-observer-0.10.0
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2244,7 +2242,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2262,7 +2259,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2284,7 +2281,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2306,7 +2303,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2336,7 +2333,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2357,7 +2354,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2383,7 +2380,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2422,7 +2419,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2446,7 +2443,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2470,7 +2467,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2500,7 +2497,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2535,7 +2532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2558,7 +2555,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2580,7 +2577,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2601,7 +2598,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2742,7 +2739,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2873,7 +2870,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3037,10 +3034,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3265,10 +3262,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3460,10 +3457,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3564,7 +3561,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3732,10 +3729,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3999,10 +3996,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4117,7 +4114,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4245,7 +4242,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: filestream-0.10.0
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4407,10 +4404,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4519,7 +4516,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: flat-run-fields-updater-0.10.0
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4775,7 +4772,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4934,10 +4931,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5147,10 +5144,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5334,10 +5331,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5432,7 +5429,7 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: metric-observer-0.10.0
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5594,10 +5591,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5711,7 +5708,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5874,10 +5871,10 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -6009,7 +6006,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -6120,7 +6117,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -6199,7 +6195,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6382,7 +6378,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: metric-observer-0.10.0
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6414,7 +6410,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6523,7 +6519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6680,7 +6676,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6697,7 +6693,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6717,8 +6713,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -6774,7 +6768,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6800,7 +6794,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6824,7 +6818,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6848,7 +6842,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6872,7 +6866,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6900,7 +6894,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7006,7 +7000,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -222,7 +222,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -256,7 +256,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -269,7 +269,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -295,7 +295,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -321,7 +321,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -334,7 +334,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -347,7 +347,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -360,7 +360,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -376,7 +376,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -394,7 +394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -409,6 +409,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -418,7 +419,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -531,7 +532,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -557,7 +558,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -808,7 +809,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1145,7 +1146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1178,7 +1179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1286,7 +1287,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1310,7 +1311,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1352,7 +1353,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1386,7 +1387,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1428,7 +1429,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1441,7 +1442,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1635,7 +1636,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1728,7 +1729,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1750,7 +1751,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1768,7 +1769,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1831,7 +1832,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1882,7 +1883,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1923,7 +1924,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1943,7 +1944,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1967,7 +1968,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1986,7 +1987,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2014,7 +2015,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2042,7 +2043,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2070,7 +2071,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,6 +2103,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2155,7 +2157,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2175,7 +2177,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2195,7 +2197,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2215,7 +2217,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2242,6 +2244,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2259,7 +2262,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2281,7 +2284,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2303,7 +2306,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2333,7 +2336,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2354,7 +2357,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2380,7 +2383,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2419,7 +2422,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2443,7 +2446,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2467,7 +2470,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2497,7 +2500,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2532,7 +2535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2555,7 +2558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2577,7 +2580,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2598,7 +2601,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2739,7 +2742,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2870,7 +2873,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3561,7 +3564,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4114,7 +4117,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4242,7 +4245,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: filestream-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4516,7 +4519,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4772,7 +4775,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5429,7 +5432,7 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5708,7 +5711,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6006,7 +6009,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -6117,6 +6120,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -6195,7 +6199,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6378,7 +6382,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6410,7 +6414,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6519,7 +6523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6676,7 +6680,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6693,7 +6697,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6713,6 +6717,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -6768,7 +6774,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6794,7 +6800,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6818,7 +6824,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6842,7 +6848,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6866,7 +6872,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6894,7 +6900,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7000,7 +7006,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.10.0
+    helm.sh/chart: filestream-0.10.1
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.0
+    helm.sh/chart: flat-run-fields-updater-0.10.1
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.0
+    helm.sh/chart: metric-observer-0.10.1
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -222,7 +222,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -243,7 +243,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -256,7 +256,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -269,7 +269,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -282,7 +282,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -295,7 +295,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filestream
   labels:
-    helm.sh/chart: filestream-0.10.0
+    helm.sh/chart: filestream-0.10.1
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.0
+    helm.sh/chart: flat-run-fields-updater-0.10.1
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -321,7 +321,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -334,7 +334,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.0
+    helm.sh/chart: metric-observer-0.10.1
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -360,7 +360,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -418,7 +418,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1768,7 +1768,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1923,7 +1923,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1986,7 +1986,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2014,7 +2014,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2042,7 +2042,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2070,7 +2070,7 @@ kind: Role
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.0
+    helm.sh/chart: metric-observer-0.10.1
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2155,7 +2155,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2175,7 +2175,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2195,7 +2195,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2215,7 +2215,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.0
+    helm.sh/chart: metric-observer-0.10.1
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2259,7 +2259,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2281,7 +2281,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2303,7 +2303,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2333,7 +2333,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2419,7 +2419,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2577,7 +2577,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2739,7 +2739,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2760,7 +2760,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2870,7 +2870,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2891,7 +2891,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3561,7 +3561,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3582,7 +3582,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4114,7 +4114,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4135,7 +4135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4242,7 +4242,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filestream-bc
   labels:
-    helm.sh/chart: filestream-0.10.0
+    helm.sh/chart: filestream-0.10.1
     app.kubernetes.io/name: filestream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4263,7 +4263,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.10.0
+        helm.sh/chart: filestream-0.10.1
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4516,7 +4516,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.0
+    helm.sh/chart: flat-run-fields-updater-0.10.1
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4537,7 +4537,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.10.0
+        helm.sh/chart: flat-run-fields-updater-0.10.1
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4772,7 +4772,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4790,7 +4790,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5429,7 +5429,7 @@ kind: Deployment
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.0
+    helm.sh/chart: metric-observer-0.10.1
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5450,7 +5450,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: metric-observer-0.10.0
+        helm.sh/chart: metric-observer-0.10.1
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5708,7 +5708,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5730,7 +5730,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6195,7 +6195,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6216,7 +6216,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6378,7 +6378,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-metric-observer
   labels:
-    helm.sh/chart: metric-observer-0.10.0
+    helm.sh/chart: metric-observer-0.10.1
     app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6676,7 +6676,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6693,7 +6693,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6768,7 +6768,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6794,7 +6794,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6818,7 +6818,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6842,7 +6842,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6894,7 +6894,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6907,7 +6907,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -7000,7 +7000,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7013,7 +7013,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3037,6 +3037,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3259,6 +3265,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3448,6 +3460,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3714,6 +3732,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3975,6 +3999,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4377,6 +4407,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4898,6 +4934,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5105,6 +5147,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5286,6 +5334,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5540,6 +5594,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5814,6 +5874,12 @@ spec:
           value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   podSelector:
@@ -41,7 +41,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -63,7 +63,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -84,7 +84,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -126,7 +126,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -152,7 +152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   minAvailable: 51%
@@ -168,7 +168,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: flat-run-fields-updater-0.10.0
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -189,7 +189,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -210,7 +210,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -231,7 +231,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -252,7 +252,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -278,7 +278,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -292,7 +292,7 @@ metadata:
   name: bufstream-service-account
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -304,7 +304,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
 ---
 # Source: operator-wandb/charts/flat-run-fields-updater/templates/serviceaccount.yaml
 apiVersion: v1
@@ -331,7 +331,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: flat-run-fields-updater-0.10.0
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -357,7 +357,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -370,7 +370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -419,7 +419,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -429,7 +428,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -543,7 +542,7 @@ metadata:
   name: bufstream-config
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -609,7 +608,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -635,7 +634,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -886,7 +885,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1223,7 +1222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1256,7 +1255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1364,7 +1363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1388,7 +1387,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1430,7 +1429,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1464,7 +1463,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1506,7 +1505,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1519,7 +1518,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1713,7 +1712,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1806,7 +1805,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1828,7 +1827,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1846,7 +1845,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1909,7 +1908,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1960,7 +1959,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2001,7 +2000,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2021,7 +2020,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2045,7 +2044,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2064,7 +2063,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2092,7 +2091,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2120,7 +2119,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2155,7 +2154,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2209,7 +2207,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2229,7 +2227,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2249,7 +2247,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2276,7 +2274,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2294,7 +2291,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2316,7 +2313,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2338,7 +2335,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2369,7 +2366,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -2394,7 +2391,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2420,7 +2417,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -2454,7 +2451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   type: ClusterIP
@@ -2483,7 +2480,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2509,7 +2506,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2548,7 +2545,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2572,7 +2569,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2596,7 +2593,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2626,7 +2623,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2661,7 +2658,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2684,7 +2681,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2706,7 +2703,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2727,7 +2724,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2868,7 +2865,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2987,7 +2984,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3151,10 +3148,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3367,10 +3364,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3550,10 +3547,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3642,7 +3639,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3810,10 +3807,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4065,10 +4062,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4171,7 +4168,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4287,7 +4284,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: flat-run-fields-updater-0.10.0
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4531,7 +4528,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4690,10 +4687,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4891,10 +4888,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5066,10 +5063,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5152,7 +5149,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5315,10 +5312,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5438,7 +5435,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5549,7 +5546,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5628,7 +5624,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5788,7 +5784,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -5918,7 +5914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   replicas: 3
@@ -6087,7 +6083,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6196,7 +6192,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6353,7 +6349,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6370,7 +6366,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6390,8 +6386,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -6447,7 +6441,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6473,7 +6467,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6497,7 +6491,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6521,7 +6515,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6545,7 +6539,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6573,7 +6567,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6667,7 +6661,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3151,6 +3151,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3361,6 +3367,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3538,6 +3550,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3792,6 +3810,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4041,6 +4065,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4660,6 +4690,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4855,6 +4891,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5024,6 +5066,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5267,6 +5315,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   podSelector:
@@ -41,7 +41,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -63,7 +63,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -84,7 +84,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -126,7 +126,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -152,7 +152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   minAvailable: 51%
@@ -168,7 +168,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -189,7 +189,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -210,7 +210,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -231,7 +231,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -252,7 +252,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -278,7 +278,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -292,7 +292,7 @@ metadata:
   name: bufstream-service-account
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -304,7 +304,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/flat-run-fields-updater/templates/serviceaccount.yaml
 apiVersion: v1
@@ -331,7 +331,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -357,7 +357,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -370,7 +370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -419,6 +419,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -428,7 +429,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -542,7 +543,7 @@ metadata:
   name: bufstream-config
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -608,7 +609,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -634,7 +635,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -885,7 +886,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1222,7 +1223,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1255,7 +1256,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1363,7 +1364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1387,7 +1388,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1429,7 +1430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1463,7 +1464,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1505,7 +1506,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1518,7 +1519,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1712,7 +1713,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1805,7 +1806,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1827,7 +1828,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1845,7 +1846,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1908,7 +1909,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1959,7 +1960,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2000,7 +2001,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2020,7 +2021,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2044,7 +2045,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2063,7 +2064,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2091,7 +2092,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2119,7 +2120,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2154,6 +2155,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2207,7 +2209,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2227,7 +2229,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2247,7 +2249,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2274,6 +2276,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2291,7 +2294,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2313,7 +2316,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2335,7 +2338,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2366,7 +2369,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -2391,7 +2394,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2417,7 +2420,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -2451,7 +2454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   type: ClusterIP
@@ -2480,7 +2483,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2506,7 +2509,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2545,7 +2548,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2569,7 +2572,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2593,7 +2596,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2623,7 +2626,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2658,7 +2661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2681,7 +2684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2703,7 +2706,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2724,7 +2727,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2865,7 +2868,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2984,7 +2987,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3639,7 +3642,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4168,7 +4171,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4284,7 +4287,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4528,7 +4531,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5149,7 +5152,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5435,7 +5438,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5546,6 +5549,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5624,7 +5628,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5784,7 +5788,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -5914,7 +5918,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   replicas: 3
@@ -6083,7 +6087,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6192,7 +6196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6349,7 +6353,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6366,7 +6370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6386,6 +6390,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -6441,7 +6447,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6467,7 +6473,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6491,7 +6497,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6515,7 +6521,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6539,7 +6545,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6567,7 +6573,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6661,7 +6667,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -63,7 +63,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -84,7 +84,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -105,7 +105,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -126,7 +126,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -168,7 +168,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.0
+    helm.sh/chart: flat-run-fields-updater-0.10.1
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -189,7 +189,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -210,7 +210,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -231,7 +231,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -252,7 +252,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -278,7 +278,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -304,7 +304,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -331,7 +331,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-flat-run-fields-updater
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.0
+    helm.sh/chart: flat-run-fields-updater-0.10.1
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -370,7 +370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -428,7 +428,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1845,7 +1845,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2000,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,7 +2063,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2091,7 +2091,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2119,7 +2119,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2207,7 +2207,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2227,7 +2227,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2247,7 +2247,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2291,7 +2291,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2313,7 +2313,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2335,7 +2335,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2391,7 +2391,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2545,7 +2545,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2703,7 +2703,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2865,7 +2865,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2886,7 +2886,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2984,7 +2984,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3005,7 +3005,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3639,7 +3639,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3660,7 +3660,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4168,7 +4168,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4189,7 +4189,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4284,7 +4284,7 @@ kind: Deployment
 metadata:
   name: chartsnap-flat-run-fields-updater-bc
   labels:
-    helm.sh/chart: flat-run-fields-updater-0.10.0
+    helm.sh/chart: flat-run-fields-updater-0.10.1
     app.kubernetes.io/name: flat-run-fields-updater
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4305,7 +4305,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.10.0
+        helm.sh/chart: flat-run-fields-updater-0.10.1
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4528,7 +4528,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4546,7 +4546,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5149,7 +5149,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5171,7 +5171,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5624,7 +5624,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5645,7 +5645,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6349,7 +6349,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6366,7 +6366,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6441,7 +6441,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6467,7 +6467,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6491,7 +6491,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6515,7 +6515,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6567,7 +6567,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6580,7 +6580,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -6661,7 +6661,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6674,7 +6674,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -214,7 +214,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -227,7 +227,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -266,7 +266,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -279,7 +279,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -292,7 +292,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -326,7 +326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -341,6 +341,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -350,7 +351,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -463,7 +464,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -489,7 +490,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -740,7 +741,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1077,7 +1078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1110,7 +1111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1218,7 +1219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1242,7 +1243,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1284,7 +1285,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1318,7 +1319,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1360,7 +1361,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1373,7 +1374,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1567,7 +1568,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1660,7 +1661,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1682,7 +1683,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1700,7 +1701,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1763,7 +1764,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1814,7 +1815,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1855,7 +1856,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1875,7 +1876,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1899,7 +1900,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1918,7 +1919,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1946,7 +1947,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1974,7 +1975,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2009,6 +2010,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2062,7 +2064,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2082,7 +2084,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,7 +2104,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2129,6 +2131,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2146,7 +2149,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2168,7 +2171,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2190,7 +2193,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2220,7 +2223,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2241,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2267,7 +2270,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2306,7 +2309,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2330,7 +2333,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2354,7 +2357,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2384,7 +2387,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2419,7 +2422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2442,7 +2445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2464,7 +2467,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2485,7 +2488,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2626,7 +2629,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2735,7 +2738,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3360,7 +3363,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3873,7 +3876,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3979,7 +3982,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4209,7 +4212,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4800,7 +4803,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5076,7 +5079,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5187,6 +5190,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5265,7 +5269,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5404,7 +5408,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5513,7 +5517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5670,7 +5674,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5687,7 +5691,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5707,6 +5711,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5762,7 +5768,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5788,7 +5794,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5812,7 +5818,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5836,7 +5842,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5860,7 +5866,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5888,7 +5894,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5972,7 +5978,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -2902,6 +2902,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3102,6 +3108,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3269,6 +3281,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3513,6 +3531,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3754,6 +3778,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4094,6 +4124,12 @@ spec:
           value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4312,6 +4348,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4497,6 +4539,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4656,6 +4704,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4889,6 +4943,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.10.0
+    helm.sh/chart: filemeta-0.10.1
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -214,7 +214,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -227,7 +227,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.10.0
+    helm.sh/chart: filemeta-0.10.1
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -266,7 +266,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -292,7 +292,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -350,7 +350,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1700,7 +1700,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1855,7 +1855,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1918,7 +1918,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1946,7 +1946,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1974,7 +1974,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2062,7 +2062,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2082,7 +2082,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,7 +2102,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2146,7 +2146,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2168,7 +2168,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2190,7 +2190,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2220,7 +2220,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2306,7 +2306,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2464,7 +2464,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2626,7 +2626,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2647,7 +2647,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2735,7 +2735,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2756,7 +2756,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3360,7 +3360,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3381,7 +3381,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3873,7 +3873,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3894,7 +3894,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3979,7 +3979,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: filemeta-0.10.0
+    helm.sh/chart: filemeta-0.10.1
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4000,7 +4000,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.10.0
+        helm.sh/chart: filemeta-0.10.1
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4209,7 +4209,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4227,7 +4227,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4800,7 +4800,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4822,7 +4822,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5265,7 +5265,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5286,7 +5286,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5670,7 +5670,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5687,7 +5687,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5762,7 +5762,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5788,7 +5788,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5812,7 +5812,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5836,7 +5836,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5888,7 +5888,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5901,7 +5901,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -5972,7 +5972,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5985,7 +5985,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: filemeta-0.10.0
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -201,7 +201,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -214,7 +214,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -227,7 +227,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -240,7 +240,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -253,7 +253,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: filemeta-0.10.0
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -266,7 +266,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -279,7 +279,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -292,7 +292,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -326,7 +326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -341,7 +341,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -351,7 +350,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -464,7 +463,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -490,7 +489,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -741,7 +740,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1078,7 +1077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1111,7 +1110,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1219,7 +1218,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1243,7 +1242,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1285,7 +1284,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1319,7 +1318,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1361,7 +1360,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1374,7 +1373,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1568,7 +1567,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1661,7 +1660,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1683,7 +1682,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1701,7 +1700,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1764,7 +1763,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1815,7 +1814,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1856,7 +1855,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1876,7 +1875,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1900,7 +1899,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1919,7 +1918,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1947,7 +1946,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1975,7 +1974,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2010,7 +2009,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2064,7 +2062,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2084,7 +2082,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2104,7 +2102,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2131,7 +2129,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2149,7 +2146,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2171,7 +2168,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2193,7 +2190,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2223,7 +2220,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2244,7 +2241,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2270,7 +2267,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2309,7 +2306,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2333,7 +2330,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2357,7 +2354,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2387,7 +2384,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2422,7 +2419,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2445,7 +2442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2467,7 +2464,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2488,7 +2485,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2629,7 +2626,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2738,7 +2735,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2902,10 +2899,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3108,10 +3105,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3281,10 +3278,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3363,7 +3360,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3531,10 +3528,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3778,10 +3775,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3876,7 +3873,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3982,7 +3979,7 @@ kind: Deployment
 metadata:
   name: chartsnap-filemeta
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: filemeta-0.10.0
     app.kubernetes.io/name: filemeta
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4124,10 +4121,10 @@ spec:
           value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4189,7 +4186,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4348,10 +4345,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4539,10 +4536,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4704,10 +4701,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4780,7 +4777,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4943,10 +4940,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5056,7 +5053,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5167,7 +5164,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5246,7 +5242,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5385,7 +5381,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5494,7 +5490,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5651,7 +5647,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5668,7 +5664,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5688,8 +5684,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5745,7 +5739,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5771,7 +5765,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5795,7 +5789,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5819,7 +5813,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5843,7 +5837,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5871,7 +5865,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5955,7 +5949,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -2868,6 +2868,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3068,6 +3074,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3235,6 +3247,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3479,6 +3497,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3718,6 +3742,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4073,6 +4103,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4258,6 +4294,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4417,6 +4459,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4650,6 +4698,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,6 +307,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -316,7 +317,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -429,7 +430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -455,7 +456,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -706,7 +707,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1043,7 +1044,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1076,7 +1077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1184,7 +1185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1208,7 +1209,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1250,7 +1251,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1284,7 +1285,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1326,7 +1327,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1339,7 +1340,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1533,7 +1534,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1626,7 +1627,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1648,7 +1649,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1666,7 +1667,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1729,7 +1730,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1780,7 +1781,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1821,7 +1822,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1842,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1865,7 +1866,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1884,7 +1885,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1912,7 +1913,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1940,7 +1941,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1975,6 +1976,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2028,7 +2030,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2048,7 +2050,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2068,7 +2070,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2095,6 +2097,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2112,7 +2115,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2156,7 +2159,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2186,7 +2189,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2207,7 +2210,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2233,7 +2236,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2272,7 +2275,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2296,7 +2299,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2320,7 +2323,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2350,7 +2353,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2385,7 +2388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2408,7 +2411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2430,7 +2433,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2451,7 +2454,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2592,7 +2595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2701,7 +2704,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3326,7 +3329,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3835,7 +3838,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3941,7 +3944,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4532,7 +4535,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4808,7 +4811,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4919,6 +4922,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4997,7 +5001,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5136,7 +5140,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5245,7 +5249,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5402,7 +5406,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5419,7 +5423,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5439,6 +5443,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5494,7 +5500,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5520,7 +5526,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5544,7 +5550,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5568,7 +5574,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5592,7 +5598,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5620,7 +5626,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5704,7 +5710,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -316,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1666,7 +1666,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1821,7 +1821,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1884,7 +1884,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1912,7 +1912,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1940,7 +1940,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2028,7 +2028,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2048,7 +2048,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2068,7 +2068,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2112,7 +2112,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2134,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2156,7 +2156,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2186,7 +2186,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2272,7 +2272,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2430,7 +2430,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2592,7 +2592,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2613,7 +2613,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2701,7 +2701,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2722,7 +2722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3326,7 +3326,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3347,7 +3347,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3835,7 +3835,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3856,7 +3856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3941,7 +3941,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3959,7 +3959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4532,7 +4532,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4554,7 +4554,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4997,7 +4997,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5018,7 +5018,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5402,7 +5402,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5419,7 +5419,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5494,7 +5494,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5520,7 +5520,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5544,7 +5544,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5568,7 +5568,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5620,7 +5620,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5633,7 +5633,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -5704,7 +5704,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5717,7 +5717,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,7 +307,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -317,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -430,7 +429,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -456,7 +455,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -707,7 +706,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1044,7 +1043,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1077,7 +1076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1185,7 +1184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1209,7 +1208,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1251,7 +1250,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1285,7 +1284,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1327,7 +1326,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1340,7 +1339,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1534,7 +1533,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1627,7 +1626,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1649,7 +1648,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1667,7 +1666,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1730,7 +1729,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1781,7 +1780,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1822,7 +1821,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1842,7 +1841,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1866,7 +1865,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1885,7 +1884,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1913,7 +1912,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1941,7 +1940,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1976,7 +1975,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2030,7 +2028,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2050,7 +2048,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2070,7 +2068,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2097,7 +2095,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2115,7 +2112,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2137,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2159,7 +2156,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2189,7 +2186,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2210,7 +2207,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2236,7 +2233,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2275,7 +2272,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2299,7 +2296,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2323,7 +2320,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2353,7 +2350,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2388,7 +2385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2411,7 +2408,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2433,7 +2430,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2454,7 +2451,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2595,7 +2592,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2704,7 +2701,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2868,10 +2865,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3074,10 +3071,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3247,10 +3244,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3329,7 +3326,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3497,10 +3494,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3742,10 +3739,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3838,7 +3835,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3944,7 +3941,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4103,10 +4100,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4294,10 +4291,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4459,10 +4456,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4535,7 +4532,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4698,10 +4695,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4811,7 +4808,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4922,7 +4919,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5001,7 +4997,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5140,7 +5136,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5249,7 +5245,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5406,7 +5402,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5423,7 +5419,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5443,8 +5439,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5500,7 +5494,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5526,7 +5520,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5550,7 +5544,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5574,7 +5568,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5598,7 +5592,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5626,7 +5620,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5710,7 +5704,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,7 +239,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -249,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -362,7 +361,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -388,7 +387,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -639,7 +638,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -976,7 +975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1009,7 +1008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1117,7 +1116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1141,7 +1140,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1183,7 +1182,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1217,7 +1216,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1259,7 +1258,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1272,7 +1271,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1466,7 +1465,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1559,7 +1558,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1581,7 +1580,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1599,7 +1598,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1662,7 +1661,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1713,7 +1712,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1754,7 +1753,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1774,7 +1773,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1798,7 +1797,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1817,7 +1816,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1852,7 +1851,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1906,7 +1904,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1933,7 +1931,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1951,7 +1948,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1973,7 +1970,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2003,7 +2000,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2024,7 +2021,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2050,7 +2047,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2089,7 +2086,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2113,7 +2110,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2137,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2167,7 +2164,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2202,7 +2199,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2225,7 +2222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2247,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2268,7 +2265,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2409,7 +2406,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,7 +2515,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2686,10 +2683,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -2931,10 +2928,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3027,7 +3024,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3133,7 +3130,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3296,10 +3293,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3409,7 +3406,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3520,7 +3517,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3599,7 +3595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3738,7 +3734,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3847,7 +3843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4004,7 +4000,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4160,10 +4156,10 @@ spec:
               value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
             - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
               value: ""
-            - name: STATSIG_API_KEY
+            - name: GORILLA_STATSIG_KEY
               valueFrom:
                 secretKeyRef:
-                  key: STATSIG_API_KEY
+                  key: GORILLA_STATSIG_KEY
                   name: gorilla-statsig
                   optional: true
             - name: LICENSE
@@ -4255,7 +4251,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4272,7 +4268,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4292,8 +4288,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4349,7 +4343,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4375,7 +4369,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4399,7 +4393,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4423,7 +4417,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4447,7 +4441,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4475,7 +4469,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4559,7 +4553,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -248,7 +248,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1598,7 +1598,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1753,7 +1753,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1816,7 +1816,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1904,7 +1904,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1948,7 +1948,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1970,7 +1970,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2000,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2086,7 +2086,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2244,7 +2244,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2406,7 +2406,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2427,7 +2427,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2515,7 +2515,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2536,7 +2536,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3024,7 +3024,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3045,7 +3045,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3130,7 +3130,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3152,7 +3152,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3595,7 +3595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3616,7 +3616,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4000,7 +4000,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4013,7 +4013,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.10.0
+            helm.sh/chart: parquet-0.10.1
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -4251,7 +4251,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4268,7 +4268,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4343,7 +4343,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4369,7 +4369,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4393,7 +4393,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4417,7 +4417,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4469,7 +4469,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4482,7 +4482,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -4553,7 +4553,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4566,7 +4566,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2686,6 +2686,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -2925,6 +2931,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3284,6 +3296,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4142,6 +4160,12 @@ spec:
               value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
             - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
               value: ""
+            - name: STATSIG_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: STATSIG_API_KEY
+                  name: gorilla-statsig
+                  optional: true
             - name: LICENSE
               valueFrom:
                 secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -151,7 +151,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -164,7 +164,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -177,7 +177,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -190,7 +190,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -239,6 +239,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -248,7 +249,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -361,7 +362,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -387,7 +388,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -638,7 +639,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -975,7 +976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1008,7 +1009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1116,7 +1117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1140,7 +1141,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1182,7 +1183,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1216,7 +1217,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1258,7 +1259,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1271,7 +1272,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1465,7 +1466,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1558,7 +1559,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1580,7 +1581,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1598,7 +1599,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1661,7 +1662,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1712,7 +1713,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1753,7 +1754,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1773,7 +1774,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1797,7 +1798,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1816,7 +1817,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1851,6 +1852,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1904,7 +1906,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1931,6 +1933,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -1948,7 +1951,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1970,7 +1973,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2000,7 +2003,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2021,7 +2024,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2047,7 +2050,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2086,7 +2089,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2110,7 +2113,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2164,7 +2167,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2199,7 +2202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2222,7 +2225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2244,7 +2247,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2265,7 +2268,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2406,7 +2409,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2515,7 +2518,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3024,7 +3027,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3130,7 +3133,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3406,7 +3409,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3517,6 +3520,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -3595,7 +3599,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3734,7 +3738,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -3843,7 +3847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -4000,7 +4004,7 @@ kind: CronJob
 metadata:
   name: chartsnap-parquet-backfill
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4251,7 +4255,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4268,7 +4272,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4288,6 +4292,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4343,7 +4349,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4369,7 +4375,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4393,7 +4399,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4417,7 +4423,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4441,7 +4447,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -4469,7 +4475,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -4553,7 +4559,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -2868,6 +2868,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3068,6 +3074,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3235,6 +3247,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3479,6 +3497,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3718,6 +3742,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4073,6 +4103,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4258,6 +4294,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4417,6 +4459,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4650,6 +4698,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,6 +307,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -316,7 +317,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -429,7 +430,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -455,7 +456,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -706,7 +707,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1043,7 +1044,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1076,7 +1077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1184,7 +1185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1208,7 +1209,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1250,7 +1251,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1284,7 +1285,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1326,7 +1327,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1339,7 +1340,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1533,7 +1534,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1626,7 +1627,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1648,7 +1649,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1666,7 +1667,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1729,7 +1730,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1780,7 +1781,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1821,7 +1822,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1841,7 +1842,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1865,7 +1866,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1884,7 +1885,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1912,7 +1913,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1940,7 +1941,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1975,6 +1976,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2028,7 +2030,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2048,7 +2050,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2068,7 +2070,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2095,6 +2097,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2112,7 +2115,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2134,7 +2137,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2156,7 +2159,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2186,7 +2189,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2207,7 +2210,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2233,7 +2236,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2272,7 +2275,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2296,7 +2299,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2320,7 +2323,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2350,7 +2353,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2385,7 +2388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2408,7 +2411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2430,7 +2433,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2451,7 +2454,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2592,7 +2595,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2701,7 +2704,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3326,7 +3329,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3835,7 +3838,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3941,7 +3944,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4532,7 +4535,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4808,7 +4811,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4919,6 +4922,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4997,7 +5001,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5136,7 +5140,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5247,7 +5251,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5404,7 +5408,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5421,7 +5425,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5441,6 +5445,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5496,7 +5502,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5522,7 +5528,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5546,7 +5552,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5570,7 +5576,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5594,7 +5600,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5622,7 +5628,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5706,7 +5712,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -316,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1666,7 +1666,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1821,7 +1821,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1884,7 +1884,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1912,7 +1912,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1940,7 +1940,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2028,7 +2028,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2048,7 +2048,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2068,7 +2068,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2112,7 +2112,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2134,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2156,7 +2156,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2186,7 +2186,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2272,7 +2272,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2430,7 +2430,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2592,7 +2592,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2613,7 +2613,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2701,7 +2701,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2722,7 +2722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3326,7 +3326,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3347,7 +3347,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3835,7 +3835,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3856,7 +3856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3941,7 +3941,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3959,7 +3959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4532,7 +4532,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4554,7 +4554,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4997,7 +4997,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5018,7 +5018,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5404,7 +5404,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5421,7 +5421,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5496,7 +5496,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5522,7 +5522,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5546,7 +5546,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5570,7 +5570,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5622,7 +5622,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5635,7 +5635,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -5706,7 +5706,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5719,7 +5719,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,7 +307,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -317,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -430,7 +429,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -456,7 +455,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -707,7 +706,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1044,7 +1043,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1077,7 +1076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1185,7 +1184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1209,7 +1208,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1251,7 +1250,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1285,7 +1284,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1327,7 +1326,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1340,7 +1339,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1534,7 +1533,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1627,7 +1626,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1649,7 +1648,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1667,7 +1666,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1730,7 +1729,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1781,7 +1780,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1822,7 +1821,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1842,7 +1841,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1866,7 +1865,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1885,7 +1884,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1913,7 +1912,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1941,7 +1940,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1976,7 +1975,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2030,7 +2028,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2050,7 +2048,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2070,7 +2068,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2097,7 +2095,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2115,7 +2112,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2137,7 +2134,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2159,7 +2156,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2189,7 +2186,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2210,7 +2207,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2236,7 +2233,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2275,7 +2272,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2299,7 +2296,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2323,7 +2320,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2353,7 +2350,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2388,7 +2385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2411,7 +2408,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2433,7 +2430,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2454,7 +2451,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2595,7 +2592,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2704,7 +2701,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2868,10 +2865,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3074,10 +3071,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3247,10 +3244,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3329,7 +3326,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3497,10 +3494,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3742,10 +3739,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3838,7 +3835,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3944,7 +3941,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4103,10 +4100,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4294,10 +4291,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4459,10 +4456,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4535,7 +4532,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4698,10 +4695,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4811,7 +4808,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4922,7 +4919,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5001,7 +4997,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5140,7 +5136,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5251,7 +5247,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5408,7 +5404,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5425,7 +5421,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5445,8 +5441,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5502,7 +5496,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5528,7 +5522,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5552,7 +5546,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5576,7 +5570,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5600,7 +5594,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5628,7 +5622,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5712,7 +5706,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -316,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1634,7 +1634,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1789,7 +1789,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1852,7 +1852,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1880,7 +1880,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1908,7 +1908,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1996,7 +1996,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2016,7 +2016,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2036,7 +2036,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2080,7 +2080,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,7 +2102,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2124,7 +2124,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2154,7 +2154,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2240,7 +2240,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2398,7 +2398,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2560,7 +2560,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2581,7 +2581,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2669,7 +2669,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2690,7 +2690,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3294,7 +3294,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3315,7 +3315,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3803,7 +3803,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3824,7 +3824,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3909,7 +3909,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3927,7 +3927,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4500,7 +4500,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4522,7 +4522,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4965,7 +4965,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4986,7 +4986,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5370,7 +5370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5387,7 +5387,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5462,7 +5462,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5488,7 +5488,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5512,7 +5512,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5536,7 +5536,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5588,7 +5588,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5601,7 +5601,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -5672,7 +5672,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5685,7 +5685,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,6 +307,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -316,7 +317,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -397,7 +398,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -423,7 +424,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -674,7 +675,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1011,7 +1012,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1044,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1152,7 +1153,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1176,7 +1177,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1218,7 +1219,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1252,7 +1253,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1294,7 +1295,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1307,7 +1308,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1501,7 +1502,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1594,7 +1595,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1616,7 +1617,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1634,7 +1635,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1697,7 +1698,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1748,7 +1749,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1789,7 +1790,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1809,7 +1810,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1833,7 +1834,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1852,7 +1853,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1880,7 +1881,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1908,7 +1909,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1943,6 +1944,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1996,7 +1998,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2016,7 +2018,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2036,7 +2038,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2063,6 +2065,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2080,7 +2083,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2102,7 +2105,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2124,7 +2127,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2154,7 +2157,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2175,7 +2178,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2201,7 +2204,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2240,7 +2243,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2264,7 +2267,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2288,7 +2291,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2318,7 +2321,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2353,7 +2356,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2376,7 +2379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2398,7 +2401,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2419,7 +2422,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2560,7 +2563,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2669,7 +2672,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3294,7 +3297,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3803,7 +3806,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3909,7 +3912,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4500,7 +4503,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4776,7 +4779,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4887,6 +4890,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4965,7 +4969,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5104,7 +5108,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5213,7 +5217,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5370,7 +5374,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5387,7 +5391,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5407,6 +5411,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5462,7 +5468,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5488,7 +5494,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5512,7 +5518,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5536,7 +5542,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5560,7 +5566,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5588,7 +5594,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5672,7 +5678,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -33,7 +33,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -54,7 +54,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -75,7 +75,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -96,7 +96,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -117,7 +117,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -138,7 +138,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -159,7 +159,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -180,7 +180,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -193,7 +193,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -206,7 +206,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -219,7 +219,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -232,7 +232,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -245,7 +245,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -258,7 +258,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -307,7 +307,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -317,7 +316,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -398,7 +397,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -424,7 +423,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -675,7 +674,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1012,7 +1011,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1045,7 +1044,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1153,7 +1152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1177,7 +1176,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1219,7 +1218,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1253,7 +1252,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1295,7 +1294,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1308,7 +1307,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1502,7 +1501,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1594,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1617,7 +1616,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1635,7 +1634,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1698,7 +1697,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1749,7 +1748,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1790,7 +1789,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1810,7 +1809,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1834,7 +1833,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1853,7 +1852,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1881,7 +1880,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1909,7 +1908,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1944,7 +1943,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -1998,7 +1996,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2018,7 +2016,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2038,7 +2036,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2065,7 +2063,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2083,7 +2080,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2105,7 +2102,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2127,7 +2124,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2157,7 +2154,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2178,7 +2175,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2204,7 +2201,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2243,7 +2240,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2267,7 +2264,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2291,7 +2288,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2321,7 +2318,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2356,7 +2353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2379,7 +2376,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2401,7 +2398,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2422,7 +2419,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2563,7 +2560,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2672,7 +2669,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2836,10 +2833,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3042,10 +3039,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3215,10 +3212,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3297,7 +3294,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3465,10 +3462,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3710,10 +3707,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3806,7 +3803,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3912,7 +3909,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4071,10 +4068,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4262,10 +4259,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4427,10 +4424,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4503,7 +4500,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4666,10 +4663,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4779,7 +4776,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -4890,7 +4887,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -4969,7 +4965,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5108,7 +5104,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -5217,7 +5213,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -5374,7 +5370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5391,7 +5387,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5411,8 +5407,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -5468,7 +5462,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5494,7 +5488,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5518,7 +5512,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5542,7 +5536,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5566,7 +5560,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -5594,7 +5588,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -5678,7 +5672,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -2836,6 +2836,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3036,6 +3042,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3203,6 +3215,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3447,6 +3465,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3686,6 +3710,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4041,6 +4071,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4226,6 +4262,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4385,6 +4427,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4618,6 +4666,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: keeper
 spec:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: clickhouse
 spec:
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   podSelector:
@@ -106,7 +106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -128,7 +128,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +149,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -170,7 +170,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -196,7 +196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -239,7 +239,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   minAvailable: 51%
@@ -281,7 +281,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -302,7 +302,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -365,7 +365,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -399,7 +399,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -412,7 +412,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -426,7 +426,7 @@ metadata:
   name: bufstream-service-account
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -443,7 +443,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
 automountServiceAccountToken: false
 ---
@@ -453,7 +453,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/glue/templates/serviceaccount.yaml
 apiVersion: v1
@@ -480,7 +480,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -493,7 +493,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -506,7 +506,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -555,6 +555,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -564,7 +565,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -577,7 +578,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -590,7 +591,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -704,7 +705,7 @@ metadata:
   name: bufstream-config
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -775,7 +776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -830,7 +831,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -863,7 +864,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -889,7 +890,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1140,7 +1141,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1477,7 +1478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1510,7 +1511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1618,7 +1619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1642,7 +1643,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1685,7 +1686,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1719,7 +1720,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1761,7 +1762,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1774,7 +1775,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1968,7 +1969,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2061,7 +2062,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2083,7 +2084,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2101,7 +2102,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2164,7 +2165,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2215,7 +2216,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2256,7 +2257,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2276,7 +2277,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2300,7 +2301,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2334,7 +2335,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2362,7 +2363,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2390,7 +2391,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2425,6 +2426,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2478,7 +2480,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2498,7 +2500,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,7 +2520,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2545,6 +2547,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2562,7 +2565,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2584,7 +2587,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2606,7 +2609,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2637,7 +2640,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -2667,7 +2670,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2712,7 +2715,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2745,7 +2748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2779,7 +2782,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2823,7 +2826,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2849,7 +2852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -2883,7 +2886,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   type: ClusterIP
@@ -2912,7 +2915,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2938,7 +2941,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2977,7 +2980,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3001,7 +3004,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3025,7 +3028,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3055,7 +3058,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3090,7 +3093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -3113,7 +3116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -3135,7 +3138,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3157,7 +3160,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3178,7 +3181,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3323,7 +3326,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3432,7 +3435,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4057,7 +4060,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4566,7 +4569,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4672,7 +4675,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5263,7 +5266,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5539,7 +5542,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5650,6 +5653,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5728,7 +5732,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: weave-trace-worker-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5833,7 +5837,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6000,7 +6004,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6140,7 +6144,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: bufstream-0.3.5
+    helm.sh/chart: '###CHART_VERSION###'
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -6270,7 +6274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -6432,7 +6436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -6617,7 +6621,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: etcd-10.7.3
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: etcd
 spec:
   replicas: 3
@@ -6786,7 +6790,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6899,7 +6903,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -7056,7 +7060,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7073,7 +7077,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7093,6 +7097,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -7149,6 +7155,8 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave
@@ -7222,7 +7230,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7248,7 +7256,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7272,7 +7280,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7296,7 +7304,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7320,7 +7328,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7348,7 +7356,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7386,7 +7394,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7470,7 +7478,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: keeper
 spec:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: clickhouse
 spec:
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   podSelector:
@@ -106,7 +106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -128,7 +128,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +149,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -170,7 +170,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -196,7 +196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -239,7 +239,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -265,7 +265,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   minAvailable: 51%
@@ -281,7 +281,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -302,7 +302,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-worker-0.10.0
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -365,7 +365,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -399,7 +399,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -412,7 +412,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -426,7 +426,7 @@ metadata:
   name: bufstream-service-account
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -443,7 +443,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
 automountServiceAccountToken: false
 ---
@@ -453,7 +453,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
 ---
 # Source: operator-wandb/charts/glue/templates/serviceaccount.yaml
 apiVersion: v1
@@ -480,7 +480,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -493,7 +493,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -506,7 +506,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -555,7 +555,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -565,7 +564,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-worker-0.10.0
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -578,7 +577,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -591,7 +590,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -705,7 +704,7 @@ metadata:
   name: bufstream-config
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -776,7 +775,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -831,7 +830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -864,7 +863,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -890,7 +889,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -1141,7 +1140,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1478,7 +1477,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1511,7 +1510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1619,7 +1618,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1643,7 +1642,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1686,7 +1685,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1720,7 +1719,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1762,7 +1761,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1775,7 +1774,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1969,7 +1968,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -2062,7 +2061,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2084,7 +2083,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2102,7 +2101,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2165,7 +2164,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2216,7 +2215,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2257,7 +2256,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2277,7 +2276,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2301,7 +2300,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2335,7 +2334,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2363,7 +2362,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2391,7 +2390,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2426,7 +2425,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2480,7 +2478,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2500,7 +2498,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2520,7 +2518,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2547,7 +2545,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2565,7 +2562,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2587,7 +2584,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2609,7 +2606,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2640,7 +2637,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -2670,7 +2667,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2715,7 +2712,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2748,7 +2745,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2782,7 +2779,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2826,7 +2823,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2852,7 +2849,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -2886,7 +2883,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   type: ClusterIP
@@ -2915,7 +2912,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2941,7 +2938,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2980,7 +2977,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3004,7 +3001,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -3028,7 +3025,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3058,7 +3055,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3093,7 +3090,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -3116,7 +3113,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -3138,7 +3135,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3160,7 +3157,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3181,7 +3178,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3326,7 +3323,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3435,7 +3432,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3599,10 +3596,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3805,10 +3802,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3978,10 +3975,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4060,7 +4057,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4228,10 +4225,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4473,10 +4470,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4569,7 +4566,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4675,7 +4672,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4834,10 +4831,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5025,10 +5022,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5190,10 +5187,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5266,7 +5263,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5429,10 +5426,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5542,7 +5539,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5653,7 +5650,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5732,7 +5728,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-worker-0.10.0
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5837,7 +5833,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6004,7 +6000,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6144,7 +6140,7 @@ metadata:
   name: bufstream
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: bufstream-0.3.5
     app: bufstream
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/name: bufstream
@@ -6274,7 +6270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -6436,7 +6432,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -6621,7 +6617,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: etcd
     app.kubernetes.io/version: 3.5.17
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: etcd-10.7.3
     app.kubernetes.io/component: etcd
 spec:
   replicas: 3
@@ -6790,7 +6786,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6903,7 +6899,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -7060,7 +7056,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7077,7 +7073,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7097,8 +7093,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -7155,8 +7149,6 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave
@@ -7230,7 +7222,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7256,7 +7248,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7280,7 +7272,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7304,7 +7296,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7328,7 +7320,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7356,7 +7348,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -7394,7 +7386,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7478,7 +7470,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3599,6 +3599,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3799,6 +3805,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3966,6 +3978,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4210,6 +4228,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4449,6 +4473,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4804,6 +4834,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4989,6 +5025,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5148,6 +5190,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5381,6 +5429,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -128,7 +128,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -149,7 +149,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -170,7 +170,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -239,7 +239,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -281,7 +281,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -302,7 +302,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -323,7 +323,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.10.0
+    helm.sh/chart: weave-trace-worker-0.10.1
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -344,7 +344,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -365,7 +365,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -386,7 +386,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -399,7 +399,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -412,7 +412,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -453,7 +453,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -480,7 +480,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -506,7 +506,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -564,7 +564,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace-worker
   labels:
-    helm.sh/chart: weave-trace-worker-0.10.0
+    helm.sh/chart: weave-trace-worker-0.10.1
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -577,7 +577,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -590,7 +590,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2101,7 +2101,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2256,7 +2256,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2334,7 +2334,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2362,7 +2362,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2390,7 +2390,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2478,7 +2478,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2498,7 +2498,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2518,7 +2518,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2562,7 +2562,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2584,7 +2584,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2606,7 +2606,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2823,7 +2823,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2977,7 +2977,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3135,7 +3135,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3157,7 +3157,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3323,7 +3323,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3344,7 +3344,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3432,7 +3432,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3453,7 +3453,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4057,7 +4057,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4078,7 +4078,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4566,7 +4566,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4587,7 +4587,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4672,7 +4672,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4690,7 +4690,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5263,7 +5263,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5285,7 +5285,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5728,7 +5728,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-worker-bc
   labels:
-    helm.sh/chart: weave-trace-worker-0.10.0
+    helm.sh/chart: weave-trace-worker-0.10.1
     app.kubernetes.io/name: weave-trace-worker
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5749,7 +5749,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.10.0
+        helm.sh/chart: weave-trace-worker-0.10.1
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5833,7 +5833,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5854,7 +5854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.10.0
+        helm.sh/chart: weave-trace-0.10.1
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6000,7 +6000,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -6021,7 +6021,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7056,7 +7056,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7073,7 +7073,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7222,7 +7222,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7248,7 +7248,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7272,7 +7272,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7296,7 +7296,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7386,7 +7386,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7399,7 +7399,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -7470,7 +7470,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -7483,7 +7483,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3322,6 +3322,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3522,6 +3528,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3689,6 +3701,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -3933,6 +3951,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4172,6 +4196,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4527,6 +4557,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4712,6 +4748,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -4871,6 +4913,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:
@@ -5104,6 +5152,12 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
+        - name: STATSIG_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: STATSIG_API_KEY
+              name: gorilla-statsig
+              optional: true
         - name: LICENSE
           valueFrom:
             secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: keeper
 spec:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: clickhouse
 spec:
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   podSelector:
     matchLabels:
@@ -98,7 +98,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -119,7 +119,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -140,7 +140,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -166,7 +166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -209,7 +209,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -230,7 +230,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -251,7 +251,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -272,7 +272,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -293,7 +293,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -314,7 +314,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -327,7 +327,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -340,7 +340,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -358,7 +358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
 automountServiceAccountToken: false
 ---
@@ -368,7 +368,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -381,7 +381,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -394,7 +394,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -407,7 +407,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -456,6 +456,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -465,7 +466,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -478,7 +479,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -596,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -651,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -684,7 +685,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -710,7 +711,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -961,7 +962,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1298,7 +1299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1331,7 +1332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1439,7 +1440,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1463,7 +1464,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1506,7 +1507,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1540,7 +1541,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1582,7 +1583,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1595,7 +1596,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1789,7 +1790,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1882,7 +1883,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1904,7 +1905,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1922,7 +1923,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1985,7 +1986,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2036,7 +2037,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2077,7 +2078,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2097,7 +2098,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2121,7 +2122,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2155,7 +2156,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2183,7 +2184,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2211,7 +2212,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2246,6 +2247,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2299,7 +2301,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2319,7 +2321,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2339,7 +2341,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2366,6 +2368,7 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2383,7 +2386,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2405,7 +2408,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2427,7 +2430,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2462,7 +2465,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2507,7 +2510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2540,7 +2543,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2574,7 +2577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2618,7 +2621,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2639,7 +2642,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2665,7 +2668,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2704,7 +2707,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2728,7 +2731,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2752,7 +2755,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: mysql-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2782,7 +2785,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: redis-exporter-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2817,7 +2820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2840,7 +2843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2862,7 +2865,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2884,7 +2887,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2905,7 +2908,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: daemonset-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3046,7 +3049,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3155,7 +3158,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3780,7 +3783,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4289,7 +4292,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4395,7 +4398,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4986,7 +4989,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5262,7 +5265,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: instance-24.5.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5373,6 +5376,7 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
+    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5451,7 +5455,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5618,7 +5622,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5762,7 +5766,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -5924,7 +5928,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: clickhouse-9.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -6104,7 +6108,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: mysql-0.1.0
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6213,7 +6217,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: redis-18.19.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6370,7 +6374,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6387,7 +6391,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6407,6 +6411,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -6463,6 +6469,8 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave
@@ -6536,7 +6544,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6562,7 +6570,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6586,7 +6594,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6610,7 +6618,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6634,7 +6642,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6662,7 +6670,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: operator-wandb-0.34.10
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6700,7 +6708,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6784,7 +6792,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -98,7 +98,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -119,7 +119,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -140,7 +140,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -209,7 +209,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -230,7 +230,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -251,7 +251,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -272,7 +272,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -293,7 +293,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -314,7 +314,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -327,7 +327,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -340,7 +340,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -368,7 +368,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -381,7 +381,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -407,7 +407,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -465,7 +465,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -478,7 +478,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1922,7 +1922,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2077,7 +2077,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2155,7 +2155,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2183,7 +2183,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2211,7 +2211,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2299,7 +2299,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2319,7 +2319,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2339,7 +2339,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2383,7 +2383,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2405,7 +2405,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2427,7 +2427,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2618,7 +2618,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2704,7 +2704,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2862,7 +2862,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2884,7 +2884,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3046,7 +3046,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: anaconda2-0.10.0
+    helm.sh/chart: anaconda2-0.10.1
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3067,7 +3067,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.10.0
+        helm.sh/chart: anaconda2-0.10.1
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3155,7 +3155,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: api-0.10.0
+    helm.sh/chart: api-0.10.1
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3176,7 +3176,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.10.0
+        helm.sh/chart: api-0.10.1
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3780,7 +3780,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: app-0.10.0
+    helm.sh/chart: app-0.10.1
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3801,7 +3801,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.10.0
+        helm.sh/chart: app-0.10.1
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4289,7 +4289,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: console-0.10.0
+    helm.sh/chart: console-0.10.1
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4310,7 +4310,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.10.0
+        helm.sh/chart: console-0.10.1
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4395,7 +4395,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: glue-0.10.0
+    helm.sh/chart: glue-0.10.1
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4413,7 +4413,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.10.0
+        helm.sh/chart: glue-0.10.1
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4986,7 +4986,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: parquet-0.10.0
+    helm.sh/chart: parquet-0.10.1
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5008,7 +5008,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.10.0
+        helm.sh/chart: parquet-0.10.1
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5451,7 +5451,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: weave-trace-0.10.0
+    helm.sh/chart: weave-trace-0.10.1
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5472,7 +5472,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.10.0
+        helm.sh/chart: weave-trace-0.10.1
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5618,7 +5618,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: weave-0.10.0
+    helm.sh/chart: weave-0.10.1
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5639,7 +5639,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.10.0
+        helm.sh/chart: weave-0.10.1
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6370,7 +6370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6387,7 +6387,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6536,7 +6536,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6562,7 +6562,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6586,7 +6586,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6610,7 +6610,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6700,7 +6700,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: appRenamePostHook-0.10.0
+    helm.sh/chart: appRenamePostHook-0.10.1
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6713,7 +6713,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePostHook-0.10.0
+        helm.sh/chart: appRenamePostHook-0.10.1
         app.kubernetes.io/name: appRenamePostHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"
@@ -6784,7 +6784,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: appRenamePreHook-0.10.0
+    helm.sh/chart: appRenamePreHook-0.10.1
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6797,7 +6797,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: appRenamePreHook-0.10.0
+        helm.sh/chart: appRenamePreHook-0.10.1
         app.kubernetes.io/name: appRenamePreHook
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: keeper
 spec:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/part-of: clickhouse
     app.kubernetes.io/component: clickhouse
 spec:
@@ -76,7 +76,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   podSelector:
     matchLabels:
@@ -98,7 +98,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -119,7 +119,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -140,7 +140,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -166,7 +166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -209,7 +209,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -230,7 +230,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -251,7 +251,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -272,7 +272,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -293,7 +293,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -314,7 +314,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -327,7 +327,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -340,7 +340,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -358,7 +358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
 automountServiceAccountToken: false
 ---
@@ -368,7 +368,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -381,7 +381,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -394,7 +394,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -407,7 +407,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 ---
 # Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
 apiVersion: v1
@@ -456,7 +456,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 ---
@@ -466,7 +465,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -479,7 +478,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -597,7 +596,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -652,7 +651,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 data:
@@ -685,7 +684,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-mysql-initdb
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -711,7 +710,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -962,7 +961,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1299,7 +1298,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   redis.conf: |-
     # User-supplied common configuration:
@@ -1332,7 +1331,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -1440,7 +1439,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 data:
   start-master.sh: |
     #!/bin/bash
@@ -1464,7 +1463,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-anaconda2-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1507,7 +1506,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-app-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1541,7 +1540,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-ca-certs
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1583,7 +1582,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-executor-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1596,7 +1595,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-filestream-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1790,7 +1789,7 @@ kind: ConfigMap
 metadata:
   name: chartsnap-local-configmap
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1883,7 +1882,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: chartsnap-mysql-data
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -1905,7 +1904,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -1923,7 +1922,7 @@ kind: ClusterRole
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1986,7 +1985,7 @@ metadata:
   name: chartsnap-otel-daemonset
   namespace: default
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2037,7 +2036,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2078,7 +2077,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2098,7 +2097,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2122,7 +2121,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2156,7 +2155,7 @@ kind: Role
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2184,7 +2183,7 @@ kind: Role
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2212,7 +2211,7 @@ kind: Role
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2247,7 +2246,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role
   namespace: default
 rules:
@@ -2301,7 +2299,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2321,7 +2319,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2341,7 +2339,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2368,7 +2366,6 @@ metadata:
     release: "chartsnap"
     heritage: "Helm"
     app.kubernetes.io/managed-by: "Helm"
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader-role-binding
   namespace: default
 roleRef:
@@ -2386,7 +2383,7 @@ kind: Service
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2408,7 +2405,7 @@ kind: Service
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2430,7 +2427,7 @@ kind: Service
 metadata:
   name: chartsnap-app
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2465,7 +2462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2510,7 +2507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2543,7 +2540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2577,7 +2574,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -2621,7 +2618,7 @@ kind: Service
 metadata:
   name: chartsnap-console
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2642,7 +2639,7 @@ kind: Service
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -2668,7 +2665,7 @@ kind: Service
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2707,7 +2704,7 @@ kind: Service
 metadata:
   name: chartsnap-parquet
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2731,7 +2728,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -2755,7 +2752,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-mysql-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-exporter-0.1.0
     app.kubernetes.io/name: prometheus-mysql-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2785,7 +2782,7 @@ kind: Service
 metadata:
   name: chartsnap-prometheus-redis-exporter
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-exporter-0.1.0
     app.kubernetes.io/name: prometheus-redis-exporter
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -2820,7 +2817,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2843,7 +2840,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   type: ClusterIP
@@ -2865,7 +2862,7 @@ kind: Service
 metadata:
   name: chartsnap-weave-trace
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2887,7 +2884,7 @@ kind: Service
 metadata:
   name: chartsnap-weave
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -2908,7 +2905,7 @@ kind: DaemonSet
 metadata:
   name: chartsnap-otel-daemonset
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: daemonset-0.1.0
     app.kubernetes.io/name: daemonset
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0.33.0"
@@ -3049,7 +3046,7 @@ kind: Deployment
 metadata:
   name: chartsnap-anaconda2
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: anaconda2-0.10.0
     app.kubernetes.io/name: anaconda2
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3158,7 +3155,7 @@ kind: Deployment
 metadata:
   name: chartsnap-api
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: api-0.10.0
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3322,10 +3319,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3528,10 +3525,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3701,10 +3698,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -3783,7 +3780,7 @@ kind: Deployment
 metadata:
   name: chartsnap-app-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: app-0.10.0
     app.kubernetes.io/name: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -3951,10 +3948,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4196,10 +4193,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4292,7 +4289,7 @@ kind: Deployment
 metadata:
   name: chartsnap-console-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: console-0.10.0
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4398,7 +4395,7 @@ kind: Deployment
 metadata:
   name: chartsnap-glue
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: glue-0.10.0
     app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -4557,10 +4554,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4748,10 +4745,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4913,10 +4910,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -4989,7 +4986,7 @@ kind: Deployment
 metadata:
   name: chartsnap-parquet-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: parquet-0.10.0
     app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5152,10 +5149,10 @@ spec:
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
           value: ""
-        - name: STATSIG_API_KEY
+        - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
-              key: STATSIG_API_KEY
+              key: GORILLA_STATSIG_KEY
               name: gorilla-statsig
               optional: true
         - name: LICENSE
@@ -5265,7 +5262,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: v2.47.0
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: instance-24.5.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
@@ -5376,7 +5373,6 @@ metadata:
     group: com.stakater.platform
     provider: stakater
     version: v1.3.0
-    helm.sh/chart: '###CHART_VERSION###'
   name: chartsnap-reloader
   namespace: default
 spec:
@@ -5455,7 +5451,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-trace-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-trace-0.10.0
     app.kubernetes.io/name: weave-trace
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5622,7 +5618,7 @@ kind: Deployment
 metadata:
   name: chartsnap-weave-bc
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: weave-0.10.0
     app.kubernetes.io/name: weave
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -5766,7 +5762,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: keeper
     app.kubernetes.io/part-of: clickhouse
 spec:
@@ -5928,7 +5924,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: clickhouse
     app.kubernetes.io/version: 25.3.2
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: clickhouse-9.1.0
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
     shard: "0"
@@ -6108,7 +6104,7 @@ kind: StatefulSet
 metadata:
   name: chartsnap-mysql
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: mysql-0.1.0
     app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.16.0"
@@ -6217,7 +6213,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redis
     app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: redis-18.19.4
     app.kubernetes.io/component: master
 spec:
   replicas: 1
@@ -6374,7 +6370,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6391,7 +6387,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6411,8 +6407,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -6469,8 +6463,6 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave
@@ -6544,7 +6536,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6570,7 +6562,7 @@ kind: Role
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6594,7 +6586,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6618,7 +6610,7 @@ kind: RoleBinding
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6642,7 +6634,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-connection"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6670,7 +6662,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-weave"
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: operator-wandb-0.34.8
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -6708,7 +6700,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-post-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePostHook-0.10.0
     app.kubernetes.io/name: appRenamePostHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"
@@ -6792,7 +6784,7 @@ kind: Job
 metadata:
   name: chartsnap-app-rename-pre-hook
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: appRenamePreHook-0.10.0
     app.kubernetes.io/name: appRenamePreHook
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.31.12"


### PR DESCRIPTION
Get the statsig key from the secret store now?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional Statsig support: services can read GORILLA_STATSIG_KEY from a secret when no global Statsig API key is set, enabling feature-flagging without impacting existing deployments.
  - Template reference added across affected services so the env is available where applicable.
  - Chart version bumped (patch) to publish the change.

- Chores
  - Improved snapshots tool UX with a unified usage/help command and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->