### PR TITLE
chore: Add initial base chart tests

### DIFF
--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -101,6 +101,8 @@ jobs:
         run: |
           if [[ -d test-configs/additional-resources/${{matrix.configuration}} ]]; then
             kubectl --context kind-${{ steps.cluster.outputs.name }} apply -f test-configs/additional-resources/${{matrix.configuration}}
+            echo "Applied additional resources for ${{matrix.configuration}}"
+            sleep 5
           else
             echo "No additional resources to be applied for ${{matrix.configuration}}"
           fi

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -1,4 +1,4 @@
-name: Test operator-wandb Chart
+name: Test wandb-base Chart
 
 on:
   pull_request:

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -45,6 +45,13 @@ jobs:
         k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
         configuration:
           [
+            env-values-example
+            env-precedence-container
+            env-precedence-sizing
+            env-precedence-chart-env
+            env-precedence-chart-legacy
+            env-precedence-global-env
+            env-precedence-global-legacy
           ]
     runs-on: ubuntu-latest
     environment: Helm Charts
@@ -94,13 +101,11 @@ jobs:
           fi
         if: env.ACT || steps.list-changed.outputs.changed == 'true'
 
-      #- name: Run chart-testing (install)
-      #  env:
-      #    LICENSE: ${{ secrets.LICENSE }}
-      #  if: env.ACT || steps.list-changed.outputs.changed == 'true'
-      #  run: |
-      #    ct install --namespace default \
-      #    --charts ./charts/operator-wandb \
-      #    --config ct.yaml \
-      #    --helm-extra-args '--kube-context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} --timeout 600s' \
-      #    --helm-extra-set-args '--values test-configs/operator-wandb/${{ matrix.configuration }}.yaml --set=license=$LICENSE'
+      - name: Run chart-testing (install)
+        if: env.ACT || steps.list-changed.outputs.changed == 'true'
+        run: |
+          ct install --namespace default \
+          --charts ./charts/wandb-base \
+          --config ct.yaml \
+          --helm-extra-args '--kube-context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} --timeout 600s' \
+          --helm-extra-set-args '--values test-configs/wandb-base/${{ matrix.configuration }}.yaml'

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -43,15 +43,14 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
-        configuration:
-          [
+        configuration: [
             env-values-example
             env-precedence-container
             env-precedence-sizing
             env-precedence-chart-env
             env-precedence-chart-legacy
             env-precedence-global-env
-            env-precedence-global-legacy
+            env-precedence-global-legacy,
           ]
     runs-on: ubuntu-latest
     environment: Helm Charts
@@ -84,18 +83,34 @@ jobs:
             echo "::set-output name=changed::true"
           fi
 
+      - name: Determine Kind Cluster Name
+        id: cluster
+        run: |
+          MATRIX_STRING="${{ matrix.k8s-version }}-${{ matrix.configuration }}"
+
+          HASH=$(python3 -c "
+          import zlib
+          data = '$MATRIX_STRING'.encode('utf-8')
+          crc = zlib.crc32(data) & 0xffffffff
+          print(f'{crc:08x}')
+          ")
+
+          export NAME="ct-${HASH}"
+          echo "::set-output name=name::${NAME}"
+          echo "Matrix: $MATRIX_STRING -> Hash: $HASH -> Name: $NAME"
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
         with:
           version: v0.27.0
-          cluster_name: chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }}
+          cluster_name: ${{ steps.cluster.outputs.name }}
           node_image: kindest/node:${{ matrix.k8s-version }}
         if: env.ACT || steps.list-changed.outputs.changed == 'true'
 
       - name: Apply user defined secrets
         run: |
           if [[ -d test-configs/additional-resources/${{matrix.configuration}} ]]; then
-            kubectl --context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} apply -f test-configs/additional-resources/${{matrix.configuration}}
+            kubectl --context kind-${{ steps.cluster.outputs.name }} apply -f test-configs/additional-resources/${{matrix.configuration}}
           else
             echo "No additional resources to be applied for ${{matrix.configuration}}"
           fi
@@ -107,5 +122,5 @@ jobs:
           ct install --namespace default \
           --charts ./charts/wandb-base \
           --config ct.yaml \
-          --helm-extra-args '--kube-context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} --timeout 600s' \
+          --helm-extra-args '--kube-context kind-${{ steps.cluster.outputs.name }} --timeout 600s' \
           --helm-extra-set-args '--values test-configs/wandb-base/${{ matrix.configuration }}.yaml'

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -43,14 +43,15 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
-        configuration: [
-            env-values-example
-            env-precedence-container
-            env-precedence-sizing
-            env-precedence-chart-env
-            env-precedence-chart-legacy
-            env-precedence-global-env
-            env-precedence-global-legacy,
+        configuration:
+          [
+            "env-values-example",
+            "env-precedence-container",
+            "env-precedence-sizing",
+            "env-precedence-chart-env",
+            "env-precedence-chart-legacy",
+            "env-precedence-global-env",
+            "env-precedence-global-legacy",
           ]
     runs-on: ubuntu-latest
     environment: Helm Charts
@@ -96,7 +97,7 @@ jobs:
           ")
 
           export NAME="ct-${HASH}"
-          echo "::set-output name=name::${NAME}"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
           echo "Matrix: $MATRIX_STRING -> Hash: $HASH -> Name: $NAME"
 
       - name: Create kind cluster

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -25,8 +25,8 @@ jobs:
 
           helm plugin install https://github.com/origranot/helm-cascade
           helm plugin install https://github.com/jlandowner/helm-chartsnap
-          ./snapshots.sh build
-          ./snapshots.sh run
+          ./snapshots.sh build wandb-base
+          ./snapshots.sh run wandb-base
 
   test:
     name: Test Chart

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -57,7 +57,7 @@ jobs:
     environment: Helm Charts
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine Kind Cluster Name

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -1,0 +1,106 @@
+name: Test operator-wandb Chart
+
+on:
+  pull_request:
+    paths:
+      - charts/operator-wandb/**
+      - test-configs/wandb-base/**
+
+jobs:
+  snapshots:
+    name: Snapshot testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.17.0
+      - name: Helm snapshot build and test
+        run: |
+          pushd ./charts/operator-wandb/
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add stakater https://stakater.github.io/stakater-charts
+          helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          popd
+          helm plugin install https://github.com/origranot/helm-cascade
+          helm plugin install https://github.com/jlandowner/helm-chartsnap
+          ./snapshots.sh build
+          ./snapshots.sh run
+      # currently this action always tries to install helm, so dont use it for now
+      - name: Chart Snapshots
+        if: ${{ !always() }}
+        uses: jlandowner/helm-chartsnap-action@v1
+        id: chartsnap
+        with:
+          chart: charts/wandb-base/
+          values: test-configs/wandb-base/
+
+  test:
+    name: Test Chart
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
+        configuration:
+          [
+          ]
+    runs-on: ubuntu-latest
+    environment: Helm Charts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.17.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+        with:
+          version: v3.12.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.12.0
+        with:
+          version: v0.27.0
+          cluster_name: chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }}
+          node_image: kindest/node:${{ matrix.k8s-version }}
+        if: env.ACT || steps.list-changed.outputs.changed == 'true'
+
+      - name: Apply user defined secrets
+        run: |
+          if [[ -d test-configs/additional-resources/${{matrix.configuration}} ]]; then
+            kubectl --context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} apply -f test-configs/additional-resources/${{matrix.configuration}}
+          else
+            echo "No additional resources to be applied for ${{matrix.configuration}}"
+          fi
+        if: env.ACT || steps.list-changed.outputs.changed == 'true'
+
+      #- name: Run chart-testing (install)
+      #  env:
+      #    LICENSE: ${{ secrets.LICENSE }}
+      #  if: env.ACT || steps.list-changed.outputs.changed == 'true'
+      #  run: |
+      #    ct install --namespace default \
+      #    --charts ./charts/operator-wandb \
+      #    --config ct.yaml \
+      #    --helm-extra-args '--kube-context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} --timeout 600s' \
+      #    --helm-extra-set-args '--values test-configs/operator-wandb/${{ matrix.configuration }}.yaml --set=license=$LICENSE'

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -19,11 +19,10 @@ jobs:
           version: v3.17.0
       - name: Helm snapshot build and test
         run: |
-          pushd ./charts/operator-wandb/
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add stakater https://stakater.github.io/stakater-charts
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
-          popd
+
           helm plugin install https://github.com/origranot/helm-cascade
           helm plugin install https://github.com/jlandowner/helm-chartsnap
           ./snapshots.sh build

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -27,14 +27,6 @@ jobs:
           helm plugin install https://github.com/jlandowner/helm-chartsnap
           ./snapshots.sh build
           ./snapshots.sh run
-      # currently this action always tries to install helm, so dont use it for now
-      - name: Chart Snapshots
-        if: ${{ !always() }}
-        uses: jlandowner/helm-chartsnap-action@v1
-        id: chartsnap
-        with:
-          chart: charts/wandb-base/
-          values: test-configs/wandb-base/
 
   test:
     name: Test Chart
@@ -43,15 +35,13 @@ jobs:
       matrix:
         k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
         configuration:
-          [
-            "env-values-example",
-            "env-precedence-container",
-            "env-precedence-sizing",
-            "env-precedence-chart-env",
-            "env-precedence-chart-legacy",
-            "env-precedence-global-env",
-            "env-precedence-global-legacy",
-          ]
+          - env-values-example
+          - env-precedence-container
+          - env-precedence-sizing
+          - env-precedence-chart-env
+          - env-precedence-chart-legacy
+          - env-precedence-global-env
+          - env-precedence-global-legacy
     runs-on: ubuntu-latest
     environment: Helm Charts
     steps:

--- a/charts/wandb-base/README.md
+++ b/charts/wandb-base/README.md
@@ -30,7 +30,7 @@ Environment variables can be defined at multiple levels, with the following prec
 5. Global environment variables (`global.env`)
 6. Legacy global environment variables (`global.extraEnv`)
 
-Example:
+#### Examples Of `env` at different levels
 
 ```yaml
 # Global environment variables (lowest precedence)
@@ -51,6 +51,71 @@ containers:
 ```
 
 In this example, the `LOG_LEVEL` for the `app` container would be set to `trace`.
+
+#### Examples of different `env` values:
+At any of the difference env levels shown above the following patterns are allowed.
+
+[k8s ref envvar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#envvar-v1-core)
+[k8s ref valueFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#envvarsource-v1-core)
+
+Basic Key/Value
+```yaml
+env:
+  EXAMPLE: "100"
+```
+
+```yaml
+env:
+  EXAMPLE_ALT:
+    value: "200"
+```
+
+Reference a configmap
+```yaml
+env:
+  EXAMPLE_FROM_CONFIGMAP:
+    valueFrom:
+      configMapKeyRef:
+        name: "my-configmap"
+        key: "configmap-key"
+```
+
+Reference a secret
+```yaml
+env:
+  EXAMPLE_FROM_SECRET:
+    valueFrom:
+      secretKeyRef:
+        name: "my-secret"
+        key: "secret-key"
+```
+
+Reference k8s data (fieldRef)
+Selects a field of the pod: supports `metadata.name`, `metadata.namespace`, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, `spec.nodeName`, `spec.serviceAccountName`, `status.hostIP`, `status.podIP`, `status.podIPs`
+```yaml
+env:
+  EXAMPLE_FROM_FIELD_REF:
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  # practical example
+  DD_AGENT_HOST:
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+```
+
+Reference k8s data (resourceFieldRef)
+Selects a resource of the container: only resources limits and requests (`limits.cpu`, `limits.memory`, `limits.ephemeral-storage`, `requests.cpu`, `requests.memory` and `requests.ephemeral-storage`) are currently supported.
+```yaml
+env:
+  EXAMPLE_FROM_RESOURCE_FIELD_REF:
+    valueFrom:
+      resourceFieldRef:
+        resource: limits.memory
+```
+
+#### Examples of `envFrom` to set groups of env vars at once
 
 Additionally, environment variables can be sourced from ConfigMaps and Secrets using the `envFrom` field:
 

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -1,12 +1,13 @@
 {{- if and .Values.test.enabled (eq .Values.kind "Job") }}
   {{- range $jobName, $job := .Values.jobs }}
     {{- $job := mergeOverwrite (dict "enabled" true) $job}}
+    {{- $fullname := include "wandb-base.fullname" $ }}
     {{- if $job.enabled }}
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "wandb-base.fullname" $ }}-test-job-{{ $jobName }}"
+  name: "{{ $fullname }}-test-job-{{ $jobName }}"
   labels:
     {{- include "wandb-base.labels" $ | nindent 4 }}
   annotations:
@@ -21,30 +22,34 @@ spec:
         - -c
         - |
           set -e
-          echo "Testing job: {{ printf "%s-%s" $.Release.Name $jobName }}"
-          
-          # Wait for the job to exist
+          echo "Testing job: {{ printf "%s-%s" $fullname $jobName }}"
+
           echo "Waiting for job to be created..."
-          kubectl wait --for=condition=Ready job/{{ printf "%s-%s" $.Release.Name $jobName }} --timeout=300s || true
-          
-          # Wait for the job to complete successfully
+          i=0
+          until kubectl get job/{{ printf "%s-%s" $fullname $jobName }} >/dev/null 2>&1; do
+            i=$((i+1))
+            if [ "$i" -ge 60 ]; then
+              echo "Timed out waiting for job creation."
+              exit 1
+            fi
+            sleep 5
+          done
+
           echo "Waiting for job to complete successfully..."
-          kubectl wait --for=condition=complete job/{{ printf "%s-%s" $.Release.Name $jobName }} --timeout=600s
-          
-          # Verify the job completed successfully (not failed)
+          kubectl wait --for=condition=complete job/{{ printf "%s-%s" $fullname $jobName }} --timeout=600s
+
           echo "Verifying job completed successfully..."
-          JOB_STATUS=$(kubectl get job {{ printf "%s-%s" $.Release.Name $jobName }} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
+          JOB_STATUS=$(kubectl get job {{ printf "%s-%s" $fullname $jobName }} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
           if [ "$JOB_STATUS" != "True" ]; then
             echo "Job did not complete successfully. Current status:"
-            kubectl describe job {{ printf "%s-%s" $.Release.Name $jobName }}
+            kubectl describe job {{ printf "%s-%s" $fullname $jobName }}
             exit 1
           fi
-          
-          echo "Job {{ printf "%s-%s" $.Release.Name $jobName }} completed successfully!"
-          
-          # Optional: Show job logs for debugging
+
+          echo "Job {{ printf "%s-%s" $fullname $jobName }} completed successfully!"
+
           echo "Job logs:"
-          kubectl logs job/{{ printf "%s-%s" $.Release.Name $jobName }} --tail=50 || echo "No logs available"
+          kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} --tail=50 || echo "No logs available"
   restartPolicy: Never
     {{- end }}
   {{- end }}

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -28,12 +28,12 @@ spec:
           until kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} >/dev/null 2>&1; do
             i=$((i+1))
             if [ "$i" -ge 60 ]; then
-              echo "Timed out polling for logs."
+              echo "Timed out waiting for job logs."
               exit 1
             fi
             sleep 5
+          done
 
-          #kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} --tail=50 || echo "No logs available"
   restartPolicy: Never
     {{- end }}
   {{- end }}

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.test.enabled (eq .Values.kind "Job") }}
+  {{- range $jobName, $job := .Values.jobs }}
+    {{- $job := mergeOverwrite (dict "enabled" true) $job}}
+    {{- if $job.enabled }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "wandb-base.fullname" $ }}-test-job-{{ $jobName }}"
+  labels:
+    {{- include "wandb-base.labels" $ | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  containers:
+    - name: job-test
+      image: bitnami/kubectl:latest
+      command: ['/bin/sh']
+      args:
+        - -c
+        - |
+          set -e
+          echo "Testing job: {{ printf "%s-%s" $.Release.Name $jobName }}"
+          
+          # Wait for the job to exist
+          echo "Waiting for job to be created..."
+          kubectl wait --for=condition=Ready job/{{ printf "%s-%s" $.Release.Name $jobName }} --timeout=300s || true
+          
+          # Wait for the job to complete successfully
+          echo "Waiting for job to complete successfully..."
+          kubectl wait --for=condition=complete job/{{ printf "%s-%s" $.Release.Name $jobName }} --timeout=600s
+          
+          # Verify the job completed successfully (not failed)
+          echo "Verifying job completed successfully..."
+          JOB_STATUS=$(kubectl get job {{ printf "%s-%s" $.Release.Name $jobName }} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
+          if [ "$JOB_STATUS" != "True" ]; then
+            echo "Job did not complete successfully. Current status:"
+            kubectl describe job {{ printf "%s-%s" $.Release.Name $jobName }}
+            exit 1
+          fi
+          
+          echo "Job {{ printf "%s-%s" $.Release.Name $jobName }} completed successfully!"
+          
+          # Optional: Show job logs for debugging
+          echo "Job logs:"
+          kubectl logs job/{{ printf "%s-%s" $.Release.Name $jobName }} --tail=50 || echo "No logs available"
+  restartPolicy: Never
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -35,6 +35,14 @@ spec:
             sleep 5
           done
 
+          echo "Waiting for job pod to be ready..."
+          kubectl wait --for=condition=Ready pod -l job-name={{ printf "%s-%s" $fullname $jobName }} --timeout=300s || {
+            echo "Job pod failed to become ready. Checking pod status:"
+            kubectl get pods -l job-name={{ printf "%s-%s" $fullname $jobName }}
+            kubectl describe pod -l job-name={{ printf "%s-%s" $fullname $jobName }}
+            exit 1
+          }
+
           echo "Waiting for job to complete successfully..."
           kubectl wait --for=condition=complete job/{{ printf "%s-%s" $fullname $jobName }} --timeout=600s
 

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.test.enabled (eq .Values.kind "Job") }}
+{{- if eq .Values.kind "Job" }}
   {{- range $jobName, $job := .Values.jobs }}
     {{- $job := mergeOverwrite (dict "enabled" true) $job}}
     {{- $fullname := include "wandb-base.fullname" $ }}

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -70,6 +70,13 @@ spec:
             fi
             sleep 5
           done
+          if ! kubectl wait --for=condition=complete job/{{ printf "%s-%s" $fullname $jobName }} --timeout=600s; then
+            echo "Job {{ printf "%s-%s" $fullname $jobName }} did not complete successfully."
+            kubectl describe job/{{ printf "%s-%s" $fullname $jobName }} || true
+            kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} --tail=200 || true
+            exit 1
+          fi
+          echo "Job {{ printf "%s-%s" $fullname $jobName }} completed successfully."
 
   restartPolicy: Never
     {{- end }}

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -5,6 +5,42 @@
     {{- if $job.enabled }}
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ $fullname }}-test-job-{{ $jobName }}-sa"
+  labels:
+    {{- include "wandb-base.labels" $ | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ $fullname }}-test-job-{{ $jobName }}-role"
+  labels:
+    {{- include "wandb-base.labels" $ | nindent 4 }}
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $fullname }}-test-job-{{ $jobName }}-binding"
+  labels:
+    {{- include "wandb-base.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ $fullname }}-test-job-{{ $jobName }}-role"
+subjects:
+- kind: ServiceAccount
+  name: "{{ $fullname }}-test-job-{{ $jobName }}-sa"
+  namespace: {{ $.Release.Namespace }}
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ $fullname }}-test-job-{{ $jobName }}"
@@ -14,6 +50,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-weight": "1"
 spec:
+  serviceAccountName: "{{ $fullname }}-test-job-{{ $jobName }}-sa"
   containers:
     - name: job-test
       image: bitnami/kubectl:latest
@@ -25,7 +62,7 @@ spec:
           echo "Testing job: {{ printf "%s-%s" $fullname $jobName }}"
 
           i=0
-          until kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} >/dev/null 2>&1; do
+          until kubectl logs job/{{ printf "%s-%s" $fullname $jobName }}; do
             i=$((i+1))
             if [ "$i" -ge 60 ]; then
               echo "Timed out waiting for job logs."

--- a/charts/wandb-base/templates/tests/test-jobs.yaml
+++ b/charts/wandb-base/templates/tests/test-jobs.yaml
@@ -24,40 +24,16 @@ spec:
           set -e
           echo "Testing job: {{ printf "%s-%s" $fullname $jobName }}"
 
-          echo "Waiting for job to be created..."
           i=0
-          until kubectl get job/{{ printf "%s-%s" $fullname $jobName }} >/dev/null 2>&1; do
+          until kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} >/dev/null 2>&1; do
             i=$((i+1))
             if [ "$i" -ge 60 ]; then
-              echo "Timed out waiting for job creation."
+              echo "Timed out polling for logs."
               exit 1
             fi
             sleep 5
-          done
 
-          echo "Waiting for job pod to be ready..."
-          kubectl wait --for=condition=Ready pod -l job-name={{ printf "%s-%s" $fullname $jobName }} --timeout=300s || {
-            echo "Job pod failed to become ready. Checking pod status:"
-            kubectl get pods -l job-name={{ printf "%s-%s" $fullname $jobName }}
-            kubectl describe pod -l job-name={{ printf "%s-%s" $fullname $jobName }}
-            exit 1
-          }
-
-          echo "Waiting for job to complete successfully..."
-          kubectl wait --for=condition=complete job/{{ printf "%s-%s" $fullname $jobName }} --timeout=600s
-
-          echo "Verifying job completed successfully..."
-          JOB_STATUS=$(kubectl get job {{ printf "%s-%s" $fullname $jobName }} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
-          if [ "$JOB_STATUS" != "True" ]; then
-            echo "Job did not complete successfully. Current status:"
-            kubectl describe job {{ printf "%s-%s" $fullname $jobName }}
-            exit 1
-          fi
-
-          echo "Job {{ printf "%s-%s" $fullname $jobName }} completed successfully!"
-
-          echo "Job logs:"
-          kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} --tail=50 || echo "No logs available"
+          #kubectl logs job/{{ printf "%s-%s" $fullname $jobName }} --tail=50 || echo "No logs available"
   restartPolicy: Never
     {{- end }}
   {{- end }}

--- a/snapshots.sh
+++ b/snapshots.sh
@@ -30,7 +30,7 @@ EOF
 }
 
 function main() {
-  local chart="operator-wandb"
+  local charts=("wandb-base" "operator-wandb")
   local values_dir="test-configs"
 
   if [ $# -eq 0 ]; then
@@ -39,24 +39,27 @@ function main() {
   fi
 
   local func="$1"
-  case "$func" in
-    build)
-      echo "Building operator-wandb"
-      helm cascade build "./charts/$chart"
-      ;;
-    update)
-      echo "Updating operator-wandb snapshots"
-      helm chartsnap -c "./charts/$chart" -u -f "./$values_dir/$chart"
-      ;;
-    run)
-      echo "Checking snapshot tests"
-      helm chartsnap -c "./charts/$chart" -f "./$values_dir/$chart"
-      ;;
-    *)
-      usage
-      exit 1
-      ;;
-  esac
+
+  for chart in "${charts[@]}"; do
+    case "$func" in
+      build)
+        echo "Building operator-wandb"
+        helm cascade build "./charts/$chart"
+        ;;
+      update)
+        echo "Updating operator-wandb snapshots"
+        helm chartsnap -c "./charts/$chart" -u -f "./$values_dir/$chart"
+        ;;
+      run)
+        echo "Checking snapshot tests"
+        helm chartsnap -c "./charts/$chart" -f "./$values_dir/$chart"
+        ;;
+      *)
+        usage
+        exit 1
+        ;;
+    esac
+  done
 }
 
 main "$@"

--- a/snapshots.sh
+++ b/snapshots.sh
@@ -20,7 +20,7 @@ function usage() {
   cat <<EOF
 A helper script for the helm-chartsnap plugin https://github.com/jlandowner/helm-chartsnap
 
-Usage: $0 [COMMAND]
+Usage: $0 [COMMAND] [optional: CHART (ex: operator-wandb)]
 
 Commands:
   build,    build the operator-wandb chart
@@ -29,7 +29,28 @@ Commands:
 EOF
 }
 
+function build_chart() {
+  local chart="$1"
+  echo "Building $chart"
+  helm cascade build "./charts/$chart"
+}
+
+function update_chart() {
+  local chart="$1"
+  local values_file="$2"
+  echo "updating $chart snapshots"
+  helm chartsnap -c "./charts/$chart" -u -f "$values_file"
+}
+
+function run_chart() {
+  local chart="$1"
+  local values_file="$2"
+  echo "Checking $chart snapshot tests"
+  helm chartsnap -c "./charts/$chart" -f "$values_file"
+}
+
 function main() {
+  local func="$1"
   local charts=("wandb-base" "operator-wandb")
   local values_dir="test-configs"
 
@@ -38,21 +59,20 @@ function main() {
     exit 1
   fi
 
-  local func="$1"
+  if [ -n "$2"  ]; then
+    charts=("$2")
+  fi
 
   for chart in "${charts[@]}"; do
     case "$func" in
       build)
-        echo "Building $chart"
-        helm cascade build "./charts/$chart"
+        build_chart "$chart"
         ;;
       update)
-        echo "Updating $chart snapshots"
-        helm chartsnap -c "./charts/$chart" -u -f "./$values_dir/$chart"
+        update_chart "$chart" "./$values_dir/$chart"
         ;;
       run)
-        echo "Checking $chart snapshot tests"
-        helm chartsnap -c "./charts/$chart" -f "./$values_dir/$chart"
+        run_chart "$chart" "./$values_dir/$chart"
         ;;
       *)
         usage

--- a/snapshots.sh
+++ b/snapshots.sh
@@ -43,15 +43,15 @@ function main() {
   for chart in "${charts[@]}"; do
     case "$func" in
       build)
-        echo "Building operator-wandb"
+        echo "Building $chart"
         helm cascade build "./charts/$chart"
         ;;
       update)
-        echo "Updating operator-wandb snapshots"
+        echo "Updating $chart snapshots"
         helm chartsnap -c "./charts/$chart" -u -f "./$values_dir/$chart"
         ;;
       run)
-        echo "Checking snapshot tests"
+        echo "Checking $chart snapshot tests"
         helm chartsnap -c "./charts/$chart" -f "./$values_dir/$chart"
         ;;
       *)

--- a/test-configs/additional-resources/env-values-example/configmap.yaml
+++ b/test-configs/additional-resources/env-values-example/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+data:
+  configmap-key: "test"

--- a/test-configs/additional-resources/env-values-example/secret.yaml
+++ b/test-configs/additional-resources/env-values-example/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+stringData:
+  secret-key: "test"

--- a/test-configs/wandb-base/.chartsnap.yaml
+++ b/test-configs/wandb-base/.chartsnap.yaml
@@ -1,0 +1,4 @@
+dynamicFields:
+  - jsonPath:
+    - /metadata/labels/helm.sh~1chart
+    value: '###CHART_VERSION###'

--- a/test-configs/wandb-base/__snapshots__/env-precedence-chart-env.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-chart-env.snap
@@ -1,0 +1,107 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          echo "EXAMPLE=$EXAMPLE"
+          EXPECTED="400"
+          if [ "$EXAMPLE" = "$EXPECTED" ]; then
+            echo "Value is $EXPECTED"
+            exit 0
+          else
+            echo "Value is NOT $EXPECTED"
+            exit 1
+          fi
+        envFrom:
+        env:
+        - name: EXAMPLE
+          value: "400"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-precedence-chart-env.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-chart-env.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -105,3 +153,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/__snapshots__/env-precedence-chart-legacy.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-chart-legacy.snap
@@ -1,0 +1,107 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          echo "EXAMPLE=$EXAMPLE"
+          EXPECTED="300"
+          if [ "$EXAMPLE" = "$EXPECTED" ]; then
+            echo "Value is $EXPECTED"
+            exit 0
+          else
+            echo "Value is NOT $EXPECTED"
+            exit 1
+          fi
+        envFrom:
+        env:
+        - name: EXAMPLE
+          value: "300"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-precedence-chart-legacy.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-chart-legacy.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -105,3 +153,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/__snapshots__/env-precedence-container.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-container.snap
@@ -1,0 +1,107 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          echo "EXAMPLE=$EXAMPLE"
+          EXPECTED="600"
+          if [ "$EXAMPLE" = "$EXPECTED" ]; then
+            echo "Value is $EXPECTED"
+            exit 0
+          else
+            echo "Value is NOT $EXPECTED"
+            exit 1
+          fi
+        envFrom:
+        env:
+        - name: EXAMPLE
+          value: "600"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-precedence-container.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-container.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -105,3 +153,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/__snapshots__/env-precedence-global-env.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-global-env.snap
@@ -1,0 +1,107 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          echo "EXAMPLE=$EXAMPLE"
+          EXPECTED="200"
+          if [ "$EXAMPLE" = "$EXPECTED" ]; then
+            echo "Value is $EXPECTED"
+            exit 0
+          else
+            echo "Value is NOT $EXPECTED"
+            exit 1
+          fi
+        envFrom:
+        env:
+        - name: EXAMPLE
+          value: "200"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-precedence-global-env.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-global-env.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -105,3 +153,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/__snapshots__/env-precedence-global-legacy.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-global-legacy.snap
@@ -1,0 +1,107 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          echo "EXAMPLE=$EXAMPLE"
+          EXPECTED="100"
+          if [ "$EXAMPLE" = "$EXPECTED" ]; then
+            echo "Value is $EXPECTED"
+            exit 0
+          else
+            echo "Value is NOT $EXPECTED"
+            exit 1
+          fi
+        envFrom:
+        env:
+        - name: EXAMPLE
+          value: "100"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-precedence-global-legacy.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-global-legacy.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -105,3 +153,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/__snapshots__/env-precedence-sizing.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-sizing.snap
@@ -1,0 +1,107 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          echo "EXAMPLE=$EXAMPLE"
+          EXPECTED="500"
+          if [ "$EXAMPLE" = "$EXPECTED" ]; then
+            echo "Value is $EXPECTED"
+            exit 0
+          else
+            echo "Value is NOT $EXPECTED"
+            exit 1
+          fi
+        envFrom:
+        env:
+        - name: EXAMPLE
+          value: "400"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-precedence-sizing.snap
+++ b/test-configs/wandb-base/__snapshots__/env-precedence-sizing.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -105,3 +153,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/__snapshots__/env-values-example.snap
+++ b/test-configs/wandb-base/__snapshots__/env-values-example.snap
@@ -1,0 +1,146 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: wandb-base-0.11.0
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: example
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          if [ "$USED_NAMESPACE" = "default" ]; then
+            echo "fieldRef test"
+          else
+            echo "fieldRef test failed"
+            exit 1
+          fi
+          if [ "$MEM_LIMIT" = "1073741824" ]; then
+            echo "resourceFieldRef test"
+          else
+            echo "resourceFieldRef test failed"
+            exit 1
+          fi
+          if [ "$BASIC" = "$BASIC_ALT" ]; then
+            echo "Basic test"
+          else
+            echo "Basic test failed"
+            exit 1
+          fi
+          if [ "$EXAMPLE_FROM_CONFIGMAP" = "$EXAMPLE_FROM_SECRET" ]; then
+            echo "configmap/secret test"
+          else
+            echo "configmap/secret test failed"
+            exit 1
+          fi
+          exit 0
+        envFrom:
+        env:
+        - name: BASIC
+          value: "600"
+        - name: BASIC_ALT
+          value: "600"
+        - name: EXAMPLE_FROM_CONFIGMAP
+          valueFrom:
+            configMapKeyRef:
+              key: configmap-key
+              name: my-configmap
+        - name: EXAMPLE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret-key
+              name: my-secret
+        - name: MEM_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: USED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+        resources:
+          limits:
+            memory: 1Gi
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/__snapshots__/env-values-example.snap
+++ b/test-configs/wandb-base/__snapshots__/env-values-example.snap
@@ -32,6 +32,54 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-role"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "chartsnap-wandb-base-test-job-test-binding"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "chartsnap-wandb-base-test-job-test-role"
+subjects:
+- kind: ServiceAccount
+  name: "chartsnap-wandb-base-test-job-test-sa"
+  namespace: default
+---
 # Source: wandb-base/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -144,3 +192,39 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/tests/test-jobs.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-wandb-base-test-job-test"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+spec:
+  serviceAccountName: "chartsnap-wandb-base-test-job-test-sa"
+  containers:
+  - name: job-test
+    image: bitnami/kubectl:latest
+    command: ['/bin/sh']
+    args:
+    - -c
+    - |
+      set -e
+      echo "Testing job: chartsnap-wandb-base-test"
+
+      i=0
+      until kubectl logs job/chartsnap-wandb-base-test; do
+        i=$((i+1))
+        if [ "$i" -ge 60 ]; then
+          echo "Timed out waiting for job logs."
+          exit 1
+        fi
+        sleep 5
+      done
+  restartPolicy: Never

--- a/test-configs/wandb-base/env-precedence-chart-env.yaml
+++ b/test-configs/wandb-base/env-precedence-chart-env.yaml
@@ -1,0 +1,34 @@
+global:
+  extraEnv:
+    EXAMPLE: "100"
+  env:
+    EXAMPLE: "200"
+
+extraEnv:
+  EXAMPLE: "300"
+
+env:
+  EXAMPLE: "400"
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            echo "EXAMPLE=$EXAMPLE"
+            EXPECTED="400"
+            if [ "$EXAMPLE" = "$EXPECTED" ]; then
+              echo "Value is $EXPECTED"
+              exit 0
+            else
+              echo "Value is NOT $EXPECTED"
+              exit 1
+            fi

--- a/test-configs/wandb-base/env-precedence-chart-legacy.yaml
+++ b/test-configs/wandb-base/env-precedence-chart-legacy.yaml
@@ -1,0 +1,31 @@
+global:
+  extraEnv:
+    EXAMPLE: "100"
+  env:
+    EXAMPLE: "200"
+
+extraEnv:
+  EXAMPLE: "300"
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            echo "EXAMPLE=$EXAMPLE"
+            EXPECTED="300"
+            if [ "$EXAMPLE" = "$EXPECTED" ]; then
+              echo "Value is $EXPECTED"
+              exit 0
+            else
+              echo "Value is NOT $EXPECTED"
+              exit 1
+            fi

--- a/test-configs/wandb-base/env-precedence-container.yaml
+++ b/test-configs/wandb-base/env-precedence-container.yaml
@@ -1,0 +1,43 @@
+global:
+  extraEnv:
+    EXAMPLE: "100"
+  env:
+    EXAMPLE: "200"
+
+extraEnv:
+  EXAMPLE: "300"
+
+env:
+  EXAMPLE: "400"
+
+size: "small"
+
+sizing:
+  small:
+    env:
+      EXAMPLE: "500"
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            echo "EXAMPLE=$EXAMPLE"
+            EXPECTED="600"
+            if [ "$EXAMPLE" = "$EXPECTED" ]; then
+              echo "Value is $EXPECTED"
+              exit 0
+            else
+              echo "Value is NOT $EXPECTED"
+              exit 1
+            fi
+        env:
+          EXAMPLE: "600"

--- a/test-configs/wandb-base/env-precedence-global-env.yaml
+++ b/test-configs/wandb-base/env-precedence-global-env.yaml
@@ -1,0 +1,28 @@
+global:
+  extraEnv:
+    EXAMPLE: "100"
+  env:
+    EXAMPLE: "200"
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            echo "EXAMPLE=$EXAMPLE"
+            EXPECTED="200"
+            if [ "$EXAMPLE" = "$EXPECTED" ]; then
+              echo "Value is $EXPECTED"
+              exit 0
+            else
+              echo "Value is NOT $EXPECTED"
+              exit 1
+            fi

--- a/test-configs/wandb-base/env-precedence-global-legacy.yaml
+++ b/test-configs/wandb-base/env-precedence-global-legacy.yaml
@@ -1,0 +1,26 @@
+global:
+  extraEnv:
+    EXAMPLE: "100"
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            echo "EXAMPLE=$EXAMPLE"
+            EXPECTED="100"
+            if [ "$EXAMPLE" = "$EXPECTED" ]; then
+              echo "Value is $EXPECTED"
+              exit 0
+            else
+              echo "Value is NOT $EXPECTED"
+              exit 1
+            fi

--- a/test-configs/wandb-base/env-precedence-sizing.yaml
+++ b/test-configs/wandb-base/env-precedence-sizing.yaml
@@ -1,0 +1,41 @@
+global:
+  extraEnv:
+    EXAMPLE: "100"
+  env:
+    EXAMPLE: "200"
+
+extraEnv:
+  EXAMPLE: "300"
+
+env:
+  EXAMPLE: "400"
+
+size: "small"
+
+sizing:
+  small:
+    env:
+      EXAMPLE: "500"
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            echo "EXAMPLE=$EXAMPLE"
+            EXPECTED="500"
+            if [ "$EXAMPLE" = "$EXPECTED" ]; then
+              echo "Value is $EXPECTED"
+              exit 0
+            else
+              echo "Value is NOT $EXPECTED"
+              exit 1
+            fi

--- a/test-configs/wandb-base/env-values-example.yaml
+++ b/test-configs/wandb-base/env-values-example.yaml
@@ -1,0 +1,77 @@
+global:
+  env:
+    USED_NAMESPACE:
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+
+env:
+  EXAMPLE_FROM_CONFIGMAP:
+    valueFrom:
+      configMapKeyRef:
+        name: "my-configmap"
+        key: "configmap-key"
+  EXAMPLE_FROM_SECRET:
+    valueFrom:
+      secretKeyRef:
+        name: "my-secret"
+        key: "secret-key"
+
+size: "small"
+
+sizing:
+  small:
+    resources:
+      limits:
+        memory: 1Gi
+    env:
+      MEM_LIMIT:
+        valueFrom:
+          resourceFieldRef:
+            resource: limits.memory
+
+kind: Job
+jobs:
+  test:
+    containers:
+      example:
+        image:
+          repository: debian
+          tag: 12-slim
+        command:
+          - /bin/bash
+        args:
+          - -c
+          - |
+            if [ "$USED_NAMESPACE" = "default" ]; then
+              echo "fieldRef test"
+            else
+              echo "fieldRef test failed"
+              exit 1
+            fi
+            if [ "$MEM_LIMIT" = "1073741824" ]; then
+              echo "resourceFieldRef test"
+            else
+              echo "resourceFieldRef test failed"
+              exit 1
+            fi
+            if [ "$BASIC" = "$BASIC_ALT" ]; then
+              echo "Basic test"
+            else
+              echo "Basic test failed"
+              exit 1
+            fi
+            if [ "$EXAMPLE_FROM_CONFIGMAP" = "$EXAMPLE_FROM_SECRET" ]; then
+              echo "configmap/secret test"
+            else
+              echo "configmap/secret test failed"
+              exit 1
+            fi
+            exit 0
+
+        env:
+          BASIC: "600"
+          BASIC_ALT:
+            value: "600"
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded chart README with extensive env/envFrom examples and precedence patterns.

* **Tests**
  * Added many wandb-base test configs validating env precedence, sizing, and multi-source env propagation.
  * Added sample ConfigMap and Secret test resources.
  * Added Helm-driven test Pod template to exercise Job logs and lifecycle.
  * Added chart-version extraction for snapshot tooling.

* **New Features**
  * Snapshot tooling now supports multi-chart operations and per-chart commands.

* **Chores**
  * Added CI workflow for matrix Kind/Helm end-to-end testing with conditional cluster runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->