### PR TITLE
refactor(weave): templatize weave workers

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -29,12 +29,6 @@ dependencies:
 - name: wandb-base
   repository: file://../wandb-base
   version: 0.12.0
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.0
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.0
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -104,5 +98,5 @@ dependencies:
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:0252b7560c056b125e85f56219107493da833d14dbcdf841e933157227af6cf2
-generated: "2026-04-24T17:25:39.084901-07:00"
+digest: sha256:4318b777da81061dffb74b2fc249df5c55acca1657713cc8dec7f3f6ffa287ff
+generated: "2026-06-08T12:56:38.643645-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.42.6
+version: 0.42.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -47,16 +47,8 @@ dependencies:
     version: "0.12.0"
     repository: file://../wandb-base
     condition: weave-trace.install
-  - name: wandb-base
-    alias: weave-trace-worker
-    version: "0.12.0"
-    repository: file://../wandb-base
-    condition: weave-trace-worker.install
-  - name: wandb-base
-    alias: weave-evaluate-model-worker
-    version: "0.12.0"
-    repository: file://../wandb-base
-    condition: weave-evaluate-model-worker.install
+  # weave workers are now rendered by templates/weave-workers.yaml
+  # from the global.weaveWorkers list instead of individual subchart dependencies
   - name: wandb-base
     alias: executor
     version: "0.12.0"

--- a/charts/operator-wandb/templates/weave-workers.yaml
+++ b/charts/operator-wandb/templates/weave-workers.yaml
@@ -1,0 +1,303 @@
+{{- /*
+  Templatized weave worker deployments.
+  Iterates over .Values.global.weaveWorkers and generates ServiceAccount, PDB,
+  Deployment, and optionally HPA for each enabled worker. This replaces the need
+  for individual Chart.yaml subchart dependencies per worker.
+*/ -}}
+{{- range $workerName := .Values.global.weaveWorkers }}
+{{- $worker := get $.Values $workerName }}
+{{- if and $worker $worker.install }}
+
+{{- /* Resolve sizing */ -}}
+{{- $size := default "" (coalesce $worker.size $.Values.global.size) }}
+{{- $sizingDefault := default (dict) (get (default (dict) $worker.sizing) "default") }}
+{{- $sizingOverride := default (dict) (get (default (dict) $worker.sizing) $size) }}
+{{- $sizing := mergeOverwrite $sizingDefault $sizingOverride }}
+{{- $resources := default (dict) $sizing.resources }}
+
+{{- /* Worker-level image defaults (used for labels and as fallback per container) */ -}}
+{{- $workerImage := default (dict) $worker.image }}
+{{- $workerTag := default "latest" $workerImage.tag }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Release.Name }}-{{ $workerName }}
+  labels:
+    app.kubernetes.io/name: {{ $workerName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- if $workerImage.digest }}
+    app.kubernetes.io/version: {{ $workerImage.digest | trimPrefix "sha256:" | trunc 12 | quote }}
+    {{- else }}
+    app.kubernetes.io/version: {{ $workerTag | trunc 63 | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    {{- include "wandb.commonLabels" $ | nindent 4 }}
+automountServiceAccountToken: true
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $.Release.Name }}-{{ $workerName }}
+  labels:
+    app.kubernetes.io/name: {{ $workerName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- if $workerImage.digest }}
+    app.kubernetes.io/version: {{ $workerImage.digest | trimPrefix "sha256:" | trunc 12 | quote }}
+    {{- else }}
+    app.kubernetes.io/version: {{ $workerTag | trunc 63 | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    {{- include "wandb.commonLabels" $ | nindent 4 }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchExpressions:
+      - key: batch.kubernetes.io/job-name
+        operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: {{ $workerName }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-{{ $workerName }}{{- if $worker.deploymentPostfix }}-{{ $worker.deploymentPostfix }}{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ $workerName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- if $workerImage.digest }}
+    app.kubernetes.io/version: {{ $workerImage.digest | trimPrefix "sha256:" | trunc 12 | quote }}
+    {{- else }}
+    app.kubernetes.io/version: {{ $workerTag | trunc 63 | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    {{- include "wandb.commonLabels" $ | nindent 4 }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ default 1 $sizing.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $workerName }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ $workerName }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        {{- if $workerImage.digest }}
+        app.kubernetes.io/version: {{ $workerImage.digest | trimPrefix "sha256:" | trunc 12 | quote }}
+        {{- else }}
+        app.kubernetes.io/version: {{ $workerTag | trunc 63 | quote }}
+        {{- end }}
+        app.kubernetes.io/managed-by: {{ $.Release.Service }}
+        {{- include "wandb.commonLabels" $ | nindent 8 }}
+        {{- include "wandb.podLabels" $ | nindent 8 }}
+    spec:
+      {{- $imagePullSecrets := concat (default list $.Values.global.imagePullSecrets) }}
+      {{- $uniqueSecrets := list }}
+      {{- range $secret := $imagePullSecrets }}
+        {{- if kindIs "string" $secret }}
+          {{- $uniqueSecrets = append $uniqueSecrets $secret }}
+        {{- else if kindIs "map" $secret }}
+          {{- if hasKey $secret "name" }}
+            {{- $uniqueSecrets = append $uniqueSecrets $secret.name }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- $uniqueSecrets = uniq (compact $uniqueSecrets) }}
+      {{- if $uniqueSecrets }}
+      imagePullSecrets:
+        {{- range $name := $uniqueSecrets }}
+        - name: {{ tpl $name $ }}
+        {{- end }}
+      {{- end }}
+      containers:
+      {{- range $containerName, $container := $worker.containers }}
+      - name: {{ $containerName }}
+        {{- if $container.command }}
+        command:
+          {{- toYaml $container.command | nindent 10 }}
+        {{- end }}
+        {{- if $container.args }}
+        args:
+          {{- toYaml $container.args | nindent 10 }}
+        {{- end }}
+        {{- /* envFrom */ -}}
+        {{- $envFrom := merge (default (dict) $container.envFrom) (default (dict) $worker.envFrom) }}
+        {{- if $envFrom }}
+        envFrom:
+          {{- range $key, $value := $envFrom }}
+          - {{ $value }}:
+              name: {{ tpl $key $ }}
+          {{- end }}
+        {{- end }}
+        env:
+        {{- /* Render envTpls */ -}}
+        {{- if $worker.envTpls }}
+          {{- range $worker.envTpls }}
+            {{- tpl . $ | nindent 8 }}
+          {{- end }}
+        {{- end }}
+        {{- /* Render merged env vars: global.env + worker.env + container.env */ -}}
+        {{- $mergedEnv := merge (default (dict) $container.env) (default (dict) $worker.env) $.Values.global.env (default (dict) $.Values.global.extraEnv) }}
+        {{- /* Remove env vars already rendered by envTpls */ -}}
+        {{- $envTplNames := list }}
+        {{- if $worker.envTpls }}
+          {{- range $worker.envTpls }}
+            {{- range $envVar := (tpl . $ | fromYamlArray) }}
+              {{- $envTplNames = append $envTplNames $envVar.name }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- range $key, $value := $mergedEnv }}
+          {{- if not (has $key $envTplNames) }}
+            {{- if kindIs "map" $value }}
+        - name: {{ $key }}
+              {{- toYaml $value | nindent 10 }}
+            {{- else }}
+        - name: {{ $key }}
+          value: {{ toString $value | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        {{- $cImage := default (dict) $container.image }}
+        {{- $effImage := merge $cImage $workerImage }}
+        {{- $repository := default "wandb/weave-trace" $effImage.repository }}
+        {{- if $.Values.global.repositoryPrefix }}
+          {{- $repository = printf "%s/%s" $.Values.global.repositoryPrefix $repository }}
+        {{- end }}
+        {{- if $effImage.digest }}
+        image: {{ printf "%s@%s" $repository $effImage.digest | quote }}
+        {{- else }}
+        image: {{ printf "%s:%s" $repository (default "latest" $effImage.tag) | quote }}
+        {{- end }}
+        imagePullPolicy: {{ default "IfNotPresent" $effImage.pullPolicy }}
+        {{- if $container.ports }}
+        ports:
+          {{- toYaml $container.ports | nindent 10 }}
+        {{- end }}
+        {{- if $container.livenessProbe }}
+        livenessProbe:
+          {{- toYaml $container.livenessProbe | nindent 10 }}
+        {{- end }}
+        {{- if $container.readinessProbe }}
+        readinessProbe:
+          {{- toYaml $container.readinessProbe | nindent 10 }}
+        {{- end }}
+        {{- if $container.startupProbe }}
+        startupProbe:
+          {{- toYaml $container.startupProbe | nindent 10 }}
+        {{- end }}
+        {{- if $resources }}
+        resources:
+          {{- toYaml $resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- include "wandb.caCertsVolumeMounts" $ | nindent 8 }}
+        {{- if $container.volumeMounts }}
+          {{- toYaml $container.volumeMounts | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      serviceAccountName: {{ $.Release.Name }}-{{ $workerName }}
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      {{- $nodeSelector := coalesce $worker.nodeSelector $.Values.global.nodeSelector }}
+      {{- if $nodeSelector }}
+      nodeSelector:
+        {{- toYaml $nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- $tolerations := coalesce $worker.tolerations $.Values.global.tolerations }}
+      {{- if $tolerations }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- end }}
+      {{- $priorityClassName := coalesce $worker.priorityClassName $.Values.global.priorityClassName }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ tpl $priorityClassName $ }}
+      {{- end }}
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ $.Release.Name }}
+            app.kubernetes.io/name: {{ $workerName }}
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ $.Release.Name }}
+            app.kubernetes.io/name: {{ $workerName }}
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      {{- include "wandb.caCertsVolumes" $ | nindent 6 }}
+      {{- if $worker.volumes }}
+        {{- tpl (toYaml $worker.volumes | nindent 6) $ }}
+      {{- end }}
+
+{{- /* HPA - check if sizing has horizontal autoscaling enabled */ -}}
+{{- $hpa := default (dict) (default (dict) $sizing.autoscaling).horizontal }}
+{{- $hpaOverride := default (dict) (default (dict) $worker.autoscaling).horizontal }}
+{{- $hpaMerged := mergeOverwrite $hpa $hpaOverride }}
+{{- if $hpaMerged.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $.Release.Name }}-{{ $workerName }}
+  labels:
+    app.kubernetes.io/name: {{ $workerName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    {{- include "wandb.commonLabels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $.Release.Name }}-{{ $workerName }}{{- if $worker.deploymentPostfix }}-{{ $worker.deploymentPostfix }}{{- end }}
+  minReplicas: {{ default 1 $hpaMerged.minReplicas }}
+  maxReplicas: {{ default 5 $hpaMerged.maxReplicas }}
+  metrics:
+    {{- if $hpaMerged.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $hpaMerged.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $hpaMerged.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $hpaMerged.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -458,6 +458,13 @@ global:
   weave-trace:
     enabled: false
 
+  # List of weave worker value keys to render as deployments.
+  # Each entry references a top-level values block (e.g. weave-trace-worker).
+  # To add a new worker, add its name here and define its values block below.
+  weaveWorkers:
+    - weave-trace-worker
+    - weave-evaluate-model-worker
+
   # As part of the migration away from using local, the `bypass` setting will
   # control whether the gorilla services will use the app service (and, thus, local)
   localService:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -401,48 +401,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: operator-wandb/charts/weave-evaluate-model-worker/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-weave-evaluate-model-worker
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-evaluate-model-worker
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: weave-evaluate-model-worker
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/weave-trace-worker/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-weave-trace-worker
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-trace-worker
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: weave-trace-worker
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
 # Source: operator-wandb/charts/weave-trace/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -484,6 +442,48 @@ spec:
       app.kubernetes.io/name: weave
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
+---
+# Source: operator-wandb/templates/weave-workers.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-weave-trace-worker
+  labels:
+    app.kubernetes.io/name: weave-trace-worker
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  maxUnavailable: 1
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: weave-trace-worker
+      app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/templates/weave-workers.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-weave-evaluate-model-worker
+  labels:
+    app.kubernetes.io/name: weave-evaluate-model-worker
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  maxUnavailable: 1
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: weave-evaluate-model-worker
+      app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/anaconda2/templates/serviceaccount.yaml
 apiVersion: v1
@@ -716,32 +716,6 @@ metadata:
   name: chartsnap-reloader
   namespace: default
 ---
-# Source: operator-wandb/charts/weave-evaluate-model-worker/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-weave-evaluate-model-worker
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-evaluate-model-worker
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/weave-trace-worker/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-weave-trace-worker
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-trace-worker
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/weave-trace/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -766,6 +740,32 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/templates/weave-workers.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-weave-trace-worker
+  labels:
+    app.kubernetes.io/name: weave-trace-worker
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: '###CHART_VERSION###'
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/templates/weave-workers.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-weave-evaluate-model-worker
+  labels:
+    app.kubernetes.io/name: weave-evaluate-model-worker
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: '###CHART_VERSION###'
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/templates/bucket.yaml
@@ -6902,317 +6902,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: chartsnap-reloader
 ---
-# Source: operator-wandb/charts/weave-evaluate-model-worker/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-weave-evaluate-model-worker-bc
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-evaluate-model-worker
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: weave-evaluate-model-worker
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.12.0
-        app.kubernetes.io/name: weave-evaluate-model-worker
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: weave-evaluate-model-worker
-        args:
-        - python
-        - -m
-        - src.workers.evaluate_model_worker.evaluate_model_worker
-        envFrom:
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-weave-trace-configmap
-        env:
-        - name: WF_CLICKHOUSE_HOST
-          value: chartsnap-clickhouse-headless
-        - name: WF_CLICKHOUSE_PORT
-          value: "8123"
-        - name: WF_CLICKHOUSE_DATABASE
-          value: weave_trace_db
-        - name: WF_CLICKHOUSE_USER
-          value: default
-        - name: WF_CLICKHOUSE_REPLICATED
-          value: "false"
-        - name: WF_CLICKHOUSE_PASS
-          valueFrom:
-            secretKeyRef:
-              key: CLICKHOUSE_PASSWORD
-              name: chartsnap-clickhouse
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        - name: WANDB_INTERNAL_SERVICE_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: weave-worker-auth
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      serviceAccountName: chartsnap-weave-evaluate-model-worker
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: weave-evaluate-model-worker
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: weave-evaluate-model-worker
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
-# Source: operator-wandb/charts/weave-trace-worker/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-weave-trace-worker-bc
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-trace-worker
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: weave-trace-worker
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: weave-trace-worker-0.12.0
-        app.kubernetes.io/name: weave-trace-worker
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: weave-trace-worker
-        args:
-        - python
-        - -m
-        - src.workers.scoring_worker
-        envFrom:
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-weave-trace-configmap
-        env:
-        - name: WF_CLICKHOUSE_HOST
-          value: chartsnap-clickhouse-headless
-        - name: WF_CLICKHOUSE_PORT
-          value: "8123"
-        - name: WF_CLICKHOUSE_DATABASE
-          value: weave_trace_db
-        - name: WF_CLICKHOUSE_USER
-          value: default
-        - name: WF_CLICKHOUSE_REPLICATED
-          value: "false"
-        - name: WF_CLICKHOUSE_PASS
-          valueFrom:
-            secretKeyRef:
-              key: CLICKHOUSE_PASSWORD
-              name: chartsnap-clickhouse
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        - name: WANDB_INTERNAL_SERVICE_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: weave-worker-auth
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/weave-trace/internal-jwt
-          name: weave-trace-internal-jwt
-      serviceAccountName: chartsnap-weave-trace-worker
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: weave-trace-worker
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: weave-trace-worker
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - name: weave-trace-internal-jwt
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: internal-service
-              expirationSeconds: 600
-              path: token
----
 # Source: operator-wandb/charts/weave-trace/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -7662,6 +7351,307 @@ spec:
           medium: ''
           sizeLimit: '20Gi'
         name: cache
+---
+# Source: operator-wandb/templates/weave-workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-weave-trace-worker-bc
+  labels:
+    app.kubernetes.io/name: weave-trace-worker
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: '###CHART_VERSION###'
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weave-trace-worker
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: weave-trace-worker
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: weave-trace-worker
+        args:
+        - python
+        - -m
+        - src.workers.scoring_worker
+        envFrom:
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-weave-trace-configmap
+        env:
+        - name: WF_CLICKHOUSE_HOST
+          value: "chartsnap-clickhouse-headless"
+        - name: WF_CLICKHOUSE_PORT
+          value: "8123"
+        - name: WF_CLICKHOUSE_DATABASE
+          value: "weave_trace_db"
+        - name: WF_CLICKHOUSE_USER
+          value: "default"
+        - name: WF_CLICKHOUSE_REPLICATED
+          value: "false"
+        - name: WF_CLICKHOUSE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: "chartsnap-clickhouse"
+              key: "CLICKHOUSE_PASSWORD"
+        - name: SSL_CERT_FILE
+          value: "/etc/ssl/certs/ca-certificates.crt"
+        - name: SSL_CERT_DIR
+          value: "/etc/ssl/certs"
+        - name: REQUESTS_CA_BUNDLE
+          value: "/etc/ssl/certs/ca-certificates.crt"
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: WANDB_INTERNAL_SERVICE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: weave-worker-auth
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/weave-trace/internal-jwt
+          name: weave-trace-internal-jwt
+      serviceAccountName: chartsnap-weave-trace-worker
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave-trace-worker
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave-trace-worker
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - name: weave-trace-internal-jwt
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: internal-service
+              expirationSeconds: 600
+              path: token
+---
+# Source: operator-wandb/templates/weave-workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-weave-evaluate-model-worker-bc
+  labels:
+    app.kubernetes.io/name: weave-evaluate-model-worker
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: '###CHART_VERSION###'
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weave-evaluate-model-worker
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: weave-evaluate-model-worker
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: weave-evaluate-model-worker
+        args:
+        - python
+        - -m
+        - src.workers.evaluate_model_worker.evaluate_model_worker
+        envFrom:
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-weave-trace-configmap
+        env:
+        - name: WF_CLICKHOUSE_HOST
+          value: "chartsnap-clickhouse-headless"
+        - name: WF_CLICKHOUSE_PORT
+          value: "8123"
+        - name: WF_CLICKHOUSE_DATABASE
+          value: "weave_trace_db"
+        - name: WF_CLICKHOUSE_USER
+          value: "default"
+        - name: WF_CLICKHOUSE_REPLICATED
+          value: "false"
+        - name: WF_CLICKHOUSE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: "chartsnap-clickhouse"
+              key: "CLICKHOUSE_PASSWORD"
+        - name: SSL_CERT_FILE
+          value: "/etc/ssl/certs/ca-certificates.crt"
+        - name: SSL_CERT_DIR
+          value: "/etc/ssl/certs"
+        - name: REQUESTS_CA_BUNDLE
+          value: "/etc/ssl/certs/ca-certificates.crt"
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: WANDB_INTERNAL_SERVICE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: weave-worker-auth
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-weave-evaluate-model-worker
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave-evaluate-model-worker
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave-evaluate-model-worker
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
 ---
 # Source: operator-wandb/charts/bufstream/templates/deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- Replace per-worker `wandb-base` subchart aliases (`weave-trace-worker`, `weave-evaluate-model-worker`) with a single `templates/weave-workers.yaml` that iterates over `global.weaveWorkers`.
- Adding a new worker (e.g. the alert worker) now needs only a values block + a list entry, no `Chart.yaml` dependency churn.
- Addresses [#574 review feedback](https://github.com/wandb/helm-charts/pull/574) on the weave-worker subchart explosion.

## Testing
chartsnap: rendered workers match the previous subchart output; only `weave-trace-with-worker.snap` changes.