### PR TITLE
fix: Add /tmp emptyDir for services using the wandb-sdk

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.35.8
+version: 0.35.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1829,6 +1829,8 @@ weave:
         failureThreshold: 12
         periodSeconds: 10
       volumeMounts:
+        - name: temp-dir
+          mountPath: /tmp/
         - name: cache
           mountPath: /vol/weave/cache
       volumeMountsTpls:
@@ -1845,9 +1847,13 @@ weave:
           cpu: 100m
           memory: 128Mi
       volumeMounts:
+        - name: temp-dir
+          mountPath: /tmp/
         - name: cache
           mountPath: /vol/weave/cache
   volumes:
+    - name: temp-dir
+      emptyDir: {}
     - name: cache
       emptyDir:
         sizeLimit: "{{ .Values.cache.size }}"
@@ -1944,6 +1950,9 @@ weave-trace:
   initContainers:
     weave-trace-migrate:
       command: ["python", "migrator.py"]
+      volumeMounts:
+        - name: temp-dir
+          mountPath: /tmp/
   containers:
     weave-trace:
       command:
@@ -1977,6 +1986,8 @@ weave-trace:
           containerPort: 8080
           protocol: TCP
       volumeMounts:
+        - name: temp-dir
+          mountPath: /tmp/
         - name: weave-trace-internal-jwt
           mountPath: /tmp/weave-trace/internal-jwt
   service:
@@ -1987,6 +1998,8 @@ weave-trace:
         port: 8722
         protocol: TCP
   volumes:
+    - name: temp-dir
+      emptyDir: {}
     - name: weave-trace-internal-jwt
       projected:
         sources:

--- a/test-configs/operator-wandb/__snapshots__/anaconda2.snap
+++ b/test-configs/operator-wandb/__snapshots__/anaconda2.snap
@@ -3675,6 +3675,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -3706,6 +3708,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -3748,6 +3752,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -3865,6 +3865,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -3896,6 +3898,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -3938,6 +3942,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/executor-enabled.snap
@@ -3956,6 +3956,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -3987,6 +3989,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -4029,6 +4033,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -6600,6 +6600,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -6653,6 +6655,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -6695,6 +6699,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/image-digest-override.snap
@@ -5613,6 +5613,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5640,6 +5642,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5682,6 +5686,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/image-tag-override.snap
@@ -5613,6 +5613,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5640,6 +5642,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5682,6 +5686,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -5714,6 +5714,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5755,6 +5757,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5797,6 +5801,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods-filemeta.snap
@@ -5345,6 +5345,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5376,6 +5378,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5418,6 +5422,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -5077,6 +5077,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5108,6 +5110,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5150,6 +5154,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -3675,6 +3675,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -3706,6 +3708,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -3748,6 +3752,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -1113,7 +1113,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-anaconda2-configmap
 ---
 apiVersion: v1
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-app-configmap
 ---
 apiVersion: v1
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-ca-certs
 ---
 apiVersion: v1
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-executor-configmap
 ---
 apiVersion: v1
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-filestream-configmap
 ---
 apiVersion: v1
@@ -1412,7 +1412,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-local-configmap
 ---
 apiVersion: v1
@@ -3645,6 +3645,8 @@ spec:
             - mountPath: /etc/ssl/certs/redis_ca.pem
               name: redis-ca
               subPath: redis_ca.pem
+            - mountPath: /tmp/
+              name: temp-dir
             - mountPath: /vol/weave/cache
               name: cache
         - command:
@@ -3676,6 +3678,8 @@ spec:
             privileged: false
             readOnlyRootFilesystem: false
           volumeMounts:
+            - mountPath: /tmp/
+              name: temp-dir
             - mountPath: /vol/weave/cache
               name: cache
       priorityClassName: wandb-global-priority
@@ -3719,6 +3723,8 @@ spec:
                 path: redis_ca.pem
             optional: true
             secretName: chartsnap-redis-secret
+        - emptyDir: {}
+          name: temp-dir
         - emptyDir:
             medium: ""
             sizeLimit: 20Gi
@@ -4431,7 +4437,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: operator-wandb-0.35.8
+    helm.sh/chart: operator-wandb-0.35.9
   name: chartsnap-operator-wandb-test-connection
 spec:
   containers:

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -5428,6 +5428,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5459,6 +5461,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       nodeSelector:
@@ -5512,6 +5516,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -5077,6 +5077,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5108,6 +5110,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5150,6 +5154,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -5045,6 +5045,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5076,6 +5078,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5118,6 +5122,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -5929,6 +5929,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /tmp/weave-trace/internal-jwt
           name: weave-trace-internal-jwt
       initContainers:
@@ -5964,6 +5966,9 @@ spec:
           readOnlyRootFilesystem: false
         image: "wandb/weave-trace:latest"
         imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
       serviceAccountName: chartsnap-weave-trace
       securityContext:
         fsGroup: 0
@@ -5990,6 +5995,8 @@ spec:
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
       volumes:
+      - emptyDir: {}
+        name: temp-dir
       - name: weave-trace-internal-jwt
         projected:
           sources:
@@ -6080,6 +6087,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -6111,6 +6120,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -6153,6 +6164,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -5547,6 +5547,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /tmp/weave-trace/internal-jwt
           name: weave-trace-internal-jwt
       initContainers:
@@ -5582,6 +5584,9 @@ spec:
           readOnlyRootFilesystem: false
         image: "wandb/weave-trace:latest"
         imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
       serviceAccountName: chartsnap-weave-trace
       securityContext:
         fsGroup: 0
@@ -5608,6 +5613,8 @@ spec:
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
       volumes:
+      - emptyDir: {}
+        name: temp-dir
       - name: weave-trace-internal-jwt
         projected:
           sources:
@@ -5698,6 +5705,8 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       - name: weave-cache-clear
@@ -5729,6 +5738,8 @@ spec:
             cpu: 100m
             memory: 128Mi
         volumeMounts:
+        - mountPath: /tmp/
+          name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
       serviceAccountName: chartsnap-weave
@@ -5771,6 +5782,8 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+      - emptyDir: {}
+        name: temp-dir
       - emptyDir:
           medium: ''
           sizeLimit: '20Gi'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared temporary storage volume mounted at /tmp across relevant operator components (including weave, weave-trace init/main, and cache-clear) to enable transient data handling during runtime.

* **Chores**
  * Bumped chart version to 0.35.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->