### PR TITLE
chore: enable OTEL profiling

### DIFF
--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -578,6 +578,10 @@ Global values will override any chart-specific values.
 - name: GORILLA_TRACER
   value: '{{ include "wandb.otelTracesEndpoint" . | trim }}'
 {{- end }}
+{{- if .Values.global.otel.profiles.enabled }}
+- name: GORILLA_PROFILER
+  value: '{{ include "wandb.otelProfilesEndpoint" . | trim }}'
+{{- end }}
 {{- end -}}
 
 {{- define "wandb.sslCertEnvs" -}}

--- a/charts/operator-wandb/templates/_helpers.tpl
+++ b/charts/operator-wandb/templates/_helpers.tpl
@@ -81,6 +81,17 @@ otlp+{{ .Values.global.otel.traces.proto }}://{{ .Release.Name }}-otel-daemonset
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the endpoint to send otel profiles to
+*/}}
+{{- define "wandb.otelProfilesEndpoint" -}}
+{{- if .Values.global.otel.profiles.host -}}
+otlp+{{ .Values.global.otel.profiles.proto }}://{{ .Values.global.otel.profiles.host }}:{{ .Values.global.otel.profiles.port }}
+{{- else -}}
+otlp+{{ .Values.global.otel.profiles.proto }}://{{ .Release.Name }}-otel-daemonset:{{ .Values.global.otel.profiles.port }}
+{{- end -}}
+{{- end -}}
+
 {{- define "wandb.internalJWTMap" -}}
 '{
 {{- $items := list -}}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -160,6 +160,14 @@ global:
       port: 4317
       # grpc, http
       proto: "grpc"
+    profiles:
+      enabled: false
+      # defaults to the otel-daemonset service
+      host: ""
+      # grpc default is 4317, http default is 4318
+      port: 4317
+      # grpc, http
+      proto: "grpc"
 
   # Weave Trace ClickHouse connection config.
   #


### PR DESCRIPTION
Enable sending profiles to the OTEL endpoint if configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new observability profiling endpoint configuration options in Helm values with customizable host, port, and protocol settings
  * New optional environment variable for profiler endpoint configuration when profiles are enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->