### PR TITLE
fix(launch-agent): don't add WANDB_API_KEY env var if using oidc

### DIFF
--- a/charts/launch-agent/Chart.yaml
+++ b/charts/launch-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: launch-agent
 icon: https://em-content.zobj.net/thumbs/240/apple/354/rocket_1f680.png
 description: A Helm chart for running the W&B Launch Agent in Kubernetes
 type: application
-version: 0.13.13
+version: 0.13.14
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/charts/launch-agent/templates/deployment.yaml
+++ b/charts/launch-agent/templates/deployment.yaml
@@ -65,11 +65,13 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           env:
+            {{- if not .Values.oidc.enabled }}
             - name: WANDB_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: wandb-api-key-{{ .Release.Name }}
                   key: password
+            {{- end }}
             - name: WANDB_LAUNCH_SERVICE_ACCOUNT_NAME
               valueFrom:
                 fieldRef:

--- a/charts/launch-agent/templates/secret.yaml
+++ b/charts/launch-agent/templates/secret.yaml
@@ -12,7 +12,7 @@ metadata:
     wandb.ai/created-by: helm-chart
 type: kubernetes.io/basic-auth
 stringData:
-  password: {{ required "Please set agent.apiKey to a W&B API key" $root.Values.agent.apiKey }}
+  password: {{ if not $root.Values.oidc.enabled }}{{ required "Please set agent.apiKey to a W&B API key" $root.Values.agent.apiKey }}{{ else }}{{ $root.Values.agent.apiKey }}{{ end }}
 ...
 {{ end }}
 


### PR DESCRIPTION
This PR removes the WANDB_API_KEY env var from the agent deployment and the api key k8s secret if oidc is enabled. This is due to new behavior in the SDK that validates the api key if the WANDB_API_KEY env var is present.

Tested in QA