### PR TITLE
fix: Adding support for pod and container securityContext to operator helm charts

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: "1.0.0"
 maintainers:
   - name: wandb

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -17,8 +17,12 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        {{- if .Values.podSecurityContext }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- else }}
         seccompProfile:
           type: RuntimeDefault
+        {{- end }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}
       - name: {{ . }}
@@ -68,6 +72,10 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         {{- if or .Values.airgapped .Values.customCACerts .Values.caCertsConfigMap }}
         volumeMounts:
           {{- if or .Values.airgapped }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -262,3 +262,11 @@ nodeSelector: {}
 # Taints to be tolerated by Pods of this application.
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
+
+# Pod-level security context
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core
+podSecurityContext: {}
+
+# Container-level security context
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core
+securityContext: {}


### PR DESCRIPTION
Adding ability to support custom pod and container securityContext to the operator helm charts.

Addresses this JIRA: https://wandb.atlassian.net/browse/STALWARTS-1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Operator Helm chart now supports configuring pod-level and container-level security contexts via values.
  * When a pod security context is provided, the default seccomp profile is not applied, allowing full control over pod security settings.

* Chores
  * Bumped Operator Helm chart version to 1.4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->