### PR TITLE
fix(MCP-32): pullable default for mcp-server image; bump operator-wandb to 0.42.2

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.42.1
+version: 0.42.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -2846,11 +2846,15 @@ weave:
 ## Requires weave-trace to be installed (WF_TRACE_SERVER_URL points to in-cluster weave-trace).
 ## If weave-trace is disabled, override WF_TRACE_SERVER_URL in the env block below.
 ## Disabled by default. Enable with: mcp-server.install: true
+## Image is hosted in W&B's public Artifact Registry (no auth required to pull).
+## If you mirror images via global.repositoryPrefix, override mcp-server.image.repository
+## to "wandb/mcp-server" so the prefix composes correctly (the chart helper always
+## prepends repositoryPrefix verbatim; see charts/wandb-base/templates/_containers.tpl).
 ## Docs: https://github.com/wandb/wandb-mcp-server
 mcp-server:
   install: false
   image:
-    repository: wandb/mcp-server
+    repository: us-docker.pkg.dev/wandb-production/public/wandb/mcp-server
     tag: "0.3.2"
   podSecurityContext:
     runAsUser: 1000

--- a/test-configs/operator-wandb/mcp-server.yaml
+++ b/test-configs/operator-wandb/mcp-server.yaml
@@ -32,6 +32,10 @@ weave-trace:
 
 mcp-server:
   install: true
+  image:
+    # Override the chart default (which is the fully-qualified GAR path) so this
+    # snapshot exercises the global.repositoryPrefix prepending behavior.
+    repository: wandb/mcp-server
 
 nginx:
   install: true


### PR DESCRIPTION
## Summary

- Default `mcp-server.image.repository` was `wandb/mcp-server` (i.e. `docker.io/wandb/mcp-server`), which doesn't exist. The image is only published to W&B's public Artifact Registry at `us-docker.pkg.dev/wandb-production/public/wandb/mcp-server`.
- CI never caught this because every `test-configs/operator-wandb/*.yaml` sets `global.repositoryPrefix: us-docker.pkg.dev/wandb-production/public`, masking the broken default. Customers following the public install in [`docs/platform/mcp-server.mdx`](https://docs.wandb.ai/platform/mcp-server) and just enabling `mcp-server.install: true` get `ImagePullBackOff`.
- This PR sets the chart default to the fully-qualified GAR path. The `mcp-server` snapshot test now overrides the repository back to `wandb/mcp-server` so it keeps exercising the `repositoryPrefix` prepending behavior; rendered image string is identical (`us-docker.pkg.dev/wandb-production/public/wandb/mcp-server:0.3.2`).
- Chart bumped `operator-wandb` `0.42.1` → `0.42.2`.

## Why this matters

`operator-wandb 0.42.1` is the headline release of the MCP subchart (PRs #571 and #590). Today, the documented public install path doesn't work — only internal/dedicated installs that mirror images via `repositoryPrefix` work. This is a hotfix for the same release line.

## Validation

### Local helm-template (the regression test)

```
$ helm template t ./charts/operator-wandb --set mcp-server.install=true \
    --set weave-trace.install=true --set clickhouse.install=true | rg "image:.*mcp-server"
          image: "us-docker.pkg.dev/wandb-production/public/wandb/mcp-server:0.3.2"

$ helm template t ./charts/operator-wandb -f test-configs/operator-wandb/mcp-server.yaml | rg "image:.*mcp-server"
          image: "us-docker.pkg.dev/wandb-production/public/wandb/mcp-server:0.3.2"
```

Both paths now render the same canonical image. Pre-fix, the first command produced `wandb/mcp-server:0.3.2` (broken).

### Live deployment (GKE in `wandb-mcp-production`, http://34-54-195-176.sslip.io)

```
$ curl -sS http://34-54-195-176.sslip.io/mcp/health
{"status":"ok","tools_registered":20}

$ kubectl get deploy wandb-mcp-server -n default -o jsonpath='{.spec.template.spec.containers[0].image}'
us-docker.pkg.dev/wandb-production/public/wandb/mcp-server:0.3.2

$ kubectl exec -n default deploy/wandb-mcp-server -- env | grep -E "WF_TRACE|WANDB_BASE"
WANDB_BASE_URL=http://34-54-195-176.sslip.io
WF_TRACE_SERVER_URL=http://34-54-195-176.sslip.io/traces
```

The MCP-32 `WF_TRACE_SERVER_URL` fix from #590 still resolves correctly with the new image default.

### Snapshot tests

No snapshot diffs from this PR's changes:
- `helm.sh/chart` is in `dynamicFields` of `test-configs/operator-wandb/.chartsnap.yaml`, so the version bump doesn't change snap output.
- The `mcp-server.yaml` test override keeps the rendered MCP image string identical.

(There is unrelated pre-existing redis `seLinuxOptions: null` drift on `main` from a Bitnami common subchart bump - that's a separate snap-regen PR, not bundled here.)

## Test plan
- [x] `helm template` renders pullable image with no `repositoryPrefix` set
- [x] `helm template` with `mcp-server.yaml` test config still renders the GAR image
- [x] Live `/mcp/health` returns 200 with the new image deployed
- [x] Live in-cluster image matches the new chart default
- [x] Live `WF_TRACE_SERVER_URL` env still has `/traces` prefix (#590 sanity)

## Risks
- Customers mirroring images via `global.repositoryPrefix` need to override `mcp-server.image.repository: wandb/mcp-server` to keep working. The new comment in `values.yaml` calls this out explicitly. (This is the same convention `bufstream` uses with its `us-docker.pkg.dev/buf-images-1/...` default.)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 0.42.2
  * Updated MCP server container image repository configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->