### PR TITLE
chore(backend): Remove CPU Limit for OTel Collector

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.41.6
+version: 0.41.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/otel/charts/agent/values.yaml
+++ b/charts/operator-wandb/charts/otel/charts/agent/values.yaml
@@ -73,7 +73,6 @@ resources:
     cpu: 200m
     memory: 200Mi
   limits:
-    cpu: 1000m
     memory: 2Gi
 
 extraEnv:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2592,7 +2592,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -2981,7 +2981,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -2830,7 +2830,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2217,7 +2217,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2251,7 +2251,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2251,7 +2251,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2217,7 +2217,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -2720,7 +2720,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -2830,7 +2830,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -2830,7 +2830,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -2840,7 +2840,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3314,7 +3314,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -8524,7 +8524,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-olap-registry-search"
   labels:
-    helm.sh/chart: operator-wandb-0.41.6
+    helm.sh/chart: operator-wandb-0.41.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -8583,7 +8583,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-olap-run-store-accelerator"
   labels:
-    helm.sh/chart: operator-wandb-0.41.6
+    helm.sh/chart: operator-wandb-0.41.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -6541,7 +6541,7 @@ kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-olap-run-store-accelerator"
   labels:
-    helm.sh/chart: operator-wandb-0.41.6
+    helm.sh/chart: operator-wandb-0.41.7
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -2734,7 +2734,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3103,7 +3103,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -2830,7 +2830,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2333,7 +2333,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2333,7 +2333,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2333,7 +2333,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2449,7 +2449,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2575,7 +2575,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2575,7 +2575,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2417,7 +2417,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2334,7 +2334,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2349,7 +2349,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2349,7 +2349,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2450,7 +2450,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2226,7 +2226,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2217,7 +2217,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2692,7 +2692,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -2830,7 +2830,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2271,7 +2271,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3178,7 +3178,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3579,7 +3579,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3272,7 +3272,6 @@ spec:
             port: 13133
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 200m


### PR DESCRIPTION
For larger customer instances we were seeing CPU throttling on the OTel collector, causing instability and leading to dropped traces.

Remove the CPU limit so we can sustain bursts of activity without losing metrics/traces.

CPU requests are retained to ensure proper pod scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 0.41.7
  * Removed CPU limit constraint from agent resource configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->