### PR TITLE
feat: bump wandb-base chart version to 0.12.0 and enhance service configurations with multiple services support and headless service support

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,40 +1,40 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -58,16 +58,16 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -76,33 +76,33 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.11.11
+  version: 0.12.0
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:6c1ad6795aafa227e294636f65e47d8dda2ff442a77b4c0f1d283b4ef7195bd8
-generated: "2026-04-16T19:55:12.225969-05:00"
+digest: sha256:0252b7560c056b125e85f56219107493da833d14dbcdf841e933157227af6cf2
+generated: "2026-04-24T17:25:39.084901-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.42.1
+version: 0.42.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,62 +14,62 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: console
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -104,15 +104,15 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: filestream
-    version: "0.11.11"
+    version: "0.12.0"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -132,42 +132,42 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.11.11"
+    version: "0.12.0"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/templates/tests/test-olap.yaml
+++ b/charts/operator-wandb/templates/tests/test-olap.yaml
@@ -3,7 +3,7 @@
     {{- $config := include "wandb.olapConfig" (dict "root" $ "featureName" $featureName) | fromYaml -}}
     {{- if $config.enabled -}}
       {{- $envVarPrefix := $featureName | snakecase | upper -}}
-      {{- $kebab := $featureName | snakecase | replace "_" "-" -}}
+      {{- $kebab := $featureName | snakecase | replace "_" "-" }}
 ---
 apiVersion: v1
 kind: Pod

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.11.11
+version: 0.12.0
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/service.yaml
+++ b/charts/wandb-base/templates/service.yaml
@@ -4,8 +4,8 @@
 {{- $serviceType := default "ClusterIP" $service.type -}}
 {{- $isHeadless := eq (lower $serviceType) "headless" -}}
 {{- $internal := or (default false $service.internal) $isHeadless -}}
+{{- $serviceName := required "service.name is required" $service.name | trunc 63 | trimSuffix "-" -}}
 {{- if $service.enabled }}
-{{- $serviceName := default (include "wandb-base.fullname" $root) $service.name | trunc 63 | trimSuffix "-" }}
 {{- if and (not $internal) (eq $root.Values.global.cloudProvider "gcp") }}
 ---
 apiVersion: cloud.google.com/v1
@@ -60,7 +60,11 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- include "wandb-base.serviceResource" (dict "root" . "service" .Values.service) }}
+{{- $defaultService := deepCopy .Values.service -}}
+{{- if not $defaultService.name -}}
+{{- $_ := set $defaultService "name" (include "wandb-base.fullname" .) -}}
+{{- end -}}
+{{- include "wandb-base.serviceResource" (dict "root" . "service" $defaultService) }}
 {{- range $service := .Values.services }}
 {{- include "wandb-base.serviceResource" (dict "root" $ "service" $service) }}
 {{- end }}

--- a/charts/wandb-base/templates/service.yaml
+++ b/charts/wandb-base/templates/service.yaml
@@ -1,16 +1,23 @@
-{{- if .Values.service.enabled }}
-{{- if eq .Values.global.cloudProvider "gcp" }}
+{{- define "wandb-base.serviceResource" -}}
+{{- $root := .root -}}
+{{- $service := .service -}}
+{{- $serviceType := default "ClusterIP" $service.type -}}
+{{- $isHeadless := eq (lower $serviceType) "headless" -}}
+{{- $internal := or (default false $service.internal) $isHeadless -}}
+{{- if $service.enabled }}
+{{- $serviceName := default (include "wandb-base.fullname" $root) $service.name | trunc 63 | trimSuffix "-" }}
+{{- if and (not $internal) (eq $root.Values.global.cloudProvider "gcp") }}
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ include "wandb-base.fullname" . }}-backend-config
+  name: {{ $serviceName }}-backend-config
   labels:
-    {{- include "wandb-base.labels" . | nindent 4 }}
+    {{- include "wandb-base.labels" $root | nindent 4 }}
 spec:
-  {{- if .Values.global.gcpSecurityPolicy }}
+  {{- if $root.Values.global.gcpSecurityPolicy }}
   securityPolicy:
-    name: {{ .Values.global.gcpSecurityPolicy }}
+    name: {{ $root.Values.global.gcpSecurityPolicy }}
   {{- end }}
   timeoutSec: 120
 {{- end }}
@@ -18,28 +25,42 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "wandb-base.serviceName" . }}
+  name: {{ $serviceName }}
   labels:
-    {{- include "wandb-base.labels" . | nindent 4 }}
-    {{- if .Values.service.labels -}}
-    {{-   toYaml .Values.service.labels | nindent 4 }}
+    {{- include "wandb-base.labels" $root | nindent 4 }}
+    {{- if $service.labels -}}
+    {{- toYaml $service.labels | nindent 4 }}
     {{- end }}
   annotations:
-    {{- tpl (include "wandb-base.commonAnnotations" . | nindent 4) . }}
-    {{- tpl (include "wandb-base.serviceAnnotations" . | nindent 4) . }}
-    {{- if and ( eq .Values.global.cloudProvider "aws" ) .Values.service.loadBalancerHealthCheckPath }}
-    alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.service.loadBalancerHealthCheckPath }}
+    {{- tpl (include "wandb-base.commonAnnotations" $root | nindent 4) $root }}
+    {{- $allServiceAnnotations := merge (default (dict) $service.annotations) $root.Values.global.service.annotations }}
+    {{- if $allServiceAnnotations }}
+    {{- toYaml $allServiceAnnotations | nindent 4 }}
     {{- end }}
-    {{- if eq .Values.global.cloudProvider "gcp" }}
+    {{- if and (not $internal) (eq $root.Values.global.cloudProvider "aws") $service.loadBalancerHealthCheckPath }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $service.loadBalancerHealthCheckPath }}
+    {{- end }}
+    {{- if and (not $internal) (eq $root.Values.global.cloudProvider "gcp") }}
     cloud.google.com/neg: '{"ingress": true}'
-    cloud.google.com/backend-config: '{"default": "{{ include "wandb-base.fullname" . }}-backend-config"}'
+    cloud.google.com/backend-config: '{"default": "{{ $serviceName }}-backend-config"}'
     {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  {{- if $isHeadless }}
+  type: ClusterIP
+  clusterIP: None
+  {{- else }}
+  type: {{ $serviceType }}
+  {{- end }}
   ports:
-    {{- with .Values.service.ports }}
+    {{- with $service.ports }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   selector:
-    {{- include "wandb-base.selectorLabels" . | nindent 4 }}
+    {{- include "wandb-base.selectorLabels" $root | nindent 4 }}
+{{- end }}
+{{- end }}
+
+{{- include "wandb-base.serviceResource" (dict "root" . "service" .Values.service) }}
+{{- range $service := .Values.services }}
+{{- include "wandb-base.serviceResource" (dict "root" $ "service" $service) }}
 {{- end }}

--- a/charts/wandb-base/templates/service.yaml
+++ b/charts/wandb-base/templates/service.yaml
@@ -2,7 +2,7 @@
 {{- $root := .root -}}
 {{- $service := .service -}}
 {{- $serviceType := default "ClusterIP" $service.type -}}
-{{- $isHeadless := eq (lower $serviceType) "headless" -}}
+{{- $isHeadless := default false $service.headless -}}
 {{- $internal := or (default false $service.internal) $isHeadless -}}
 {{- $serviceName := required "service.name is required" $service.name | trunc 63 | trimSuffix "-" -}}
 {{- if $service.enabled }}
@@ -45,11 +45,9 @@ metadata:
     cloud.google.com/backend-config: '{"default": "{{ $serviceName }}-backend-config"}'
     {{- end }}
 spec:
-  {{- if $isHeadless }}
-  type: ClusterIP
-  clusterIP: None
-  {{- else }}
   type: {{ $serviceType }}
+  {{- if $isHeadless }}
+  clusterIP: None
   {{- end }}
   ports:
     {{- with $service.ports }}

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -294,6 +294,8 @@ service:
   name: ""
   labels: {}
   annotations: {}
+  # Set to true to configure a headless service (`clusterIP: None`).
+  headless: false
   # If true, skip cloud-provider specific resources and annotations for this service
   internal: false
   # This path is currently only used for AWS ALB health checks
@@ -308,6 +310,15 @@ service:
 
 # Additional services to create (same schema as `service`)
 # NOTE: every entry in `services` must set `name`.
+# Example headless service:
+# - name: app-headless
+#   enabled: true
+#   headless: true
+#   ports:
+#     - port: 80
+#       targetPort: http
+#       protocol: TCP
+#       name: http
 services: []
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -294,6 +294,8 @@ service:
   name: ""
   labels: {}
   annotations: {}
+  # If true, skip cloud-provider specific resources and annotations for this service
+  internal: false
   # This path is currently only used for AWS ALB health checks
   loadBalancerHealthCheckPath: ""
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
@@ -303,6 +305,9 @@ service:
       targetPort: http
       protocol: TCP
       name: http
+
+# Additional services to create (same schema as `service`)
+services: []
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -307,6 +307,7 @@ service:
       name: http
 
 # Additional services to create (same schema as `service`)
+# NOTE: every entry in `services` must set `name`.
 services: []
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2667,7 +2667,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3267,7 +3267,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3415,7 +3415,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3550,7 +3550,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4059,7 +4059,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4532,7 +4532,7 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3043,7 +3043,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3213,7 +3213,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3808,7 +3808,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4445,7 +4445,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4603,7 +4603,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4910,7 +4910,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5197,7 +5197,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.11.11
+        helm.sh/chart: filestream-0.12.0
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5506,7 +5506,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.11.11
+        helm.sh/chart: flat-run-fields-updater-0.12.0
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5803,7 +5803,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5961,7 +5961,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6529,7 +6529,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: metric-observer-0.11.11
+        helm.sh/chart: metric-observer-0.12.0
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6843,7 +6843,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6992,7 +6992,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7514,7 +7514,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8021,7 +8021,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -2892,7 +2892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3040,7 +3040,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3591,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4184,7 +4184,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4320,7 +4320,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4605,7 +4605,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4870,7 +4870,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5006,7 +5006,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5530,7 +5530,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5657,7 +5657,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6157,7 +6157,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6620,7 +6620,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2279,7 +2279,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2851,7 +2851,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2981,7 +2981,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3385,7 +3385,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3791,7 +3791,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2313,7 +2313,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2885,7 +2885,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3011,7 +3011,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3290,7 +3290,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3694,7 +3694,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4100,7 +4100,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2313,7 +2313,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2885,7 +2885,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3014,7 +3014,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.11.11
+        helm.sh/chart: flat-run-fields-updater-0.12.0
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3283,7 +3283,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3687,7 +3687,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4093,7 +4093,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2279,7 +2279,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2851,7 +2851,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2981,7 +2981,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3385,7 +3385,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3759,7 +3759,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -2782,7 +2782,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2930,7 +2930,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3486,7 +3486,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3622,7 +3622,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3907,7 +3907,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4172,7 +4172,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4308,7 +4308,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4837,7 +4837,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4964,7 +4964,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5464,7 +5464,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5927,7 +5927,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -2892,7 +2892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3040,7 +3040,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3596,7 +3596,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4185,7 +4185,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4321,7 +4321,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4606,7 +4606,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4871,7 +4871,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5007,7 +5007,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5536,7 +5536,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5663,7 +5663,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6163,7 +6163,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6626,7 +6626,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3219,7 +3219,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3770,7 +3770,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4363,7 +4363,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4499,7 +4499,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5023,7 +5023,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: mcp-server-0.11.11
+        helm.sh/chart: mcp-server-0.12.0
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.2"
@@ -5198,7 +5198,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5325,7 +5325,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5825,7 +5825,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.11.11
+        helm.sh/chart: weave-trace-0.12.0
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6072,7 +6072,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6882,7 +6882,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -2892,7 +2892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3040,7 +3040,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3591,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4184,7 +4184,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4320,7 +4320,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4605,7 +4605,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4870,7 +4870,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5006,7 +5006,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5530,7 +5530,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5657,7 +5657,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6157,7 +6157,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6620,7 +6620,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -2902,7 +2902,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3621,7 +3621,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4234,7 +4234,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4370,7 +4370,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4655,7 +4655,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4920,7 +4920,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5056,7 +5056,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5580,7 +5580,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5707,7 +5707,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6207,7 +6207,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6670,7 +6670,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -8518,13 +8518,15 @@ spec:
         echo "OK: TEST_CONNECTION_URL is set"
       fi
       exit $fail
-  restartPolicy: Never---
+  restartPolicy: Never
+---
+# Source: operator-wandb/templates/tests/test-olap.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-olap-registry-search"
   labels:
-    helm.sh/chart: operator-wandb-0.42.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -8577,13 +8579,15 @@ spec:
         echo "OK: TEST_CONNECTION_URL is set"
       fi
       exit $fail
-  restartPolicy: Never---
+  restartPolicy: Never
+---
+# Source: operator-wandb/templates/tests/test-olap.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-olap-run-store-accelerator"
   labels:
-    helm.sh/chart: operator-wandb-0.42.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3376,7 +3376,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3524,7 +3524,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4155,7 +4155,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4748,7 +4748,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4884,7 +4884,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5169,7 +5169,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5434,7 +5434,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5570,7 +5570,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6174,7 +6174,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6301,7 +6301,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6820,7 +6820,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.11.11
+        helm.sh/chart: weave-trace-0.12.0
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7067,7 +7067,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7877,7 +7877,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -2796,7 +2796,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3427,7 +3427,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4020,7 +4020,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4159,7 +4159,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4295,7 +4295,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4899,7 +4899,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5026,7 +5026,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5526,7 +5526,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5989,7 +5989,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -6535,13 +6535,15 @@ spec:
         echo "OK: TEST_CONNECTION_URL is set"
       fi
       exit $fail
-  restartPolicy: Never---
+  restartPolicy: Never
+---
+# Source: operator-wandb/templates/tests/test-olap.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: "chartsnap-operator-wandb-test-olap-run-store-accelerator"
   labels:
-    helm.sh/chart: operator-wandb-0.42.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: operator-wandb
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3165,7 +3165,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3323,7 +3323,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3894,7 +3894,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4507,7 +4507,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4653,7 +4653,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4948,7 +4948,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5223,7 +5223,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.11.11
+        helm.sh/chart: flat-run-fields-updater-0.12.0
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5508,7 +5508,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5654,7 +5654,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6198,7 +6198,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6335,7 +6335,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6845,7 +6845,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7628,7 +7628,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -2892,7 +2892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3040,7 +3040,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3619,7 +3619,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4240,7 +4240,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4376,7 +4376,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4661,7 +4661,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4926,7 +4926,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5062,7 +5062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5586,7 +5586,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5713,7 +5713,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6213,7 +6213,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6676,7 +6676,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2395,7 +2395,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2929,7 +2929,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3501,7 +3501,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3631,7 +3631,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4035,7 +4035,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4473,7 +4473,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2395,7 +2395,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2929,7 +2929,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3501,7 +3501,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3633,7 +3633,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4037,7 +4037,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4475,7 +4475,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2395,7 +2395,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2929,7 +2929,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3501,7 +3501,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3633,7 +3633,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4037,7 +4037,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4475,7 +4475,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2511,7 +2511,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2653,7 +2653,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3230,7 +3230,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3364,7 +3364,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3858,7 +3858,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4309,7 +4309,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2637,7 +2637,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -2775,7 +2775,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3309,7 +3309,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3881,7 +3881,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4007,7 +4007,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
@@ -4285,7 +4285,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.11.11
+        helm.sh/chart: filestream-0.12.0
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
@@ -4565,7 +4565,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.11.11
+        helm.sh/chart: flat-run-fields-updater-0.12.0
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
@@ -4830,7 +4830,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5338,7 +5338,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5742,7 +5742,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6308,7 +6308,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2637,7 +2637,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -2775,7 +2775,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3309,7 +3309,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3881,7 +3881,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4007,7 +4007,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
@@ -4285,7 +4285,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filestream-0.11.11
+        helm.sh/chart: filestream-0.12.0
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
@@ -4565,7 +4565,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.11.11
+        helm.sh/chart: flat-run-fields-updater-0.12.0
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
@@ -4830,7 +4830,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5338,7 +5338,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5742,7 +5742,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6308,7 +6308,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2479,7 +2479,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3046,7 +3046,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3655,7 +3655,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3804,7 +3804,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4226,7 +4226,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4703,7 +4703,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2396,7 +2396,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2930,7 +2930,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3502,7 +3502,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3632,7 +3632,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4036,7 +4036,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4474,7 +4474,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2411,7 +2411,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2965,7 +2965,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3557,7 +3557,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3687,7 +3687,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4091,7 +4091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4529,7 +4529,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2411,7 +2411,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2965,7 +2965,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3557,7 +3557,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3687,7 +3687,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4091,7 +4091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4529,7 +4529,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2512,7 +2512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2655,7 +2655,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3233,7 +3233,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3368,7 +3368,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3863,7 +3863,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4316,7 +4316,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2288,7 +2288,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2870,7 +2870,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3000,7 +3000,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3409,7 +3409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3815,7 +3815,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2279,7 +2279,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2855,7 +2855,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2985,7 +2985,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3391,7 +3391,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3797,7 +3797,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2754,7 +2754,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2907,7 +2907,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3452,7 +3452,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4044,7 +4044,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4188,7 +4188,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4455,7 +4455,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4979,7 +4979,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5484,7 +5484,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5957,7 +5957,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -2892,7 +2892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3040,7 +3040,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3591,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4184,7 +4184,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4320,7 +4320,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4605,7 +4605,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4870,7 +4870,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5006,7 +5006,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5530,7 +5530,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5657,7 +5657,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6157,7 +6157,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6622,7 +6622,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2333,7 +2333,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2905,7 +2905,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3035,7 +3035,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3439,7 +3439,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.11.11
+        helm.sh/chart: weave-trace-0.12.0
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3686,7 +3686,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4124,7 +4124,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3240,7 +3240,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3388,7 +3388,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3995,7 +3995,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4594,7 +4594,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4730,7 +4730,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5018,7 +5018,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5286,7 +5286,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5422,7 +5422,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6002,7 +6002,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6129,7 +6129,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6632,7 +6632,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7445,7 +7445,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3641,7 +3641,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3789,7 +3789,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4340,7 +4340,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4933,7 +4933,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5069,7 +5069,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5354,7 +5354,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5619,7 +5619,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5755,7 +5755,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6279,7 +6279,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6406,7 +6406,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6906,7 +6906,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.11.11
+        helm.sh/chart: weave-evaluate-model-worker-0.12.0
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7057,7 +7057,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.11.11
+        helm.sh/chart: weave-trace-worker-0.12.0
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7208,7 +7208,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.11.11
+        helm.sh/chart: weave-trace-0.12.0
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7455,7 +7455,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8565,7 +8565,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3334,7 +3334,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.11.11
+        helm.sh/chart: anaconda2-0.12.0
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3482,7 +3482,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: api-0.11.11
+        helm.sh/chart: api-0.12.0
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4033,7 +4033,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.11.11
+        helm.sh/chart: app-0.12.0
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4626,7 +4626,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.11.11
+        helm.sh/chart: console-0.12.0
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4762,7 +4762,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: executor-0.11.11
+        helm.sh/chart: executor-0.12.0
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5047,7 +5047,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: filemeta-0.11.11
+        helm.sh/chart: filemeta-0.12.0
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5312,7 +5312,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.11.11
+        helm.sh/chart: frontend-0.12.0
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5448,7 +5448,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: glue-0.11.11
+        helm.sh/chart: glue-0.12.0
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5972,7 +5972,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.11.11
+        helm.sh/chart: nginx-0.12.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6099,7 +6099,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: parquet-0.11.11
+        helm.sh/chart: parquet-0.12.0
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6599,7 +6599,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.11.11
+        helm.sh/chart: weave-trace-0.12.0
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6846,7 +6846,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.11.11
+        helm.sh/chart: weave-0.12.0
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7656,7 +7656,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.11.11
+            helm.sh/chart: parquet-0.12.0
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/wandb-base/.chartsnap.yaml
+++ b/test-configs/wandb-base/.chartsnap.yaml
@@ -2,3 +2,11 @@ dynamicFields:
   - jsonPath:
     - /metadata/labels/helm.sh~1chart
     value: '###CHART_VERSION###'
+  - kind: Job
+    jsonPath:
+      - /spec/template/metadata/labels/helm.sh~1chart
+    value: "###CHART_VERSION###"
+  - kind: Deployment
+    jsonPath:
+      - /spec/template/metadata/labels/helm.sh~1chart
+    value: "###CHART_VERSION###"

--- a/test-configs/wandb-base/__snapshots__/global-volumeMounts-override.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumeMounts-override.snap
@@ -46,7 +46,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wandb-base-0.11.11
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: wandb-base
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm

--- a/test-configs/wandb-base/__snapshots__/global-volumes-and-mounts.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumes-and-mounts.snap
@@ -46,7 +46,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wandb-base-0.11.11
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: wandb-base
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm

--- a/test-configs/wandb-base/__snapshots__/global-volumes-override.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumes-override.snap
@@ -46,7 +46,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wandb-base-0.11.11
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: wandb-base
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm

--- a/test-configs/wandb-base/__snapshots__/global-volumes.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumes.snap
@@ -46,7 +46,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wandb-base-0.11.11
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: wandb-base
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm

--- a/test-configs/wandb-base/__snapshots__/ingress-gcp.snap
+++ b/test-configs/wandb-base/__snapshots__/ingress-gcp.snap
@@ -58,7 +58,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wandb-base-0.11.11
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: wandb-base
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `service.internal` configuration option to control cloud provider resource behavior
  * Added `service.headless` configuration option to allow creation of headless services
  * Enabled defining multiple additional services alongside the primary service

* **Improvements**
  * Enhanced service template with improved support for internal and headless services
  * Refined cloud provider resource handling based on service type

* **Chores**
  * Updated wandb-base dependency to version 0.12.0
  * Bumped operator-wandb chart to version 0.42.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->