### PR TITLE
chore: remove redundant WANDB_*_DIR env vars from MCP values

### DIFF
--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -2911,17 +2911,27 @@ mcp-server:
     MCP_RATE_LIMIT_ENABLED: "true"
     MCP_RATE_LIMIT_PER_KEY: "60/minute"
     MCP_RATE_LIMIT_GLOBAL: "1000/minute"
-    WANDB_CACHE_DIR: "/tmp/.wandb_cache"
-    WANDB_CONFIG_DIR: "/tmp/.wandb_config"
-    WANDB_DATA_DIR: "/tmp/.wandb_data"
-    HOME: "/tmp"
-  ## Observability -- all disabled by default.
+    # Note: WANDB_CACHE_DIR, WANDB_CONFIG_DIR, WANDB_DATA_DIR, and HOME=/tmp
+    # are already set by the MCP Docker image. The emptyDir volume mounted
+    # at /tmp/ above gives the pod isolated writable scratch space matching
+    # the image's defaults.
+  ## Observability -- all disabled by default, matching other W&B services.
   ## Prerequisites before enabling:
   ##   - ddtrace / opentelemetry-distro baked into the MCP server image (>= 0.3.0)
   ##   - dd-agent DaemonSet running on nodes (for datadog)
   ##   - OTEL Collector deployed in-cluster (for otel)
   ##   - Datadog Monitors + PagerDuty integration configured (ops layer)
   ##   - ADR filed, security review completed
+  ##
+  ## Datadog API key inheritance (K8s managed-install):
+  ## When datadog.enabled=true, _mcp.tpl sets DD_AGENT_HOST=status.hostIP which
+  ## routes traces/stats to the node-local Datadog Agent DaemonSet. The agent
+  ## holds the API key from the shared `datadog-secrets` secret in the `datadog`
+  ## namespace (managed by core/charts/datadog Terraform). NO workload-level
+  ## DD_API_KEY is needed -- do NOT set analytics.datadogApiKeySecret on K8s.
+  ##
+  ## The analytics.datadogApiKeySecret values block is ONLY for edge cases
+  ## without a local DD agent (e.g., Cloud Run). Leave unset on managed-install.
   datadog:
     enabled: false
   otel:


### PR DESCRIPTION
## Summary

Fully addresses @zacharyblasczyk's original review feedback on #571 about shipping fs-perm env vars as chart defaults.

## What Changed

### Removed redundant env vars

The 4 env vars (`WANDB_CACHE_DIR`, `WANDB_CONFIG_DIR`, `WANDB_DATA_DIR`, `HOME=/tmp`) are already baked into the MCP Docker image via `ENV` declarations in the Dockerfile:

\`\`\`dockerfile
ENV WANDB_CACHE_DIR=/tmp/.wandb_cache
ENV WANDB_CONFIG_DIR=/tmp/.wandb_config
ENV WANDB_DATA_DIR=/tmp/.wandb_data
ENV HOME=/tmp
\`\`\`

Shipping them as chart defaults is redundant -- the image already sets them. Zachary's original concern was "shipping fs-perm env vars as chart defaults"; this removes them.

### Kept

The emptyDir volume at `/tmp/` (added in #588) stays -- it gives the pod isolated writable scratch space matching the image's `HOME=/tmp`.

### Added: Datadog API key inheritance docs

Documented the standard W&B observability pattern in the values.yaml comment block:

- **K8s managed-install**: `mcp-server.datadog.enabled=true` -> `_mcp.tpl` sets `DD_AGENT_HOST=status.hostIP` -> node-local DD agent DaemonSet (which holds the API key from `datadog-secrets` in the `datadog` namespace) handles forwarding. **No workload-level `DD_API_KEY` needed.**
- **Cloud Run / no agent**: the `analytics.datadogApiKeySecret` block is the fallback for edge cases. Leave unset on K8s.

## Future Work (not this PR)

Longer-term cleaner fix Zachary hinted at (\"or at `/home/wandb`\"):

1. Update MCP Dockerfile: `HOME=/home/wandb`, proper `mkdir -p /home/wandb`
2. Remove `WANDB_*_DIR` env vars from Dockerfile (wandb library defaults to `$HOME/.wandb`)
3. Update helm chart emptyDir mount from `/tmp/` to `/home/wandb`

Requires new image build + chart update together. Defer to v0.3.3.

Made with [Cursor](https://cursor.com)