### PR TITLE
feat: Add image tag to environment

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.38.3
+version: 0.38.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -5,7 +5,7 @@
 {{- $allExtraEnvFrom := mergeOverwrite $global $values $local -}}
 {{- range $key, $value := $allExtraEnvFrom }}
 - name: {{ $key }}
-  valueFrom: 
+  valueFrom:
 {{ toYaml $value | nindent 4 }}
 {{- end -}}
 {{- end -}}
@@ -110,7 +110,7 @@ Global values will override any chart-specific values.
 {{- define "wandb.mysqlConfigEnvs" -}}
 {{- /*
   ATTENTION!
-  
+
   MYSQL_PASSWORD, MYSQL_PORT, MYSQL_HOST, MYSQL_DATABASE, MYSQL_USER
 
   Are all set in the the values.yaml under global.mysql.(host,port,database,user,password)

--- a/charts/operator-wandb/templates/api.yaml
+++ b/charts/operator-wandb/templates/api.yaml
@@ -38,3 +38,4 @@ data:
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: {{ tpl (include "wandb.internalJWTMap" .) . }}
   {{- end }}
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "{{ .Values.api.image.tag }}"

--- a/charts/operator-wandb/templates/executor.yaml
+++ b/charts/operator-wandb/templates/executor.yaml
@@ -6,3 +6,4 @@ metadata:
     {{- include "wandb.labels" . | nindent 4 }}
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "{{ .Values.executor.image.tag }}"

--- a/charts/operator-wandb/templates/filemeta.yaml
+++ b/charts/operator-wandb/templates/filemeta.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-filemeta-configmap
+  labels:
+    {{- include "wandb.labels" . | nindent 4 }}
+data:
+  GORILLA_IMAGE_TAG: "{{ .Values.filemeta.image.tag }}"

--- a/charts/operator-wandb/templates/filestream.yaml
+++ b/charts/operator-wandb/templates/filestream.yaml
@@ -4,4 +4,5 @@ metadata:
   name: {{ .Release.Name }}-filestream-configmap
   labels:
     {{- include "wandb.labels" . | nindent 4 }}
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "{{ .Values.filestream.image.tag }}"

--- a/charts/operator-wandb/templates/glue.yaml
+++ b/charts/operator-wandb/templates/glue.yaml
@@ -54,3 +54,4 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "{{ .Values.glue.image.tag }}"

--- a/charts/operator-wandb/templates/metric-observer.yaml
+++ b/charts/operator-wandb/templates/metric-observer.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-flat-run-fields-updater-configmap
+  name: {{ .Release.Name }}-metric-observer-configmap
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
@@ -10,4 +10,4 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
-  GORILLA_IMAGE_TAG: "{{ index .Values "flat-run-fields-updater" "image" "tag" }}"
+  GORILLA_IMAGE_TAG: "{{ index .Values "metric-observer" "image" "tag" }}"

--- a/charts/operator-wandb/templates/parquet.yaml
+++ b/charts/operator-wandb/templates/parquet.yaml
@@ -7,16 +7,18 @@ metadata:
 data:
   # Port configuration
   GORILLA_PARQUET_PORT: "8087"
-  
+
   # RPC path configuration
   GORILLA_PARQUET_RPC_PATH: "/_goRPC_"
   # Task queue configuration
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
-  
+
   # Parquet-specific configuration
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+
+  GORILLA_IMAGE_TAG: "{{ .Values.parquet.image.tag }}"
 
 ---
 apiVersion: v1
@@ -25,4 +27,3 @@ metadata:
   name: {{ .Release.Name }}-parquet-secret
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
-data: {}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -944,6 +944,7 @@ filemeta:
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
     "{{ .Release.Name }}-global-configmap": "configMapRef"
     "{{ .Release.Name }}-global-secret": "secretRef"
+    "{{ .Release.Name }}-filemeta-configmap": "configMapRef"
   envTpls:
     - '{{ include "wandb.downwardEnvs" . }}'
     - '{{ include "wandb.bucket.cwIdentity" . }}'
@@ -1549,7 +1550,7 @@ metric-observer:
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
     "{{ .Release.Name }}-global-configmap": "configMapRef"
     "{{ .Release.Name }}-global-secret": "secretRef"
-    "{{ .Release.Name }}-flat-run-fields-updater-configmap": "configMapRef"
+    "{{ .Release.Name }}-metric-observer-configmap": "configMapRef"
   envTpls:
     - '{{ include "wandb.downwardEnvs" . }}'
     - '{{ include "wandb.bucket.cwIdentity" . }}'

--- a/test-configs/operator-wandb/__snapshots__/dedicated.snap
+++ b/test-configs/operator-wandb/__snapshots__/dedicated.snap
@@ -57,7 +57,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "0.75.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -153,6 +153,48 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
+# Source: operator-wandb/charts/filestream/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-filestream
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: filestream
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: filestream
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/flat-run-fields-updater/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-flat-run-fields-updater
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: flat-run-fields-updater
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.75.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: flat-run-fields-updater
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
 # Source: operator-wandb/charts/frontend/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -192,6 +234,27 @@ spec:
       operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: glue
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/metric-observer/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-metric-observer
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: metric-observer
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: metric-observer
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
@@ -280,7 +343,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "0.75.2"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -336,6 +399,32 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: operator-wandb/charts/filestream/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-filestream
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: filestream
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/flat-run-fields-updater/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-flat-run-fields-updater
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: flat-run-fields-updater
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.75.2"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
 # Source: operator-wandb/charts/frontend/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -357,6 +446,19 @@ metadata:
   labels:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: glue
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/metric-observer/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-metric-observer
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: metric-observer
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -548,7 +650,7 @@ metadata:
   name: "chartsnap-redis-secret"
   labels:
 data:
-  REDIS_PASSWORD: dGVzdCU0MCUzQyUzRSUyNSU3QiU3RCU3QyU1RSUyMiUyMCU1QyUyQnBhc3N3b3Jk
+  REDIS_PASSWORD: cmVkaXMxMjM=
   REDIS_CA_CERT:
 ---
 # Source: operator-wandb/templates/session-key.yaml
@@ -1390,7 +1492,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
-  GORILLA_IMAGE_TAG: "latest"
+  GORILLA_IMAGE_TAG: "0.75.2"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1526,7 +1628,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
-  GORILLA_IMAGE_TAG: "latest"
+  GORILLA_IMAGE_TAG: "0.75.2"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1786,6 +1888,10 @@ data:
         location /bucket {
           proxy_set_header Host minio:9000;
           proxy_pass http://minio:9000;
+        }
+        location /bucket-admin {
+          proxy_set_header Host minio:9090;
+          proxy_pass http://minio:9090;
         }
       }
     }
@@ -2143,7 +2249,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "0.75.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -2211,6 +2317,31 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+---
+# Source: operator-wandb/charts/metric-observer/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-metric-observer
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: metric-observer
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -2288,7 +2419,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "0.75.2"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
@@ -2337,6 +2468,26 @@ subjects:
 roleRef:
   kind: Role
   name: chartsnap-glue
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/metric-observer/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-metric-observer
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: metric-observer
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-metric-observer
+  namespace: default
+roleRef:
+  kind: Role
+  name: chartsnap-metric-observer
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: operator-wandb/charts/reloader/templates/rolebinding.yaml
@@ -2395,7 +2546,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "0.75.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -2792,7 +2943,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: daemonset
-        image: "us-docker.pkg.dev/wandb-production/public/otel/opentelemetry-collector-contrib:0.97.0"
+        image: "otel/opentelemetry-collector-contrib:0.97.0"
         securityContext:
           capabilities:
           allowPrivilegeEscalation: false
@@ -2926,6 +3077,8 @@ spec:
         - configMapRef:
             name: chartsnap-anaconda2-configmap
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: DD_AGENT_HOST
@@ -2938,12 +3091,32 @@ spec:
               fieldPath: status.hostIP
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2951,7 +3124,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
+        image: "wandb/anaconda2:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8082
@@ -3011,7 +3184,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "0.75.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     reloader.stakater.com/auto: "true"
@@ -3032,7 +3205,7 @@ spec:
         helm.sh/chart: api-0.11.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.75.2"
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
@@ -3169,15 +3342,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -3194,6 +3367,8 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
@@ -3204,12 +3379,32 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3217,7 +3412,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:0.75.2"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081
@@ -3389,15 +3584,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -3414,6 +3609,8 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
@@ -3424,12 +3621,32 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3437,7 +3654,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
+        image: "wandb/local:latest"
         imagePullPolicy:
       - name: migrate-db
         command:
@@ -3574,15 +3791,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -3599,6 +3816,8 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
@@ -3609,12 +3828,32 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3622,7 +3861,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:0.75.2"
         imagePullPolicy: IfNotPresent
       serviceAccountName: chartsnap-api
       securityContext:
@@ -3838,15 +4077,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -3863,6 +4102,8 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: BUCKET_QUEUE
@@ -3875,6 +4116,10 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILEMETA_ENABLED
           value: "false"
         - name: GORILLA_FILE_STORE_IS_PROXIED
@@ -3889,12 +4134,28 @@ spec:
           value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
         - name: GORILLA_STORAGE_BUCKET
           value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3902,7 +4163,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
+        image: "wandb/local:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -4099,15 +4360,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -4124,6 +4385,8 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: BUCKET_QUEUE
@@ -4136,6 +4399,10 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILEMETA_ENABLED
           value: "false"
         - name: GORILLA_FILE_STORE_IS_PROXIED
@@ -4150,12 +4417,28 @@ spec:
           value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
         - name: GORILLA_STORAGE_BUCKET
           value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4163,7 +4446,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
+        image: "wandb/local:latest"
         imagePullPolicy:
       serviceAccountName: chartsnap-app
       securityContext:
@@ -4247,16 +4530,38 @@ spec:
         - configMapRef:
             name: chartsnap-console-configmap
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4264,7 +4569,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
+        image: "wandb/console:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8082
@@ -4292,8 +4597,8 @@ spec:
             cpu: "2"
             memory: 2Gi
           requests:
-            cpu: 50m
-            memory: 64Mi
+            cpu: "1"
+            memory: 1Gi
       serviceAccountName: chartsnap-console
       securityContext:
         fsGroup: 0
@@ -4480,15 +4785,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -4505,18 +4810,40 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
         - name: GORILLA_TASK_QUEUE
           value: 'redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)&concurrency=10'
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4524,7 +4851,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -4755,16 +5082,38 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4772,7 +5121,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -4810,6 +5159,574 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/name: filemeta
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+---
+# Source: operator-wandb/charts/filestream/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-filestream-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: filestream
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: filestream
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: filestream-0.11.4
+        app.kubernetes.io/name: filestream
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: filestream
+        args:
+        - filestream
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filestream-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: pubsub:/playground-111/filestream
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: pubsub:/playground-111/run-updates-shadow
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_FILE_STREAM_WORKER_SOURCE_ADDRESS
+          value: 'pubsub:/playground-111/filestream/filestream-gorilla'
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-filestream
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: filestream
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: filestream
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+---
+# Source: operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-flat-run-fields-updater-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: flat-run-fields-updater
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.75.2"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flat-run-fields-updater
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: flat-run-fields-updater-0.11.4
+        app.kubernetes.io/name: flat-run-fields-updater
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "0.75.2"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: flat-run-fields-updater
+        args:
+        - flat-run-fields-updater
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-flat-run-fields-updater-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: pubsub:/playground-111/filestream
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: pubsub:/playground-111/run-updates-shadow
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_FLAT_RUN_FIELDS_UPDATER
+          value: 'pubsub:/playground-111/run-updates-shadow/flat-run-fields-updater'
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "wandb/megabinary:0.75.2"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-flat-run-fields-updater
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: flat-run-fields-updater
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: flat-run-fields-updater
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
@@ -4874,16 +5791,38 @@ spec:
         - secretRef:
             name: chartsnap-global-secret
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4891,7 +5830,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
+        image: "wandb/frontend-nginx:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -5101,15 +6040,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -5126,16 +6065,38 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5143,7 +6104,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -5306,15 +6267,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -5331,16 +6292,38 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5348,7 +6331,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
+        image: "wandb/local:latest"
         imagePullPolicy:
       - name: migrate-db
         command:
@@ -5483,15 +6466,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -5508,16 +6491,38 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5525,7 +6530,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
       serviceAccountName: chartsnap-glue
       securityContext:
@@ -5570,6 +6575,297 @@ spec:
             path: redis_ca.pem
           optional: true
 ---
+# Source: operator-wandb/charts/metric-observer/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-metric-observer
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: metric-observer
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metric-observer
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: metric-observer-0.11.4
+        app.kubernetes.io/name: metric-observer
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: metric-observer
+        args:
+        - metric-observer
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-metric-observer-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: pubsub:/playground-111/filestream
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: pubsub:/playground-111/run-updates-shadow
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: GORILLA_METRIC_OBSERVER_STORE
+          value: 'redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)'
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_METRIC_OBSERVER
+          value: 'pubsub:/playground-111/run-updates-shadow/metric-observer'
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /usr/local/share/ca-certificates/inline
+          name: wandb-ca-certs
+        - mountPath: /usr/local/share/ca-certificates/configmap
+          name: wandb-ca-certs-user
+        - mountPath: /etc/ssl/certs/redis_ca.pem
+          name: redis-ca
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-metric-observer
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: metric-observer
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: metric-observer
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: 'chartsnap-ca-certs'
+        name: wandb-ca-certs
+      - configMap:
+          name: 'noCertProvided'
+          optional: true
+        name: wandb-ca-certs-user
+      - name: redis-ca
+        secret:
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+          secretName: 'chartsnap-redis-secret'
+---
 # Source: operator-wandb/charts/nginx/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -5607,16 +6903,38 @@ spec:
       - name: nginx
         envFrom:
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5624,7 +6942,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
+        image: "nginxinc/nginx-unprivileged:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -5837,15 +7155,15 @@ spec:
               name: chartsnap-kafka
               optional: true
         - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: pubsub:/playground-111/filestream
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+          value: pubsub:/playground-111/run-updates-shadow
         - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
+          value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
         - name: GORILLA_STATSIG_KEY
           valueFrom:
             secretKeyRef:
@@ -5862,16 +7180,38 @@ spec:
             secretKeyRef:
               key: license
               name: chartsnap-license
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5879,7 +7219,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        image: "wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8087
@@ -6103,7 +7443,7 @@ spec:
         version: v1.3.0
     spec:
       containers:
-      - image: "us-docker.pkg.dev/wandb-production/public/stakater/reloader:v1.3.0"
+      - image: "ghcr.io/stakater/reloader:v1.3.0"
         imagePullPolicy: IfNotPresent
         name: chartsnap-reloader
         env:
@@ -6192,16 +7532,38 @@ spec:
         - configMapRef:
             name: chartsnap-weave-configmap
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6209,7 +7571,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
+        image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9994
@@ -6255,16 +7617,38 @@ spec:
         - configMapRef:
             name: chartsnap-weave-configmap
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6272,7 +7656,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
+        image: "wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -6377,7 +7761,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: mysql
-        image: "us-docker.pkg.dev/wandb-production/public/mysql:latest"
+        image: "mysql:8.4"
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -6403,8 +7787,6 @@ spec:
             secretKeyRef:
               name: chartsnap-mysql
               key: MYSQL_ROOT_PASSWORD
-        - name: MYSQL_PASSWORD
-          value: "test@<>%{}|^\" \\\\+password"
         livenessProbe:
           tcpSocket:
             port: 3306
@@ -6431,7 +7813,7 @@ spec:
             cpu: 4000m
             memory: 8Gi
           requests:
-            cpu: 50m
+            cpu: 40m
             memory: 64Mi
       volumes:
       - name: initdb
@@ -6503,7 +7885,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: redis
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/redis:7.2.4-debian-12-r9
+        image: docker.io/bitnamilegacy/redis:7.2.4-debian-12-r9
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -6763,15 +8145,15 @@ spec:
                   name: chartsnap-kafka
                   optional: true
             - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+              value: pubsub:/playground-111/filestream
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-              value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+              value: pubsub:/playground-111/run-updates-shadow
             - name: GORILLA_HISTORY_STORE
-              value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+              value: http://chartsnap-parquet:8087/_goRPC_,bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
             - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+              value: bigtablev3://playground-111/fmbtest,bigtablev2://playground-111/fmbtest
             - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-              value: ""
+              value: bigtablev2://playground-111/fmbtest,bigtablev3://playground-111/fmbtest
             - name: GORILLA_STATSIG_KEY
               valueFrom:
                 secretKeyRef:
@@ -6788,10 +8170,16 @@ spec:
                 secretKeyRef:
                   key: license
                   name: chartsnap-license
+            - name: BIGTABLE_EMULATOR_HOST
+              value: "bigtable-wandb-base:8086"
             - name: BUCKET_PROXY
               value: "true"
             - name: GLOBAL_ADMIN_API_KEY
               value: "local-123456789-123456789-123456789-1234"
+            - name: GORILLA_DEV
+              value: "true"
+            - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+              value: "true"
             - name: GORILLA_FILE_STORE_IS_PROXIED
               value: "true"
             - name: GORILLA_GLUE_EXECUTE
@@ -6802,6 +8190,22 @@ spec:
               value: "true"
             - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
               value: "true"
+            - name: GORILLA_PUBSUB_INSECURE
+              value: "true"
+            - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+              value: "true"
+            - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+              value: "true"
+            - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+              value: "false"
+            - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+              value: "true"
+            - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+              value: "true"
+            - name: PUBSUB_EMULATOR_HOST
+              value: "pubsub-wandb-base:8085"
+            - name: PUBSUB_PROJECT_ID
+              value: "playground-111"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -6809,7 +8213,7 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+            image: "wandb/megabinary:latest"
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -7124,16 +8528,38 @@ spec:
         - /cleanup-scripts/post_upgrade.sh
         envFrom:
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -7141,7 +8567,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
+        image: "alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -7214,16 +8640,38 @@ spec:
         - /cleanup-scripts/pre_upgrade.sh
         envFrom:
         env:
+        - name: BIGTABLE_EMULATOR_HOST
+          value: "bigtable-wandb-base:8086"
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
           value: "local-123456789-123456789-123456789-1234"
+        - name: GORILLA_DEV
+          value: "true"
+        - name: GORILLA_ENABLE_RUN_AUTOMATIONS
+          value: "true"
         - name: GORILLA_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_PUBSUB_INSECURE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS
+          value: "false"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR
+          value: "true"
+        - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES
+          value: "true"
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-wandb-base:8085"
+        - name: PUBSUB_PROJECT_ID
+          value: "playground-111"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -7231,7 +8679,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
+        image: "alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -386,7 +386,6 @@ metadata:
   labels:
     global-common-label: "global-common-label-value"
     helm.sh/chart: '###CHART_VERSION###'
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1246,6 +1245,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1346,6 +1346,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1358,7 +1373,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1373,6 +1389,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1547,6 +1564,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1578,6 +1596,21 @@ data:
   GLUE_ENABLED: "true"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+    global-common-label: "global-common-label-value"
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1639,6 +1672,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -642,7 +642,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1493,6 +1492,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1587,6 +1587,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1599,7 +1614,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1612,6 +1628,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1778,6 +1795,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1807,6 +1825,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1882,6 +1913,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -4919,6 +4951,8 @@ spec:
         - configMapRef:
             name: chartsnap-bucket-configmap
         - configMapRef:
+            name: chartsnap-filemeta-configmap
+        - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:
             name: chartsnap-global-secret
@@ -6582,13 +6616,13 @@ spec:
         - configMapRef:
             name: chartsnap-bucket-configmap
         - configMapRef:
-            name: chartsnap-flat-run-fields-updater-configmap
-        - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:
             name: chartsnap-global-secret
         - configMapRef:
             name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-metric-observer-configmap
         - configMapRef:
             name: chartsnap-redis-configmap
         env:

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -540,7 +540,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1395,6 +1394,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1489,6 +1489,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1501,7 +1516,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1514,6 +1530,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1680,6 +1697,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1712,6 +1730,19 @@ data:
   OIDC_CLIENT_ID: wandb
   OIDC_AUTH_METHOD: pkce
   OIDC_ISSUER: http://keycloak:8080/keycloak/realms/master/
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1786,6 +1817,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -4651,6 +4683,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -652,7 +652,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1570,6 +1569,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1664,6 +1664,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1676,7 +1691,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1689,6 +1705,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1855,6 +1872,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1884,6 +1902,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1955,6 +1986,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -4944,6 +4976,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/__snapshots__/separate-pods.snap
+++ b/test-configs/operator-wandb/__snapshots__/separate-pods.snap
@@ -540,7 +540,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1391,6 +1390,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1485,6 +1485,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1497,7 +1512,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1510,6 +1526,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1676,6 +1693,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1705,6 +1723,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1776,6 +1807,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -4591,6 +4623,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -336,7 +336,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1187,6 +1186,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1281,6 +1281,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1293,7 +1308,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1306,6 +1322,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1472,6 +1489,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1501,6 +1519,19 @@ data:
   GLUE_ENABLED: "true"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1556,6 +1587,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -489,7 +489,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1314,6 +1313,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1408,6 +1408,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1420,7 +1435,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "filestreamtag"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1433,6 +1449,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1599,6 +1616,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1628,6 +1646,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1695,6 +1726,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -489,7 +489,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1314,6 +1313,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1408,6 +1408,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "executortag"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1420,7 +1435,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "filestreamtag"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1433,6 +1449,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "flatrunfieldsupdatertag"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1599,6 +1616,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1628,6 +1646,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1695,6 +1726,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings.snap
@@ -326,7 +326,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1154,6 +1153,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1248,6 +1248,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1260,7 +1275,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1273,6 +1289,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1439,6 +1456,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1471,6 +1489,19 @@ data:
   OIDC_CLIENT_ID: myclientid
   OIDC_AUTH_METHOD: oidc
   OIDC_ISSUER: myissuer
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1538,6 +1569,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -336,7 +336,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1187,6 +1186,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1281,6 +1281,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1293,7 +1308,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1306,6 +1322,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1472,6 +1489,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1501,6 +1519,19 @@ data:
   GLUE_ENABLED: "true"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1556,6 +1587,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -438,7 +438,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1289,6 +1288,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1383,6 +1383,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1395,7 +1410,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1408,6 +1424,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1574,6 +1591,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1603,6 +1621,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1670,6 +1701,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -4187,6 +4219,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -527,7 +527,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/session-key.yaml
 apiVersion: v1
@@ -1368,6 +1367,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_AUTH_METHOD: implicit
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1462,6 +1462,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1474,7 +1489,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1487,6 +1503,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1653,6 +1670,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1682,6 +1700,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -1753,6 +1784,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -4589,6 +4621,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -848,7 +848,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1860,6 +1859,7 @@ data:
   GORILLA_AUTH_METHOD: implicit
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local"}'
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1954,6 +1954,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1966,7 +1981,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1979,6 +1995,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -2145,6 +2162,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -2174,6 +2192,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -2248,6 +2279,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -5350,6 +5382,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -702,7 +702,6 @@ kind: Secret
 metadata:
   name: chartsnap-parquet-secret
   labels:
-data: {}
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -1647,6 +1646,7 @@ data:
   GORILLA_AUTH_METHOD: implicit
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local"}'
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -1741,6 +1741,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_IMAGE_TAG: "latest"
+---
+# Source: operator-wandb/templates/filemeta.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filemeta-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/filestream.yaml
 apiVersion: v1
@@ -1753,7 +1768,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
-data: {}
+data:
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/flat-run-fields-updater.yaml
 apiVersion: v1
@@ -1766,6 +1782,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/frontend.yaml
 apiVersion: v1
@@ -1932,6 +1949,7 @@ data:
 
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -1961,6 +1979,19 @@ data:
   GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
+---
+# Source: operator-wandb/templates/metric-observer.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-metric-observer-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
@@ -2035,6 +2066,7 @@ data:
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
   GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
   GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_IMAGE_TAG: "latest"
 ---
 # Source: operator-wandb/templates/redis.yaml
 apiVersion: v1
@@ -5033,6 +5065,8 @@ spec:
         envFrom:
         - configMapRef:
             name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-filemeta-configmap
         - configMapRef:
             name: chartsnap-global-configmap
         - secretRef:

--- a/test-configs/operator-wandb/dedicated.yaml
+++ b/test-configs/operator-wandb/dedicated.yaml
@@ -1,0 +1,122 @@
+global:
+  bucket:
+    provider: "s3"
+    name: "minio:9000/bucket"
+    region: "us-east-1"
+    accessKey: "minio"
+    secretKey: "testpassword"
+  redis:
+    password: "redis123"
+  glue:
+    enabled: true
+  api:
+    enabled: true
+  executor:
+    enabled: true
+  pubSub:
+    enabled: true
+    project: "playground-111"
+    filestreamTopic: "filestream"
+    runUpdateShadowTopic: "run-updates-shadow"
+  bigtable:
+    v2:
+      enabled: true
+    v3:
+      enabled: true
+    project: "playground-111"
+    instance: "fmbtest"
+  env:
+    GORILLA_PUBSUB_INSECURE: "true"
+    GORILLA_DEV: "true"
+    PUBSUB_EMULATOR_HOST: "pubsub-wandb-base:8085"
+    PUBSUB_PROJECT_ID: "playground-111"
+    BIGTABLE_EMULATOR_HOST: "bigtable-wandb-base:8086"
+    GLOBAL_ADMIN_API_KEY: "local-123456789-123456789-123456789-1234"
+    GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS: "true"
+    GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES: "true"
+    GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE: "true"
+    GORILLA_RUN_STORE_ONPREM_MIGRATE_SHADOW_RUN_UPDATES: "true"
+    GORILLA_RUN_STORE_ONPREM_MIGRATE_DISABLE_READS: "false"
+    GORILLA_RUN_STORE_ONPREM_MIGRATE_FLAT_RUNS_MIGRATOR: "true"
+    GORILLA_ENABLE_RUN_AUTOMATIONS: "true"
+    BUCKET_PROXY: "true"
+    GORILLA_GLUE_FILE_STORE_IS_PROXIED: "true"
+    GORILLA_FILE_STORE_IS_PROXIED: "true"
+  size: "testing"
+
+api:
+  image:
+    tag: "0.75.2"
+
+app:
+  env:
+    GORILLA_STORAGE_BUCKET: "s3://local-files"
+    GORILLA_FILEMETA_ENABLED: "false"
+
+executor:
+  install: true
+
+filemeta:
+  install: true
+
+frontend:
+  install: true
+
+flat-run-fields-updater:
+  install: true
+  pubSub:
+    subscription: "flat-run-fields-updater"
+  image:
+    tag: "0.75.2"
+
+filestream:
+  install: true
+  pubSub:
+    subscription: "filestream-gorilla"
+
+metric-observer:
+  install: true
+  pubSub:
+    subscription: "metric-observer"
+
+nginx:
+  install: true
+  additionalServices:
+    bucket:
+      host: "http://minio:9000"
+      headers:
+        Host: "minio:9000"
+    bucket-admin:
+      host: "http://minio:9090"
+      headers:
+        Host: "minio:9090"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: true
+  image:
+    tag: "8.4"
+  resources:
+    requests:
+      cpu: "40m"
+      memory: "64Mi"
+
+redis:
+  install: true
+  resources:
+    requests:
+      cpu: "40m"
+      memory: "64Mi"
+
+reloader:
+  install: true
+  resources:
+    requests:
+      cpu: "40m"
+      memory: "64Mi"
+
+anaconda2:
+  install: true


### PR DESCRIPTION
We want the images to have an idea of what release version has been deployed. The image tag should be a reasonable proxy for that, I think. If there's a better way to do this, please let me know

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 0.38.4.
  * Exposed image-tag configuration to runtime config for multiple components.
  * Added and re-mapped component configuration entries and environment references to improve service wiring.

* **Tests**
  * Added a comprehensive dedicated deployment config for multi-component testing and local emulator scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->