### PR TITLE
fix: Fix operator ca cert mount

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: "1.0.0"
 maintainers:
   - name: wandb

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - name: {{ include "name" . }}-charts
             mountPath: /charts
           {{- end }}
-          {{- if .Values.caCertsConfigMap }}
+          {{- if or .Values.customCACerts .Values.caCertsConfigMap }}
           - name: wandb-ca-certs
             mountPath: /certs/
           {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * The operator now mounts CA certificates when either built-in or custom CA certificates are configured, improving connectivity in environments with private CAs. Ensures the /certs volume is created and populated whenever any CA certificates are provided, reducing configuration friction. No changes are required for existing user setups.

* Chores
  * Bumped chart version to 1.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->