### PR TITLE
feat(operator-wandb): use deployment-wide Azure storage identity

### DIFF
--- a/.github/workflows/test-operator-wandb.yaml
+++ b/.github/workflows/test-operator-wandb.yaml
@@ -29,6 +29,8 @@ jobs:
           popd
           helm plugin install https://github.com/origranot/helm-cascade
           helm cascade build ./charts/operator-wandb/
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.1.1
+          helm unittest --file 'tests/azure_storage_auth_test.yaml' ./charts/operator-wandb/
           helm plugin install https://github.com/jlandowner/helm-chartsnap
           ./snapshots.sh run
       # currently this action always tries to install helm, so dont use it for now

--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
-digest: sha256:bcdecca7a05ea099496166ece8dadd0ed4735cfdfa10969debebadf4975ba6f5
-generated: "2026-07-15T03:47:17.895685-05:00"
+  version: 0.12.4
+digest: sha256:6c378616605bdde9cb62aa59528ac25bbb43f26b7e08610e58316d4be125561c
+generated: "2026-07-08T16:53:12.842245-07:00"

--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
-digest: sha256:6c378616605bdde9cb62aa59528ac25bbb43f26b7e08610e58316d4be125561c
-generated: "2026-07-08T16:53:12.842245-07:00"
+  version: 0.12.5
+digest: sha256:bcdecca7a05ea099496166ece8dadd0ed4735cfdfa10969debebadf4975ba6f5
+generated: "2026-07-28T13:31:57.307079-05:00"

--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://../wandb-base
   version: 0.12.5
 digest: sha256:bcdecca7a05ea099496166ece8dadd0ed4735cfdfa10969debebadf4975ba6f5
-generated: "2026-07-28T13:31:57.307079-05:00"
+generated: "2026-07-15T03:47:17.895685-05:00"

--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
-digest: sha256:bcdecca7a05ea099496166ece8dadd0ed4735cfdfa10969debebadf4975ba6f5
-generated: "2026-07-28T13:31:57.307079-05:00"
+  version: 0.12.6
+digest: sha256:60d1023fe307cba27e2dfe573be514601dc0dcacb6d72f91323615fedaa42772
+generated: "2026-07-29T18:00:40.632395-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.4
+version: 0.2.3
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,16 +61,16 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -79,39 +79,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:849d7e51087e44492f5b62dcddb6a681e79284417acca20d562272fb5b3ab236
-generated: "2026-07-15T03:40:08.826928-05:00"
+digest: sha256:0e67f6021c73fce140809b538b15641945271a9b56fb30b3c193a72f37a5d747
+generated: "2026-07-08T16:53:16.185582-07:00"

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
   version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.5
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,34 +82,34 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,39 +82,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:c184b462210609f094cf2064dffeb2c2aeebb22e6af809ec45d1f1b0ba91df91
-generated: "2026-07-29T16:15:40.380955-04:00"
+digest: sha256:25515ff6c8eb5603fede4c98b59dd5c1db5271efdee90839f9a3a6b6a6890681
+generated: "2026-07-29T17:56:35.934531-05:00"

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -116,5 +116,5 @@ dependencies:
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:25515ff6c8eb5603fede4c98b59dd5c1db5271efdee90839f9a3a6b6a6890681
-generated: "2026-07-29T17:56:35.934531-05:00"
+digest: sha256:039ae3137a49174b04980ea7cafdd5f83fc517a898b577278b76a587b1723266
+generated: "2026-08-05T08:44:45.513577-05:00"

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,16 +61,16 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -79,39 +79,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:0e67f6021c73fce140809b538b15641945271a9b56fb30b3c193a72f37a5d747
-generated: "2026-07-08T16:53:16.185582-07:00"
+digest: sha256:849d7e51087e44492f5b62dcddb6a681e79284417acca20d562272fb5b3ab236
+generated: "2026-07-28T13:31:53.413788-05:00"

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
   version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,34 +82,34 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,16 +61,16 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -79,39 +79,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:849d7e51087e44492f5b62dcddb6a681e79284417acca20d562272fb5b3ab236
-generated: "2026-07-28T13:31:53.413788-05:00"
+digest: sha256:25515ff6c8eb5603fede4c98b59dd5c1db5271efdee90839f9a3a6b6a6890681
+generated: "2026-07-29T17:56:35.934531-05:00"

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -114,4 +114,4 @@ dependencies:
   repository: file://charts/clickhouse
   version: 9.1.1
 digest: sha256:849d7e51087e44492f5b62dcddb6a681e79284417acca20d562272fb5b3ab236
-generated: "2026-07-28T13:31:53.413788-05:00"
+generated: "2026-07-15T03:40:08.826928-05:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: console
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,15 +109,15 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: filestream
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -137,52 +137,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: console
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,12 +109,12 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
@@ -122,7 +122,7 @@ dependencies:
     version: "0.12.5"
   - name: wandb-base
     alias: filestream
-    version: "0.12.5"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.6
+version: 0.44.0
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: console
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,15 +109,15 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: filestream
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -137,52 +137,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: console
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,15 +109,15 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: filestream
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -137,52 +137,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.10
+version: 0.44.0
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: console
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,12 +109,12 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
@@ -122,7 +122,7 @@ dependencies:
     version: "0.12.5"
   - name: wandb-base
     alias: filestream
-    version: "0.12.4"
+    version: "0.12.5"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.9
+version: 0.43.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: console
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,20 +109,20 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: filestream
-    version: "0.12.5"
+    version: "0.12.6"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/charts/bufstream/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/bufstream/templates/_helpers.tpl
@@ -21,6 +21,34 @@ Helpers to allow overriding the namespace
 {{- end -}}
 
 {{/*
+Select the umbrella chart's Azure storage ServiceAccount when Bufstream uses
+the deployment-wide identity. Bucket-scoped identity and key-based BYOB retain
+the component account.
+*/}}
+{{- define "bufstream.azureStorageServiceAccountEnabled" -}}
+  {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $globalConfigured := and (not (empty $identity.tenantId)) (not (empty $identity.clientId)) -}}
+  {{- $bucket := default (dict) .Values.global.bucket -}}
+  {{- $hasCustomerBucket := not (empty $bucket.name) -}}
+  {{- $defaultBucket := default (dict) .Values.global.defaultBucket -}}
+  {{- $usesDeploymentIdentity := or
+  (and (not $hasCustomerBucket) (eq $defaultBucket.provider "az"))
+  (and $hasCustomerBucket (eq $bucket.azureAuthMethod "workloadIdentity"))
+  -}}
+{{- and $globalConfigured $usesDeploymentIdentity -}}
+{{- end -}}
+
+{{- define "bufstream.serviceAccountName" -}}
+{{- if include "bufstream.azureStorageServiceAccountEnabled" . | trim | eq "true" -}}
+  {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+{{ default "wandb-bucket-access" $serviceAccount.name }}
+{{- else -}}
+{{ .Values.bufstream.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Helpers to generate application configurations from a base, allowing arbitrary overrides from a value
 */}}
 

--- a/charts/operator-wandb/charts/bufstream/templates/cluster-role-bind.yaml
+++ b/charts/operator-wandb/charts/bufstream/templates/cluster-role-bind.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "bufstream.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.bufstream.serviceAccount.name }}
+  name: {{ include "bufstream.serviceAccountName" . }}
   namespace: {{ include "bufstream.namespace" . }}
 roleRef:
   kind: ClusterRole

--- a/charts/operator-wandb/charts/bufstream/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/bufstream/templates/deployment.yaml
@@ -1,5 +1,9 @@
 apiVersion: apps/v1
 kind: {{ .Values.bufstream.deployment.kind | default "Deployment" }}
+{{- $podLabels := deepCopy (default (dict) .Values.bufstream.deployment.podLabels) }}
+{{- if include "bufstream.azureStorageServiceAccountEnabled" . | trim | eq "true" }}
+  {{- $_ := set $podLabels "azure.workload.identity/use" "true" }}
+{{- end }}
 metadata:
   name: {{ include "bufstream.name" . }}
   namespace: {{ include "bufstream.namespace" . }}
@@ -26,7 +30,7 @@ spec:
         {{- include "bufstream.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: bufstream
         bufstream.buf.build/cluster: {{ .Values.cluster | quote }}
-        {{- with .Values.bufstream.deployment.podLabels }}
+        {{- with $podLabels }}
           {{- toYaml . | nindent 8 -}}
         {{- end }}
       annotations:
@@ -238,7 +242,7 @@ spec:
         {{- with .Values.bufstream.deployment.extraContainers }}
         {{ include "bufstream.render" (dict "value" . "context" $) | nindent 8 }}
         {{- end }}
-      serviceAccountName: {{ tpl .Values.bufstream.serviceAccount.name . }}
+      serviceAccountName: {{ include "bufstream.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.bufstream.deployment.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume

--- a/charts/operator-wandb/charts/bufstream/templates/service-account.yaml
+++ b/charts/operator-wandb/charts/bufstream/templates/service-account.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.bufstream.serviceAccount.create }}
+{{- if and .Values.bufstream.serviceAccount.create (not (include "bufstream.azureStorageServiceAccountEnabled" . | trim | eq "true")) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.bufstream.serviceAccount.name }}
+  name: {{ include "bufstream.serviceAccountName" . }}
   namespace: {{ include "bufstream.namespace" . }}
   labels:
     {{- include "bufstream.labels" . | nindent 4 }}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -13,6 +13,31 @@
 {{ .Release.Name }}-bucket-configmap
 {{- end -}}
 
+{{/*
+Returns the effective Azure storage identity. The dedicated global override is
+owned by the deployment and takes precedence over the CR/user bucket values.
+*/}}
+{{- define "wandb.azureStorageIdentity" -}}
+{{- $bucket := include "wandb.bucket" . | fromYaml -}}
+{{- $override := default (dict) .Values.global.azureStorageIdentity -}}
+{{- $overrideTenantId := default "" $override.tenantId -}}
+{{- $overrideClientId := default "" $override.clientId -}}
+{{- $tenantId := default "" $bucket.azureTenantId -}}
+{{- $clientId := default "" $bucket.azureClientId -}}
+{{- $overrideConfigured := or (not (empty $overrideTenantId)) (not (empty $overrideClientId)) -}}
+{{- if $overrideConfigured -}}
+  {{- if ne (empty $overrideTenantId) (empty $overrideClientId) -}}
+    {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
+  {{- end -}}
+  {{- $tenantId = $overrideTenantId -}}
+  {{- $clientId = $overrideClientId -}}
+{{- else if and (eq $bucket.provider "az") (ne (empty $tenantId) (empty $clientId)) -}}
+  {{- fail "Azure bucket azureTenantId and azureClientId must be provided together" -}}
+{{- end -}}
+{{- $enabled := and (eq $bucket.provider "az") (not (empty $tenantId)) (not (empty $clientId)) -}}
+{{- dict "enabled" $enabled "tenantId" $tenantId "clientId" $clientId | toYaml -}}
+{{- end }}
+
 
 {{- define "wandb.bucket" -}}
 {{- $url := "" -}}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -72,8 +72,8 @@ provider: {{ $provider }}
 path: {{ $path }}
 accessKey: {{ $accessKey }}
 secretKey: {{ $secretKey }}
-azureTenantId: {{ $azureTenantId }}
-azureClientId: {{ $azureClientId }}
+azureTenantId: {{ $azureTenantId | toJson }}
+azureClientId: {{ $azureClientId | toJson }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}
 secretName: {{ include "wandb.bucket.secret" . }}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -15,7 +15,8 @@
 
 {{/*
 Returns the effective Azure storage identity. The dedicated global override is
-owned by the deployment and takes precedence over the CR/user bucket values.
+supplied by the customer's infrastructure and takes precedence over the
+W&B-managed CR bucket values.
 */}}
 {{- define "wandb.azureStorageIdentity" -}}
 {{- $bucket := include "wandb.bucket" . | fromYaml -}}
@@ -36,6 +37,11 @@ owned by the deployment and takes precedence over the CR/user bucket values.
 {{- end -}}
 {{- $enabled := and (eq $bucket.provider "az") (not (empty $tenantId)) (not (empty $clientId)) -}}
 {{- dict "enabled" $enabled "tenantId" $tenantId "clientId" $clientId | toYaml -}}
+{{- end }}
+
+{{/* Return whether the effective Azure storage identity is configured. */}}
+{{- define "wandb.azureStorageIdentityEnabled" -}}
+{{- (include "wandb.azureStorageIdentity" . | fromYaml).enabled -}}
 {{- end }}
 
 

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -80,7 +80,8 @@ Legacy bucket-scoped identities deliberately retain their component accounts.
   {{- $identity := include "wandb.azureStorageIdentity" . | fromYaml -}}
   {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
   {{- $globalConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
-{{- and $globalConfigured $identity.enabled -}}
+  {{- $weaveUsesDefaultBucket := include "wandb.weaveTraceUsesAzureWorkloadIdentity" . | trim | eq "true" -}}
+{{- and $globalConfigured (or $identity.enabled $weaveUsesDefaultBucket) -}}
 {{- end }}
 
 {{- define "wandb.azureStorageServiceAccountName" -}}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -14,35 +14,96 @@
 {{- end -}}
 
 {{/*
-Returns the effective Azure storage identity. The global identity belongs to
-the infrastructure-managed default bucket. A customer BYOB bucket uses its own
-credentials and must not inherit the default bucket identity.
+Returns the Azure identity used to authenticate the effective bucket. The
+global identity belongs to the deployment. Customer buckets retain the legacy
+key path unless they explicitly select workload identity.
 */}}
 {{- define "wandb.azureStorageIdentity" -}}
 {{- $bucket := include "wandb.bucket" . | fromYaml -}}
 {{- $hasCustomerBucket := not (empty .Values.global.bucket.name) -}}
-{{- $override := default (dict) .Values.global.azureStorageIdentity -}}
-{{- $overrideTenantId := default "" $override.tenantId -}}
-{{- $overrideClientId := default "" $override.clientId -}}
+{{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+{{- $globalTenantId := default "" $globalIdentity.tenantId -}}
+{{- $globalClientId := default "" $globalIdentity.clientId -}}
 {{- $tenantId := default "" $bucket.azureTenantId -}}
 {{- $clientId := default "" $bucket.azureClientId -}}
-{{- $overrideConfigured := or (not (empty $overrideTenantId)) (not (empty $overrideClientId)) -}}
-{{- if and (not $hasCustomerBucket) $overrideConfigured -}}
-  {{- if ne (empty $overrideTenantId) (empty $overrideClientId) -}}
-    {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
-  {{- end -}}
-  {{- $tenantId = $overrideTenantId -}}
-  {{- $clientId = $overrideClientId -}}
-{{- else if and (eq $bucket.provider "az") (ne (empty $tenantId) (empty $clientId)) -}}
+{{- $globalConfigured := and (not (empty $globalTenantId)) (not (empty $globalClientId)) -}}
+{{- $bucketIdentityConfigured := and (not (empty $tenantId)) (not (empty $clientId)) -}}
+{{- $authMethod := default "" .Values.global.bucket.azureAuthMethod -}}
+{{- if ne (empty $globalTenantId) (empty $globalClientId) -}}
+  {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
+{{- end -}}
+{{- if and (eq $bucket.provider "az") (ne (empty $tenantId) (empty $clientId)) -}}
   {{- fail "Azure bucket azureTenantId and azureClientId must be provided together" -}}
 {{- end -}}
-{{- $enabled := and (eq $bucket.provider "az") (not (empty $tenantId)) (not (empty $clientId)) -}}
+{{- if and (not (empty $authMethod)) (not (has $authMethod (list "accessKey" "workloadIdentity"))) -}}
+  {{- fail "global.bucket.azureAuthMethod must be accessKey or workloadIdentity" -}}
+{{- end -}}
+{{- $enabled := false -}}
+{{- if and $hasCustomerBucket (eq $authMethod "workloadIdentity") -}}
+  {{- if not $globalConfigured -}}
+    {{- fail "global.azureStorageIdentity.tenantId and clientId are required when global.bucket.azureAuthMethod is workloadIdentity" -}}
+  {{- end -}}
+  {{- $tenantId = $globalTenantId -}}
+  {{- $clientId = $globalClientId -}}
+  {{- $enabled = true -}}
+{{- else if and $hasCustomerBucket (eq $authMethod "accessKey") -}}
+  {{- $enabled = false -}}
+{{- else if and $hasCustomerBucket (eq $bucket.provider "az") $bucketIdentityConfigured -}}
+  {{- /* Backward compatibility for existing bucket-scoped identity values. */ -}}
+  {{- $enabled = true -}}
+{{- else if and (not $hasCustomerBucket) (eq $bucket.provider "az") $globalConfigured -}}
+  {{- $tenantId = $globalTenantId -}}
+  {{- $clientId = $globalClientId -}}
+  {{- $enabled = true -}}
+{{- else if and (not $hasCustomerBucket) (eq $bucket.provider "az") $bucketIdentityConfigured -}}
+  {{- $enabled = true -}}
+{{- end -}}
 {{- dict "enabled" $enabled "tenantId" $tenantId "clientId" $clientId | toYaml -}}
 {{- end }}
 
-{{/* Return whether the effective Azure storage identity is configured. */}}
+{{/*
+Return whether Azure workload identity token injection is needed anywhere in
+the deployment. Bucket authentication can still use a storage key.
+*/}}
 {{- define "wandb.azureStorageIdentityEnabled" -}}
-{{- (include "wandb.azureStorageIdentity" . | fromYaml).enabled -}}
+{{- $identity := include "wandb.azureStorageIdentity" . | fromYaml -}}
+{{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+{{- $globalConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+{{- or $globalConfigured $identity.enabled -}}
+{{- end }}
+
+{{/*
+Return the URI used when Weave explicitly opts into the deployment bucket.
+Weave accepts az://<account>/<container>; a W&B bucket path with a prefix
+cannot be represented without changing Weave's object layout.
+*/}}
+{{- define "wandb.weaveTraceFileStorageURI" -}}
+{{- $weaveTrace := index .Values.global "weave-trace" | default dict -}}
+{{- $fileStorage := index $weaveTrace "fileStorage" | default dict -}}
+{{- if (index $fileStorage "useDefaultBucket" | default false) -}}
+  {{- $bucket := .Values.global.defaultBucket -}}
+  {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $identityConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+  {{- if ne $bucket.provider "az" -}}
+    {{- fail "global.weave-trace.fileStorage.useDefaultBucket currently requires an Azure bucket" -}}
+  {{- end -}}
+  {{- if not $identityConfigured -}}
+    {{- fail "global.weave-trace.fileStorage.useDefaultBucket requires global.azureStorageIdentity" -}}
+  {{- end -}}
+  {{- $pathParts := splitList "/" (trimAll "/" $bucket.path) -}}
+  {{- if or (empty $bucket.path) (ne (len $pathParts) 1) -}}
+    {{- fail "global.weave-trace.fileStorage.useDefaultBucket requires global.defaultBucket.path to contain exactly one Azure container name and no object prefix" -}}
+  {{- end -}}
+  {{- printf "az://%s/%s" $bucket.name (first $pathParts) -}}
+{{- end -}}
+{{- end }}
+
+{{- define "wandb.weaveTraceUsesAzureWorkloadIdentity" -}}
+{{- $weaveTrace := index .Values.global "weave-trace" | default dict -}}
+{{- $fileStorage := index $weaveTrace "fileStorage" | default dict -}}
+{{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+{{- $identityConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+{{- and (index $fileStorage "useDefaultBucket" | default false) $identityConfigured -}}
 {{- end }}
 
 

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -14,19 +14,20 @@
 {{- end -}}
 
 {{/*
-Returns the effective Azure storage identity. The dedicated global override is
-supplied by the customer's infrastructure and takes precedence over the
-W&B-managed CR bucket values.
+Returns the effective Azure storage identity. The global identity belongs to
+the infrastructure-managed default bucket. A customer BYOB bucket uses its own
+credentials and must not inherit the default bucket identity.
 */}}
 {{- define "wandb.azureStorageIdentity" -}}
 {{- $bucket := include "wandb.bucket" . | fromYaml -}}
+{{- $hasCustomerBucket := not (empty .Values.global.bucket.name) -}}
 {{- $override := default (dict) .Values.global.azureStorageIdentity -}}
 {{- $overrideTenantId := default "" $override.tenantId -}}
 {{- $overrideClientId := default "" $override.clientId -}}
 {{- $tenantId := default "" $bucket.azureTenantId -}}
 {{- $clientId := default "" $bucket.azureClientId -}}
 {{- $overrideConfigured := or (not (empty $overrideTenantId)) (not (empty $overrideClientId)) -}}
-{{- if $overrideConfigured -}}
+{{- if and (not $hasCustomerBucket) $overrideConfigured -}}
   {{- if ne (empty $overrideTenantId) (empty $overrideClientId) -}}
     {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
   {{- end -}}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -73,6 +73,23 @@ the deployment. Bucket authentication can still use a storage key.
 {{- end }}
 
 {{/*
+Return whether workloads can use the deployment-wide Azure storage account.
+Legacy bucket-scoped identities deliberately retain their component accounts.
+*/}}
+{{- define "wandb.azureStorageServiceAccountEnabled" -}}
+  {{- $identity := include "wandb.azureStorageIdentity" . | fromYaml -}}
+  {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $globalConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+{{- and $globalConfigured $identity.enabled -}}
+{{- end }}
+
+{{- define "wandb.azureStorageServiceAccountName" -}}
+  {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+{{- default "wandb-bucket-access" $serviceAccount.name -}}
+{{- end }}
+
+{{/*
 Return the URI used when Weave explicitly opts into the deployment bucket.
 Weave accepts az://<account>/<container>; a W&B bucket path with a prefix
 cannot be represented without changing Weave's object layout.

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -19,45 +19,45 @@ global identity belongs to the deployment. Customer buckets retain the legacy
 key path unless they explicitly select workload identity.
 */}}
 {{- define "wandb.azureStorageIdentity" -}}
-{{- $bucket := include "wandb.bucket" . | fromYaml -}}
-{{- $hasCustomerBucket := not (empty .Values.global.bucket.name) -}}
-{{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
-{{- $globalTenantId := default "" $globalIdentity.tenantId -}}
-{{- $globalClientId := default "" $globalIdentity.clientId -}}
-{{- $tenantId := default "" $bucket.azureTenantId -}}
-{{- $clientId := default "" $bucket.azureClientId -}}
-{{- $globalConfigured := and (not (empty $globalTenantId)) (not (empty $globalClientId)) -}}
-{{- $bucketIdentityConfigured := and (not (empty $tenantId)) (not (empty $clientId)) -}}
-{{- $authMethod := default "" .Values.global.bucket.azureAuthMethod -}}
-{{- if ne (empty $globalTenantId) (empty $globalClientId) -}}
-  {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
-{{- end -}}
-{{- if and (eq $bucket.provider "az") (ne (empty $tenantId) (empty $clientId)) -}}
-  {{- fail "Azure bucket azureTenantId and azureClientId must be provided together" -}}
-{{- end -}}
-{{- if and (not (empty $authMethod)) (not (has $authMethod (list "accessKey" "workloadIdentity"))) -}}
-  {{- fail "global.bucket.azureAuthMethod must be accessKey or workloadIdentity" -}}
-{{- end -}}
-{{- $enabled := false -}}
-{{- if and $hasCustomerBucket (eq $authMethod "workloadIdentity") -}}
-  {{- if not $globalConfigured -}}
-    {{- fail "global.azureStorageIdentity.tenantId and clientId are required when global.bucket.azureAuthMethod is workloadIdentity" -}}
+  {{- $bucket := include "wandb.bucket" . | fromYaml -}}
+  {{- $hasCustomerBucket := not (empty .Values.global.bucket.name) -}}
+  {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $globalTenantId := default "" $globalIdentity.tenantId -}}
+  {{- $globalClientId := default "" $globalIdentity.clientId -}}
+  {{- $tenantId := default "" $bucket.azureTenantId -}}
+  {{- $clientId := default "" $bucket.azureClientId -}}
+  {{- $globalConfigured := and (not (empty $globalTenantId)) (not (empty $globalClientId)) -}}
+  {{- $bucketIdentityConfigured := and (not (empty $tenantId)) (not (empty $clientId)) -}}
+  {{- $authMethod := default "" .Values.global.bucket.azureAuthMethod -}}
+  {{- if ne (empty $globalTenantId) (empty $globalClientId) -}}
+    {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
   {{- end -}}
-  {{- $tenantId = $globalTenantId -}}
-  {{- $clientId = $globalClientId -}}
-  {{- $enabled = true -}}
-{{- else if and $hasCustomerBucket (eq $authMethod "accessKey") -}}
-  {{- $enabled = false -}}
-{{- else if and $hasCustomerBucket (eq $bucket.provider "az") $bucketIdentityConfigured -}}
-  {{- /* Backward compatibility for existing bucket-scoped identity values. */ -}}
-  {{- $enabled = true -}}
-{{- else if and (not $hasCustomerBucket) (eq $bucket.provider "az") $globalConfigured -}}
-  {{- $tenantId = $globalTenantId -}}
-  {{- $clientId = $globalClientId -}}
-  {{- $enabled = true -}}
-{{- else if and (not $hasCustomerBucket) (eq $bucket.provider "az") $bucketIdentityConfigured -}}
-  {{- $enabled = true -}}
-{{- end -}}
+  {{- if and (eq $bucket.provider "az") (ne (empty $tenantId) (empty $clientId)) -}}
+    {{- fail "Azure bucket azureTenantId and azureClientId must be provided together" -}}
+  {{- end -}}
+  {{- if and (not (empty $authMethod)) (not (has $authMethod (list "accessKey" "workloadIdentity"))) -}}
+    {{- fail "global.bucket.azureAuthMethod must be accessKey or workloadIdentity" -}}
+  {{- end -}}
+  {{- $enabled := false -}}
+  {{- if and $hasCustomerBucket (eq $authMethod "workloadIdentity") -}}
+    {{- if not $globalConfigured -}}
+      {{- fail "global.azureStorageIdentity.tenantId and clientId are required when global.bucket.azureAuthMethod is workloadIdentity" -}}
+    {{- end -}}
+    {{- $tenantId = $globalTenantId -}}
+    {{- $clientId = $globalClientId -}}
+    {{- $enabled = true -}}
+  {{- else if and $hasCustomerBucket (eq $authMethod "accessKey") -}}
+    {{- $enabled = false -}}
+  {{- else if and $hasCustomerBucket (eq $bucket.provider "az") $bucketIdentityConfigured -}}
+    {{- /* Backward compatibility for existing bucket-scoped identity values. */ -}}
+    {{- $enabled = true -}}
+  {{- else if and (not $hasCustomerBucket) (eq $bucket.provider "az") $globalConfigured -}}
+    {{- $tenantId = $globalTenantId -}}
+    {{- $clientId = $globalClientId -}}
+    {{- $enabled = true -}}
+  {{- else if and (not $hasCustomerBucket) (eq $bucket.provider "az") $bucketIdentityConfigured -}}
+    {{- $enabled = true -}}
+  {{- end -}}
 {{- dict "enabled" $enabled "tenantId" $tenantId "clientId" $clientId | toYaml -}}
 {{- end }}
 
@@ -66,9 +66,9 @@ Return whether Azure workload identity token injection is needed anywhere in
 the deployment. Bucket authentication can still use a storage key.
 */}}
 {{- define "wandb.azureStorageIdentityEnabled" -}}
-{{- $identity := include "wandb.azureStorageIdentity" . | fromYaml -}}
-{{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
-{{- $globalConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+  {{- $identity := include "wandb.azureStorageIdentity" . | fromYaml -}}
+  {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $globalConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
 {{- or $globalConfigured $identity.enabled -}}
 {{- end }}
 
@@ -78,60 +78,60 @@ Weave accepts az://<account>/<container>; a W&B bucket path with a prefix
 cannot be represented without changing Weave's object layout.
 */}}
 {{- define "wandb.weaveTraceFileStorageURI" -}}
-{{- $weaveTrace := index .Values.global "weave-trace" | default dict -}}
-{{- $fileStorage := index $weaveTrace "fileStorage" | default dict -}}
-{{- if (index $fileStorage "useDefaultBucket" | default false) -}}
-  {{- $bucket := .Values.global.defaultBucket -}}
-  {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
-  {{- $identityConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
-  {{- if ne $bucket.provider "az" -}}
-    {{- fail "global.weave-trace.fileStorage.useDefaultBucket currently requires an Azure bucket" -}}
+  {{- $weaveTrace := index .Values.global "weave-trace" | default dict -}}
+  {{- $fileStorage := index $weaveTrace "fileStorage" | default dict -}}
+  {{- if (index $fileStorage "useDefaultBucket" | default false) -}}
+    {{- $bucket := .Values.global.defaultBucket -}}
+    {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+    {{- $identityConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+    {{- if ne $bucket.provider "az" -}}
+      {{- fail "global.weave-trace.fileStorage.useDefaultBucket currently requires an Azure bucket" -}}
+    {{- end -}}
+    {{- if not $identityConfigured -}}
+      {{- fail "global.weave-trace.fileStorage.useDefaultBucket requires global.azureStorageIdentity" -}}
+    {{- end -}}
+    {{- $pathParts := splitList "/" (trimAll "/" $bucket.path) -}}
+    {{- if or (empty $bucket.path) (ne (len $pathParts) 1) -}}
+      {{- fail "global.weave-trace.fileStorage.useDefaultBucket requires global.defaultBucket.path to contain exactly one Azure container name and no object prefix" -}}
+    {{- end -}}
+    {{- printf "az://%s/%s" $bucket.name (first $pathParts) -}}
   {{- end -}}
-  {{- if not $identityConfigured -}}
-    {{- fail "global.weave-trace.fileStorage.useDefaultBucket requires global.azureStorageIdentity" -}}
-  {{- end -}}
-  {{- $pathParts := splitList "/" (trimAll "/" $bucket.path) -}}
-  {{- if or (empty $bucket.path) (ne (len $pathParts) 1) -}}
-    {{- fail "global.weave-trace.fileStorage.useDefaultBucket requires global.defaultBucket.path to contain exactly one Azure container name and no object prefix" -}}
-  {{- end -}}
-  {{- printf "az://%s/%s" $bucket.name (first $pathParts) -}}
-{{- end -}}
 {{- end }}
 
 {{- define "wandb.weaveTraceUsesAzureWorkloadIdentity" -}}
-{{- $weaveTrace := index .Values.global "weave-trace" | default dict -}}
-{{- $fileStorage := index $weaveTrace "fileStorage" | default dict -}}
-{{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
-{{- $identityConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
+  {{- $weaveTrace := index .Values.global "weave-trace" | default dict -}}
+  {{- $fileStorage := index $weaveTrace "fileStorage" | default dict -}}
+  {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $identityConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
 {{- and (index $fileStorage "useDefaultBucket" | default false) $identityConfigured -}}
 {{- end }}
 
 
 {{- define "wandb.bucket" -}}
-{{- $url := "" -}}
-{{- $path := "" -}}
-{{- $provider := "" -}}
-{{- $accessKey := "" -}}
-{{- $secretKey := "" -}}
-{{- $azureTenantId := "" -}}
-{{- $azureClientId := "" -}}
-{{- if .Values.global.bucket.name -}}
-{{- $provider = .Values.global.bucket.provider -}}
-{{- $path = .Values.global.bucket.path -}}
-{{- $accessKey = default "" .Values.global.bucket.accessKey -}}
-{{- $secretKey = default "" .Values.global.bucket.secretKey -}}
-{{- $azureTenantId = default "" .Values.global.bucket.azureTenantId -}}
-{{- $azureClientId = default "" .Values.global.bucket.azureClientId -}}
+  {{- $url := "" -}}
+  {{- $path := "" -}}
+  {{- $provider := "" -}}
+  {{- $accessKey := "" -}}
+  {{- $secretKey := "" -}}
+  {{- $azureTenantId := "" -}}
+  {{- $azureClientId := "" -}}
+  {{- if .Values.global.bucket.name -}}
+    {{- $provider = .Values.global.bucket.provider -}}
+    {{- $path = .Values.global.bucket.path -}}
+    {{- $accessKey = default "" .Values.global.bucket.accessKey -}}
+    {{- $secretKey = default "" .Values.global.bucket.secretKey -}}
+    {{- $azureTenantId = default "" .Values.global.bucket.azureTenantId -}}
+    {{- $azureClientId = default "" .Values.global.bucket.azureClientId -}}
 name: {{ .Values.global.bucket.name }}
 region: {{ .Values.global.bucket.region }}
 kmsKey: {{ .Values.global.bucket.kmsKey }}
-{{- else -}}
-{{- $provider = .Values.global.defaultBucket.provider -}}
-{{- $path = .Values.global.defaultBucket.path -}}
-{{- $accessKey = default "" .Values.global.defaultBucket.accessKey -}}
-{{- $secretKey = default "" .Values.global.defaultBucket.secretKey -}}
-{{- $azureTenantId = default "" .Values.global.defaultBucket.azureTenantId -}}
-{{- $azureClientId = default "" .Values.global.defaultBucket.azureClientId -}}
+  {{- else -}}
+    {{- $provider = .Values.global.defaultBucket.provider -}}
+    {{- $path = .Values.global.defaultBucket.path -}}
+    {{- $accessKey = default "" .Values.global.defaultBucket.accessKey -}}
+    {{- $secretKey = default "" .Values.global.defaultBucket.secretKey -}}
+    {{- $azureTenantId = default "" .Values.global.defaultBucket.azureTenantId -}}
+    {{- $azureClientId = default "" .Values.global.defaultBucket.azureClientId -}}
 name: {{ .Values.global.defaultBucket.name }}
 region: {{ .Values.global.defaultBucket.region }}
 kmsKey: {{ .Values.global.defaultBucket.kmsKey }}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -15,24 +15,30 @@
 
 
 {{- define "wandb.bucket" -}}
-  {{- $url := "" -}}
-  {{- $path := "" -}}
-  {{- $provider := "" -}}
-  {{- $accessKey := "" -}}
-  {{- $secretKey := "" -}}
-  {{- if .Values.global.bucket.name -}}
-    {{- $provider = .Values.global.bucket.provider -}}
-    {{- $path = .Values.global.bucket.path -}}
-    {{- $accessKey = default "" .Values.global.bucket.accessKey -}}
-    {{- $secretKey = default "" .Values.global.bucket.secretKey -}}
+{{- $url := "" -}}
+{{- $path := "" -}}
+{{- $provider := "" -}}
+{{- $accessKey := "" -}}
+{{- $secretKey := "" -}}
+{{- $azureTenantId := "" -}}
+{{- $azureClientId := "" -}}
+{{- if .Values.global.bucket.name -}}
+{{- $provider = .Values.global.bucket.provider -}}
+{{- $path = .Values.global.bucket.path -}}
+{{- $accessKey = default "" .Values.global.bucket.accessKey -}}
+{{- $secretKey = default "" .Values.global.bucket.secretKey -}}
+{{- $azureTenantId = default "" .Values.global.bucket.azureTenantId -}}
+{{- $azureClientId = default "" .Values.global.bucket.azureClientId -}}
 name: {{ .Values.global.bucket.name }}
 region: {{ .Values.global.bucket.region }}
 kmsKey: {{ .Values.global.bucket.kmsKey }}
-  {{- else -}}
-    {{- $provider = .Values.global.defaultBucket.provider -}}
-    {{- $path = .Values.global.defaultBucket.path -}}
-    {{- $accessKey = default "" .Values.global.defaultBucket.accessKey -}}
-    {{- $secretKey = default "" .Values.global.defaultBucket.secretKey -}}
+{{- else -}}
+{{- $provider = .Values.global.defaultBucket.provider -}}
+{{- $path = .Values.global.defaultBucket.path -}}
+{{- $accessKey = default "" .Values.global.defaultBucket.accessKey -}}
+{{- $secretKey = default "" .Values.global.defaultBucket.secretKey -}}
+{{- $azureTenantId = default "" .Values.global.defaultBucket.azureTenantId -}}
+{{- $azureClientId = default "" .Values.global.defaultBucket.azureClientId -}}
 name: {{ .Values.global.defaultBucket.name }}
 region: {{ .Values.global.defaultBucket.region }}
 kmsKey: {{ .Values.global.defaultBucket.kmsKey }}
@@ -41,6 +47,8 @@ provider: {{ $provider }}
 path: {{ $path }}
 accessKey: {{ $accessKey }}
 secretKey: {{ $secretKey }}
+azureTenantId: {{ $azureTenantId }}
+azureClientId: {{ $azureClientId }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}
 secretName: {{ include "wandb.bucket.secret" . }}

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -59,6 +59,14 @@ Global values will override any chart-specific values.
       name: {{ (include "wandb.bucket" . | fromYaml).secretName | quote }}
       key: {{ (include "wandb.bucket" . | fromYaml).accessKeyName | quote }}
       optional: true
+{{- if (include "wandb.bucket" . | fromYaml).azureTenantId }}
+- name: AZURE_STORAGE_TENANT_ID
+  value: {{ (include "wandb.bucket" . | fromYaml).azureTenantId | quote }}
+{{- end }}
+{{- if (include "wandb.bucket" . | fromYaml).azureClientId }}
+- name: AZURE_STORAGE_CLIENT_ID
+  value: {{ (include "wandb.bucket" . | fromYaml).azureClientId | quote }}
+{{- end }}
 - name: BUCKET_ACCESS_KEY
   valueFrom:
     secretKeyRef:

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -64,9 +64,17 @@ Global values will override any chart-specific values.
 {{- end }}
 {{- if $azureIdentity.enabled }}
 - name: AZURE_STORAGE_TENANT_ID
+{{- if kindIs "map" $azureIdentity.tenantId }}
+{{- toYaml $azureIdentity.tenantId | nindent 2 }}
+{{- else }}
   value: {{ $azureIdentity.tenantId | quote }}
+{{- end }}
 - name: AZURE_STORAGE_CLIENT_ID
+{{- if kindIs "map" $azureIdentity.clientId }}
+{{- toYaml $azureIdentity.clientId | nindent 2 }}
+{{- else }}
   value: {{ $azureIdentity.clientId | quote }}
+{{- end }}
 {{- end }}
 - name: BUCKET_ACCESS_KEY
   valueFrom:

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -53,29 +53,28 @@ Global values will override any chart-specific values.
 {{- end -}}
 
 {{- define "wandb.bucketEnvs" -}}
-{{- $azureIdentity := include "wandb.azureStorageIdentity" . | fromYaml -}}
-{{- if not $azureIdentity.enabled }}
+  {{- $azureIdentity := include "wandb.azureStorageIdentity" . | fromYaml -}}
+  {{- if not $azureIdentity.enabled }}
 - name: AZURE_STORAGE_KEY
   valueFrom:
     secretKeyRef:
       name: {{ (include "wandb.bucket" . | fromYaml).secretName | quote }}
       key: {{ (include "wandb.bucket" . | fromYaml).accessKeyName | quote }}
       optional: true
-{{- end }}
-{{- if $azureIdentity.enabled }}
+  {{- else }}
 - name: AZURE_STORAGE_TENANT_ID
-{{- if kindIs "map" $azureIdentity.tenantId }}
+    {{- if kindIs "map" $azureIdentity.tenantId }}
 {{- toYaml $azureIdentity.tenantId | nindent 2 }}
-{{- else }}
+    {{- else }}
   value: {{ $azureIdentity.tenantId | quote }}
-{{- end }}
+    {{- end }}
 - name: AZURE_STORAGE_CLIENT_ID
-{{- if kindIs "map" $azureIdentity.clientId }}
+    {{- if kindIs "map" $azureIdentity.clientId }}
 {{- toYaml $azureIdentity.clientId | nindent 2 }}
-{{- else }}
+    {{- else }}
   value: {{ $azureIdentity.clientId | quote }}
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 - name: BUCKET_ACCESS_KEY
   valueFrom:
     secretKeyRef:

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -124,6 +124,7 @@ Global values will override any chart-specific values.
   {{- end }}
 {{- end -}}
 
+
 {{- define "wandb.mysqlConfigEnvs" -}}
   {{- /*
     ATTENTION!

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -53,19 +53,20 @@ Global values will override any chart-specific values.
 {{- end -}}
 
 {{- define "wandb.bucketEnvs" -}}
+{{- $azureIdentity := include "wandb.azureStorageIdentity" . | fromYaml -}}
+{{- if not $azureIdentity.enabled }}
 - name: AZURE_STORAGE_KEY
   valueFrom:
     secretKeyRef:
       name: {{ (include "wandb.bucket" . | fromYaml).secretName | quote }}
       key: {{ (include "wandb.bucket" . | fromYaml).accessKeyName | quote }}
       optional: true
-{{- if (include "wandb.bucket" . | fromYaml).azureTenantId }}
-- name: AZURE_STORAGE_TENANT_ID
-  value: {{ (include "wandb.bucket" . | fromYaml).azureTenantId | quote }}
 {{- end }}
-{{- if (include "wandb.bucket" . | fromYaml).azureClientId }}
+{{- if $azureIdentity.enabled }}
+- name: AZURE_STORAGE_TENANT_ID
+  value: {{ $azureIdentity.tenantId | quote }}
 - name: AZURE_STORAGE_CLIENT_ID
-  value: {{ (include "wandb.bucket" . | fromYaml).azureClientId | quote }}
+  value: {{ $azureIdentity.clientId | quote }}
 {{- end }}
 - name: BUCKET_ACCESS_KEY
   valueFrom:
@@ -655,4 +656,3 @@ Global values will override any chart-specific values.
   value: "true"
   {{- end }}
 {{- end -}}
-

--- a/charts/operator-wandb/templates/azure-storage-serviceaccount.yaml
+++ b/charts/operator-wandb/templates/azure-storage-serviceaccount.yaml
@@ -1,10 +1,16 @@
 {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
 {{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+{{- $annotations := default (dict) $serviceAccount.annotations -}}
 {{- $create := true -}}
 {{- if hasKey $serviceAccount "create" -}}
   {{- $create = $serviceAccount.create -}}
 {{- end -}}
 {{- if and (include "wandb.azureStorageServiceAccountEnabled" . | trim | eq "true") $create }}
+  {{- if kindIs "string" $identity.clientId -}}
+    {{- $annotations = merge $annotations (dict "azure.workload.identity/client-id" $identity.clientId) -}}
+  {{- else if not (hasKey $annotations "azure.workload.identity/client-id") -}}
+    {{- fail "global.azureStorageIdentity.serviceAccount.annotations.azure.workload.identity/client-id is required when clientId is not a literal string" -}}
+  {{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,7 +20,7 @@ metadata:
   {{- with $serviceAccount.labels }}
       {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with $serviceAccount.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/operator-wandb/templates/azure-storage-serviceaccount.yaml
+++ b/charts/operator-wandb/templates/azure-storage-serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+{{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+{{- $create := true -}}
+{{- if hasKey $serviceAccount "create" -}}
+  {{- $create = $serviceAccount.create -}}
+{{- end -}}
+{{- if and (include "wandb.azureStorageServiceAccountEnabled" . | trim | eq "true") $create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wandb.azureStorageServiceAccountName" . }}
+  labels:
+    {{- include "wandb.commonLabels" . | nindent 4 }}
+  {{- with $serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/operator-wandb/templates/bucket.yaml
+++ b/charts/operator-wandb/templates/bucket.yaml
@@ -22,8 +22,8 @@ metadata:
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
-{{- with include "wandb.bucket" . | fromYaml }}
-  {{- if and .accessKey (not $azureIdentity.enabled) }}
+  {{- with include "wandb.bucket" . | fromYaml }}
+    {{- if and .accessKey (not $azureIdentity.enabled) }}
   {{ .accessKeyName }}: {{ .accessKey | b64enc }}
     {{- end }}
     {{- if .secretKey }}

--- a/charts/operator-wandb/templates/bucket.yaml
+++ b/charts/operator-wandb/templates/bucket.yaml
@@ -26,7 +26,7 @@ data:
     {{- if and .accessKey (not $azureIdentity.enabled) }}
   {{ .accessKeyName }}: {{ .accessKey | b64enc }}
     {{- end }}
-    {{- if .secretKey }}
+    {{- if and .secretKey (not $azureIdentity.enabled) }}
   {{ .secretKeyName }}: {{ .secretKey | b64enc }}
     {{- end }}
   {{- end }}

--- a/charts/operator-wandb/templates/bucket.yaml
+++ b/charts/operator-wandb/templates/bucket.yaml
@@ -1,3 +1,4 @@
+{{- $azureIdentity := include "wandb.azureStorageIdentity" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,8 +22,8 @@ metadata:
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
-  {{- with include "wandb.bucket" . | fromYaml }}
-    {{- if .accessKey }}
+{{- with include "wandb.bucket" . | fromYaml }}
+  {{- if and .accessKey (not $azureIdentity.enabled) }}
   {{ .accessKeyName }}: {{ .accessKey | b64enc }}
     {{- end }}
     {{- if .secretKey }}

--- a/charts/operator-wandb/templates/weave-trace.yaml
+++ b/charts/operator-wandb/templates/weave-trace.yaml
@@ -27,4 +27,7 @@ data:
   KAFKA_BROKER_HOST: "{{ include "wandb.kafka.brokerHost" . }}"
   KAFKA_BROKER_PORT: "{{ include "wandb.kafka.brokerPort" . }}"
   WEAVE_REDIS_URL: "{{ include "wandb.redis.connectionString" . | trim }}"
-
+  {{- $fileStorageURI := include "wandb.weaveTraceFileStorageURI" . }}
+  {{- if $fileStorageURI }}
+  WF_FILE_STORAGE_URI: {{ $fileStorageURI | quote }}
+  {{- end }}

--- a/charts/operator-wandb/templates/weave-trace.yaml
+++ b/charts/operator-wandb/templates/weave-trace.yaml
@@ -27,7 +27,7 @@ data:
   KAFKA_BROKER_HOST: "{{ include "wandb.kafka.brokerHost" . }}"
   KAFKA_BROKER_PORT: "{{ include "wandb.kafka.brokerPort" . }}"
   WEAVE_REDIS_URL: "{{ include "wandb.redis.connectionString" . | trim }}"
-  {{- $fileStorageURI := include "wandb.weaveTraceFileStorageURI" . }}
-  {{- if $fileStorageURI }}
+{{- $fileStorageURI := include "wandb.weaveTraceFileStorageURI" . }}
+{{- if $fileStorageURI }}
   WF_FILE_STORAGE_URI: {{ $fileStorageURI | quote }}
-  {{- end }}
+{{- end }}

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -345,6 +345,59 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: wandb-bucket-access
 
+  - it: creates the shared account for Weave's default bucket alongside access-key BYOB
+    template: templates/azure-storage-serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          secretKey: customer-storage-secret
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: wandb-bucket-access
+
+  - it: does not create the shared account for ordinary access-key BYOB
+    template: templates/azure-storage-serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          secretKey: customer-storage-secret
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: keeps Weave on its component account when its default bucket gate is disabled
     template: charts/weave-trace/templates/deployment.yaml
     set:

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -13,6 +13,7 @@ tests:
           name: managed-storage-account
           path: managed-container
           accessKey: orphaned-managed-storage-key
+          secretKey: orphaned-managed-storage-secret
         azureStorageIdentity:
           tenantId: tenant-id
           clientId: client-id
@@ -21,6 +22,8 @@ tests:
     asserts:
       - notExists:
           path: data.ACCESS_KEY
+      - notExists:
+          path: data.SECRET_KEY
 
   - it: renders the customer access key when BYOB explicitly uses key authentication
     set:
@@ -30,6 +33,7 @@ tests:
           name: customer-storage-account
           path: customer-container
           accessKey: customer-storage-key
+          secretKey: customer-storage-secret
           azureAuthMethod: accessKey
         azureStorageIdentity:
           tenantId: tenant-id
@@ -40,3 +44,6 @@ tests:
       - equal:
           path: data.ACCESS_KEY
           value: Y3VzdG9tZXItc3RvcmFnZS1rZXk=
+      - equal:
+          path: data.SECRET_KEY
+          value: Y3VzdG9tZXItc3RvcmFnZS1zZWNyZXQ=

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -1,0 +1,42 @@
+suite: Azure storage authentication
+templates:
+  - templates/bucket.yaml
+release:
+  name: chartsnap
+
+tests:
+  - it: does not render a stale managed access key when workload identity is enabled
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+          accessKey: orphaned-managed-storage-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    template: templates/bucket.yaml
+    documentIndex: 1
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+
+  - it: renders the customer access key when BYOB explicitly uses key authentication
+    set:
+      global:
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    template: templates/bucket.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: data.ACCESS_KEY
+          value: Y3VzdG9tZXItc3RvcmFnZS1rZXk=

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -56,6 +56,27 @@ tests:
           path: data.SECRET_KEY
           value: Y3VzdG9tZXItc3RvcmFnZS1zZWNyZXQ=
 
+  - it: suppresses stale customer keys when BYOB explicitly uses workload identity
+    set:
+      global:
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: orphaned-customer-storage-key
+          secretKey: orphaned-customer-storage-secret
+          azureAuthMethod: workloadIdentity
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    template: templates/bucket.yaml
+    documentIndex: 1
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+      - notExists:
+          path: data.SECRET_KEY
+
   - it: creates one chart-owned shared account for the deployment-wide identity
     template: templates/azure-storage-serviceaccount.yaml
     set:
@@ -262,6 +283,49 @@ tests:
           provider: az
           name: managed-storage-account
           path: managed-container
+        azureStorageIdentity:
+          tenantId:
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: tenant-id
+          clientId:
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: client-id
+          serviceAccount:
+            annotations:
+              azure.workload.identity/client-id: infrastructure-client-id
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_TENANT_ID
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: tenant-id
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: client-id
+          any: true
+
+  - it: uses deployment identity references for workload-identity BYOB
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          azureAuthMethod: workloadIdentity
         azureStorageIdentity:
           tenantId:
             valueFrom:

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -6,6 +6,9 @@ templates:
   - charts/app/templates/serviceaccount.yaml
   - charts/app/templates/rolebinding.yaml
   - charts/weave-trace/templates/deployment.yaml
+  - charts/bufstream/templates/deployment.yaml
+  - charts/bufstream/templates/service-account.yaml
+  - charts/bufstream/templates/cluster-role-bind.yaml
 release:
   name: chartsnap
 
@@ -65,8 +68,6 @@ tests:
           tenantId: tenant-id
           clientId: client-id
           serviceAccount:
-            annotations:
-              azure.workload.identity/client-id: client-id
             labels:
               identity.wandb.ai/storage: shared
     asserts:
@@ -81,6 +82,52 @@ tests:
       - equal:
           path: metadata.labels["identity.wandb.ai/storage"]
           value: shared
+
+  - it: preserves explicit annotations for a reference-valued Azure client ID
+    template: templates/azure-storage-serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId:
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: client-id
+          serviceAccount:
+            annotations:
+              azure.workload.identity/client-id: infrastructure-client-id
+              identity.wandb.ai/federated: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["azure.workload.identity/client-id"]
+          value: infrastructure-client-id
+      - equal:
+          path: metadata.annotations["identity.wandb.ai/federated"]
+          value: "true"
+
+  - it: rejects a reference-valued Azure client ID without a ServiceAccount annotation
+    template: templates/azure-storage-serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId:
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: client-id
+    asserts:
+      - failedTemplate:
+          errorMessage: global.azureStorageIdentity.serviceAccount.annotations.azure.workload.identity/client-id is required when clientId is not a literal string
 
   - it: selects the chart-owned shared account without creating component accounts
     template: charts/app/templates/deployment.yaml
@@ -226,6 +273,9 @@ tests:
               secretKeyRef:
                 name: azure-storage-identity
                 key: client-id
+          serviceAccount:
+            annotations:
+              azure.workload.identity/client-id: infrastructure-client-id
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -266,3 +316,158 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: wandb-bucket-access
+
+  - it: gives Weave the shared account when its default bucket gate is enabled alongside access-key BYOB
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace:
+        install: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          secretKey: customer-storage-secret
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: wandb-bucket-access
+
+  - it: keeps Weave on its component account when its default bucket gate is disabled
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace:
+        install: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          secretKey: customer-storage-secret
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-weave-trace
+
+  - it: gives Bufstream the shared account and suppresses its component account
+    template: charts/bufstream/templates/deployment.yaml
+    set:
+      bufstream:
+        install: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: wandb-bucket-access
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+
+  - it: suppresses the Bufstream component account in shared identity mode
+    template: charts/bufstream/templates/service-account.yaml
+    set:
+      bufstream:
+        install: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: follows the shared account in Bufstream node-reader bindings
+    template: charts/bufstream/templates/cluster-role-bind.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: wandb-bucket-access
+
+  - it: keeps Bufstream on its component account for access-key BYOB
+    template: charts/bufstream/templates/deployment.yaml
+    set:
+      bufstream:
+        install: true
+      global:
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          secretKey: customer-storage-secret
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: bufstream-service-account
+
+  - it: gives Bufstream an externally-created shared account by its configured name
+    template: charts/bufstream/templates/deployment.yaml
+    set:
+      bufstream:
+        install: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            name: externally-created-bucket-access
+            create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: externally-created-bucket-access

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -1,6 +1,11 @@
 suite: Azure storage authentication
 templates:
   - templates/bucket.yaml
+  - templates/azure-storage-serviceaccount.yaml
+  - charts/app/templates/deployment.yaml
+  - charts/app/templates/serviceaccount.yaml
+  - charts/app/templates/rolebinding.yaml
+  - charts/weave-trace/templates/deployment.yaml
 release:
   name: chartsnap
 
@@ -47,3 +52,217 @@ tests:
       - equal:
           path: data.SECRET_KEY
           value: Y3VzdG9tZXItc3RvcmFnZS1zZWNyZXQ=
+
+  - it: creates one chart-owned shared account for the deployment-wide identity
+    template: templates/azure-storage-serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            annotations:
+              azure.workload.identity/client-id: client-id
+            labels:
+              identity.wandb.ai/storage: shared
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: wandb-bucket-access
+      - equal:
+          path: metadata.annotations["azure.workload.identity/client-id"]
+          value: client-id
+      - equal:
+          path: metadata.labels["identity.wandb.ai/storage"]
+          value: shared
+
+  - it: selects the chart-owned shared account without creating component accounts
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: wandb-bucket-access
+
+  - it: suppresses the app component account when the shared account is selected
+    template: charts/app/templates/serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: follows the shared account in component role bindings
+    template: charts/app/templates/rolebinding.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+      app:
+        role:
+          create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: wandb-bucket-access
+
+  - it: does not render an externally-created shared account
+    template: templates/azure-storage-serviceaccount.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            name: externally-created-bucket-access
+            create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses an externally-created shared account in storage workloads
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            name: externally-created-bucket-access
+            create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: externally-created-bucket-access
+
+  - it: preserves component accounts for a legacy bucket-scoped identity
+    template: charts/app/templates/serviceaccount.yaml
+    set:
+      global:
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          azureTenantId: legacy-tenant-id
+          azureClientId: legacy-client-id
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: chartsnap-app
+
+  - it: preserves component accounts for explicit Azure access-key BYOB
+    template: charts/app/templates/serviceaccount.yaml
+    set:
+      global:
+        bucket:
+          provider: az
+          name: customer-storage-account
+          path: customer-container
+          accessKey: customer-storage-key
+          secretKey: customer-storage-secret
+          azureAuthMethod: accessKey
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: chartsnap-app
+
+  - it: renders Azure identity references after JSON helper serialization
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId:
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: tenant-id
+          clientId:
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: client-id
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_TENANT_ID
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: tenant-id
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: azure-storage-identity
+                key: client-id
+          any: true
+
+  - it: gives Weave the shared account only when it opts into the default bucket
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace:
+        install: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: wandb-bucket-access

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,6 +396,13 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
+  # Deployment-owned Azure workload identity for Blob storage. When set, this
+  # pair takes precedence over identity values in both bucket and defaultBucket,
+  # so a user-edited CR cannot replace the infrastructure-managed identity.
+  azureStorageIdentity:
+    tenantId: ""
+    clientId: ""
+
   # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
   defaultBucket:
     # az, s3, gcs
@@ -588,6 +595,8 @@ artifactsGc:
   DeleteFilesNumWorkers: 0
 
 api:
+  azureWorkloadIdentity:
+    enabled: true
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -784,6 +793,8 @@ api:
           minReplicas: 2
 
 app:
+  azureWorkloadIdentity:
+    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -1116,6 +1127,8 @@ console:
         verbs: ["get"]
 
 executor:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   deploymentPostfix: "bc"
   workerConcurrency: 10
@@ -1234,6 +1247,8 @@ executor:
           minReplicas: 2
 
 filemeta:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -1397,6 +1412,8 @@ anaconda2:
           minReplicas: 2
 
 filestream:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1504,6 +1521,8 @@ filestream:
           minReplicas: 1
 
 flat-run-fields-updater:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1789,6 +1808,8 @@ flat-run-fields-updater:
           # triggers must be provided by user when enabling KEDA
 
 history-updater:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   pubSub:
     # pubSub subscription comes from terraform
@@ -2069,6 +2090,8 @@ history-updater:
 
 # history-reader is a gRPC service that serves run history from ClickHouse.
 history-reader:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2321,6 +2344,8 @@ frontend:
           minReplicas: 2
 
 glue:
+  azureWorkloadIdentity:
+    enabled: true
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
@@ -2503,6 +2528,8 @@ internalSignerPreHook:
         verbs: ["get", "patch", "create", "update"]
 
 metric-observer:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2641,6 +2668,8 @@ metric-observer:
           minReplicas: 8
 
 parquet:
+  azureWorkloadIdentity:
+    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -2842,6 +2871,8 @@ parquet:
           minReplicas: 2
 
 parquet-metadata-cache:
+  azureWorkloadIdentity:
+    enabled: true
   maxColumnChunks: 10000000
   install: false
   serviceAccount:
@@ -2971,6 +3002,8 @@ parquet-metadata-cache:
           minReplicas: 1
 
 settingsMigrationJob:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -4142,6 +4175,8 @@ bufstream:
           memory: 4Gi
 
 lumen-agent:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   kind: CronJob
   image:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,9 +396,9 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
-  # Customer-supplied Azure workload identity for Blob storage. When set, this
-  # pair takes precedence over identity values in both bucket and defaultBucket,
-  # allowing the customer's infrastructure identity to override the W&B-managed CR.
+  # Infrastructure-managed Azure workload identity for the default Blob storage
+  # bucket. A customer BYOB bucket does not inherit this identity; it uses the
+  # access key or identity values configured on global.bucket.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
   #   clientId:
   #     valueFrom:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,9 +396,9 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
-  # Infrastructure-managed Azure workload identity for the default Blob storage
-  # bucket. A customer BYOB bucket does not inherit this identity; it uses the
-  # access key or identity values configured on global.bucket.
+  # Infrastructure-managed Azure workload identity for this deployment. The
+  # managed default bucket uses this identity. A customer Azure bucket can opt
+  # in with global.bucket.azureAuthMethod: workloadIdentity.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
   #   clientId:
   #     valueFrom:
@@ -408,6 +408,9 @@ global:
   azureStorageIdentity:
     tenantId: null
     clientId: null
+    # Principal ID is exposed to administrators for Azure role assignments.
+    # The chart does not use it for pod authentication.
+    principalId: null
 
   # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
   defaultBucket:
@@ -430,6 +433,10 @@ global:
 
   # If specified, the application will use this bucket for all storage operations, and will not be overridable by the user.
   bucket:
+    # Azure only. Existing configurations default to access-key authentication.
+    # Set to workloadIdentity to use global.azureStorageIdentity.
+    azureAuthMethod: null
+    # Legacy bucket-scoped identity values remain supported.
     # azureTenantId: ""
     # azureClientId: ""
     secret:
@@ -512,6 +519,10 @@ global:
 
   weave-trace:
     enabled: false
+    # Weave stores files in ClickHouse unless this is explicitly enabled.
+    # Enable only with a Weave image that supports Azure workload identity.
+    fileStorage:
+      useDefaultBucket: false
 
   # As part of the migration away from using local, the `bypass` setting will
   # control whether the gorilla services will use the app service (and, thus, local)
@@ -3495,6 +3506,8 @@ mcp-server:
 weave-trace:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3633,6 +3646,8 @@ weave-trace:
 weave-trace-worker:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3742,6 +3757,8 @@ weave-trace-worker:
 weave-evaluate-model-worker:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3845,6 +3862,8 @@ weave-evaluate-model-worker:
 weave-trace-agent-scoring-worker:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -404,9 +404,20 @@ global:
     path: ""
     region: ""
     kmsKey: ""
+    # Azure (provider "az") identity-based auth. When both are set the application
+    # authenticates to Blob storage with an Entra ID workload identity
+    # (user-delegation SAS) and the storage account access key is optional.
+    # NOTE: the pod must also run with Azure workload identity enabled -- the
+    # ServiceAccount needs the `azure.workload.identity/client-id` annotation and
+    # the pod the `azure.workload.identity/use: "true"` label so the federated
+    # token is projected. See PR description for the remaining infra wiring.
+    azureTenantId: ""
+    azureClientId: ""
 
   # If specified, the application will use this bucket for all storage operations, and will not be overridable by the user.
   bucket:
+    # azureTenantId: ""
+    # azureClientId: ""
     secret:
       secretName: ""
       accessKeyName: "ACCESS_KEY"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -422,8 +422,8 @@ global:
     # authenticates to Blob storage with an Entra ID workload identity
     # (user-delegation SAS) and the storage account access key is optional.
     # The chart adds the required workload-identity pod label to services that
-    # consume bucket credentials. ServiceAccount annotations supplied by the
-    # customer's infrastructure remain supported but are not required here.
+    # consume bucket credentials. The customer's infrastructure must separately
+    # configure federated credentials and ServiceAccount annotations.
     azureTenantId: null
     azureClientId: null
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -399,9 +399,18 @@ global:
   # Deployment-owned Azure workload identity for Blob storage. When set, this
   # pair takes precedence over identity values in both bucket and defaultBucket,
   # so a user-edited CR cannot replace the infrastructure-managed identity.
+  # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
+  #   clientId:
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: azure-storage-identity
+  #         key: client-id
+  # Referenced values cannot be copied into ServiceAccount annotations. In that
+  # mode, provide azure.workload.identity/client-id through each bucket-consuming
+  # service's serviceAccount.annotations.
   azureStorageIdentity:
-    tenantId: ""
-    clientId: ""
+    tenantId: null
+    clientId: null
 
   # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
   defaultBucket:
@@ -411,15 +420,16 @@ global:
     path: ""
     region: ""
     kmsKey: ""
-    # Azure (provider "az") identity-based auth. When both are set the application
+    # Azure (provider "az") identity-based auth. Each value can be a literal
+    # string or a Kubernetes EnvVarSource-style map. When both are set the application
     # authenticates to Blob storage with an Entra ID workload identity
     # (user-delegation SAS) and the storage account access key is optional.
-    # NOTE: the pod must also run with Azure workload identity enabled -- the
-    # ServiceAccount needs the `azure.workload.identity/client-id` annotation and
-    # the pod the `azure.workload.identity/use: "true"` label so the federated
-    # token is projected. See PR description for the remaining infra wiring.
-    azureTenantId: ""
-    azureClientId: ""
+    # The chart detects workloads that consume bucket envs and adds the required
+    # pod label. It also adds ServiceAccount annotations for literal IDs; when
+    # using valueFrom, provide the client-id annotation separately because
+    # Kubernetes annotations cannot reference Secrets or ConfigMaps.
+    azureTenantId: null
+    azureClientId: null
 
   # If specified, the application will use this bucket for all storage operations, and will not be overridable by the user.
   bucket:
@@ -595,8 +605,6 @@ artifactsGc:
   DeleteFilesNumWorkers: 0
 
 api:
-  azureWorkloadIdentity:
-    enabled: true
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -793,8 +801,6 @@ api:
           minReplicas: 2
 
 app:
-  azureWorkloadIdentity:
-    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -1127,8 +1133,6 @@ console:
         verbs: ["get"]
 
 executor:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   deploymentPostfix: "bc"
   workerConcurrency: 10
@@ -1247,8 +1251,6 @@ executor:
           minReplicas: 2
 
 filemeta:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -1412,8 +1414,6 @@ anaconda2:
           minReplicas: 2
 
 filestream:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1521,8 +1521,6 @@ filestream:
           minReplicas: 1
 
 flat-run-fields-updater:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1808,8 +1806,6 @@ flat-run-fields-updater:
           # triggers must be provided by user when enabling KEDA
 
 history-updater:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   pubSub:
     # pubSub subscription comes from terraform
@@ -2395,8 +2391,6 @@ run-store-accelerator-run-updater:
 
 # history-reader is a gRPC service that serves run history from ClickHouse.
 history-reader:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2649,8 +2643,6 @@ frontend:
           minReplicas: 2
 
 glue:
-  azureWorkloadIdentity:
-    enabled: true
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
@@ -2833,8 +2825,6 @@ internalSignerPreHook:
         verbs: ["get", "patch", "create", "update"]
 
 metric-observer:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2973,8 +2963,6 @@ metric-observer:
           minReplicas: 8
 
 parquet:
-  azureWorkloadIdentity:
-    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -3176,8 +3164,6 @@ parquet:
           minReplicas: 2
 
 parquet-metadata-cache:
-  azureWorkloadIdentity:
-    enabled: true
   maxColumnChunks: 10000000
   install: false
   serviceAccount:
@@ -3307,8 +3293,6 @@ parquet-metadata-cache:
           minReplicas: 1
 
 settingsMigrationJob:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -4480,8 +4464,6 @@ bufstream:
           memory: 4Gi
 
 lumen-agent:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   kind: CronJob
   image:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -423,7 +423,8 @@ global:
     # (user-delegation SAS) and the storage account access key is optional.
     # The chart adds the required workload-identity pod label to services that
     # consume bucket credentials. The customer's infrastructure must separately
-    # configure federated credentials and ServiceAccount annotations.
+    # configure federated credentials. ServiceAccount names and annotations
+    # remain infrastructure-owned because other Azure clients may use them.
     azureTenantId: null
     azureClientId: null
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -399,9 +399,18 @@ global:
   # Deployment-owned Azure workload identity for Blob storage. When set, this
   # pair takes precedence over identity values in both bucket and defaultBucket,
   # so a user-edited CR cannot replace the infrastructure-managed identity.
+  # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
+  #   clientId:
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: azure-storage-identity
+  #         key: client-id
+  # Referenced values cannot be copied into ServiceAccount annotations. In that
+  # mode, provide azure.workload.identity/client-id through each bucket-consuming
+  # service's serviceAccount.annotations.
   azureStorageIdentity:
-    tenantId: ""
-    clientId: ""
+    tenantId: null
+    clientId: null
 
   # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
   defaultBucket:
@@ -411,15 +420,16 @@ global:
     path: ""
     region: ""
     kmsKey: ""
-    # Azure (provider "az") identity-based auth. When both are set the application
+    # Azure (provider "az") identity-based auth. Each value can be a literal
+    # string or a Kubernetes EnvVarSource-style map. When both are set the application
     # authenticates to Blob storage with an Entra ID workload identity
     # (user-delegation SAS) and the storage account access key is optional.
-    # NOTE: the pod must also run with Azure workload identity enabled -- the
-    # ServiceAccount needs the `azure.workload.identity/client-id` annotation and
-    # the pod the `azure.workload.identity/use: "true"` label so the federated
-    # token is projected. See PR description for the remaining infra wiring.
-    azureTenantId: ""
-    azureClientId: ""
+    # The chart detects workloads that consume bucket envs and adds the required
+    # pod label. It also adds ServiceAccount annotations for literal IDs; when
+    # using valueFrom, provide the client-id annotation separately because
+    # Kubernetes annotations cannot reference Secrets or ConfigMaps.
+    azureTenantId: null
+    azureClientId: null
 
   # If specified, the application will use this bucket for all storage operations, and will not be overridable by the user.
   bucket:
@@ -595,8 +605,6 @@ artifactsGc:
   DeleteFilesNumWorkers: 0
 
 api:
-  azureWorkloadIdentity:
-    enabled: true
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -793,8 +801,6 @@ api:
           minReplicas: 2
 
 app:
-  azureWorkloadIdentity:
-    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -1127,8 +1133,6 @@ console:
         verbs: ["get"]
 
 executor:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   deploymentPostfix: "bc"
   workerConcurrency: 10
@@ -1247,8 +1251,6 @@ executor:
           minReplicas: 2
 
 filemeta:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -1412,8 +1414,6 @@ anaconda2:
           minReplicas: 2
 
 filestream:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1521,8 +1521,6 @@ filestream:
           minReplicas: 1
 
 flat-run-fields-updater:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1808,8 +1806,6 @@ flat-run-fields-updater:
           # triggers must be provided by user when enabling KEDA
 
 history-updater:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   pubSub:
     # pubSub subscription comes from terraform
@@ -2090,8 +2086,6 @@ history-updater:
 
 # history-reader is a gRPC service that serves run history from ClickHouse.
 history-reader:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2344,8 +2338,6 @@ frontend:
           minReplicas: 2
 
 glue:
-  azureWorkloadIdentity:
-    enabled: true
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
@@ -2528,8 +2520,6 @@ internalSignerPreHook:
         verbs: ["get", "patch", "create", "update"]
 
 metric-observer:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2668,8 +2658,6 @@ metric-observer:
           minReplicas: 8
 
 parquet:
-  azureWorkloadIdentity:
-    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -2871,8 +2859,6 @@ parquet:
           minReplicas: 2
 
 parquet-metadata-cache:
-  azureWorkloadIdentity:
-    enabled: true
   maxColumnChunks: 10000000
   install: false
   serviceAccount:
@@ -3002,8 +2988,6 @@ parquet-metadata-cache:
           minReplicas: 1
 
 settingsMigrationJob:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -4175,8 +4159,6 @@ bufstream:
           memory: 4Gi
 
 lumen-agent:
-  azureWorkloadIdentity:
-    enabled: true
   install: false
   kind: CronJob
   image:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1052,6 +1052,8 @@ appRenamePostHook:
         verbs: ["get", "delete", "list", "watch"]
 
 console:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: true
   deploymentPostfix: "bc"
   service:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,18 +396,15 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
-  # Deployment-owned Azure workload identity for Blob storage. When set, this
+  # Customer-supplied Azure workload identity for Blob storage. When set, this
   # pair takes precedence over identity values in both bucket and defaultBucket,
-  # so a user-edited CR cannot replace the infrastructure-managed identity.
+  # allowing the customer's infrastructure identity to override the W&B-managed CR.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
   #   clientId:
   #     valueFrom:
   #       secretKeyRef:
   #         name: azure-storage-identity
   #         key: client-id
-  # Referenced values cannot be copied into ServiceAccount annotations. In that
-  # mode, provide azure.workload.identity/client-id through each bucket-consuming
-  # service's serviceAccount.annotations.
   azureStorageIdentity:
     tenantId: null
     clientId: null
@@ -424,10 +421,9 @@ global:
     # string or a Kubernetes EnvVarSource-style map. When both are set the application
     # authenticates to Blob storage with an Entra ID workload identity
     # (user-delegation SAS) and the storage account access key is optional.
-    # The chart detects workloads that consume bucket envs and adds the required
-    # pod label. It also adds ServiceAccount annotations for literal IDs; when
-    # using valueFrom, provide the client-id annotation separately because
-    # Kubernetes annotations cannot reference Secrets or ConfigMaps.
+    # The chart adds the required workload-identity pod label to services that
+    # consume bucket credentials. ServiceAccount annotations supplied by the
+    # customer's infrastructure remain supported but are not required here.
     azureTenantId: null
     azureClientId: null
 
@@ -605,6 +601,8 @@ artifactsGc:
   DeleteFilesNumWorkers: 0
 
 api:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -801,6 +799,8 @@ api:
           minReplicas: 2
 
 app:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: true
   deploymentPostfix: "bc"
   image:
@@ -1133,6 +1133,8 @@ console:
         verbs: ["get"]
 
 executor:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   deploymentPostfix: "bc"
   workerConcurrency: 10
@@ -1251,6 +1253,8 @@ executor:
           minReplicas: 2
 
 filemeta:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -1414,6 +1418,8 @@ anaconda2:
           minReplicas: 2
 
 filestream:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1521,6 +1527,8 @@ filestream:
           minReplicas: 1
 
 flat-run-fields-updater:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1806,6 +1814,8 @@ flat-run-fields-updater:
           # triggers must be provided by user when enabling KEDA
 
 history-updater:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   pubSub:
     # pubSub subscription comes from terraform
@@ -2086,6 +2096,8 @@ history-updater:
 
 # history-reader is a gRPC service that serves run history from ClickHouse.
 history-reader:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -2338,6 +2350,8 @@ frontend:
           minReplicas: 2
 
 glue:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
@@ -2520,6 +2534,8 @@ internalSignerPreHook:
         verbs: ["get", "patch", "create", "update"]
 
 metric-observer:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -2658,6 +2674,8 @@ metric-observer:
           minReplicas: 8
 
 parquet:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: true
   deploymentPostfix: "bc"
   image:
@@ -2859,6 +2877,8 @@ parquet:
           minReplicas: 2
 
 parquet-metadata-cache:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   maxColumnChunks: 10000000
   install: false
   serviceAccount:
@@ -2988,6 +3008,8 @@ parquet-metadata-cache:
           minReplicas: 1
 
 settingsMigrationJob:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -4159,6 +4181,8 @@ bufstream:
           memory: 4Gi
 
 lumen-agent:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   kind: CronJob
   image:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -408,6 +408,13 @@ global:
   azureStorageIdentity:
     tenantId: null
     clientId: null
+    # One deployment-wide account for Azure storage workload identity. Set
+    # create: false when infrastructure creates and federates this account.
+    serviceAccount:
+      name: "wandb-bucket-access"
+      create: true
+      annotations: {}
+      labels: {}
     # Principal ID is exposed to administrators for Azure role assignments.
     # The chart does not use it for pod authentication.
     principalId: null

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -3517,6 +3517,7 @@ weave-trace:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3657,6 +3658,7 @@ weave-trace-worker:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3768,6 +3770,7 @@ weave-evaluate-model-worker:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3873,6 +3876,7 @@ weave-trace-agent-scoring-worker:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,18 +396,15 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
-  # Deployment-owned Azure workload identity for Blob storage. When set, this
+  # Customer-supplied Azure workload identity for Blob storage. When set, this
   # pair takes precedence over identity values in both bucket and defaultBucket,
-  # so a user-edited CR cannot replace the infrastructure-managed identity.
+  # allowing the customer's infrastructure identity to override the W&B-managed CR.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
   #   clientId:
   #     valueFrom:
   #       secretKeyRef:
   #         name: azure-storage-identity
   #         key: client-id
-  # Referenced values cannot be copied into ServiceAccount annotations. In that
-  # mode, provide azure.workload.identity/client-id through each bucket-consuming
-  # service's serviceAccount.annotations.
   azureStorageIdentity:
     tenantId: null
     clientId: null
@@ -424,10 +421,9 @@ global:
     # string or a Kubernetes EnvVarSource-style map. When both are set the application
     # authenticates to Blob storage with an Entra ID workload identity
     # (user-delegation SAS) and the storage account access key is optional.
-    # The chart detects workloads that consume bucket envs and adds the required
-    # pod label. It also adds ServiceAccount annotations for literal IDs; when
-    # using valueFrom, provide the client-id annotation separately because
-    # Kubernetes annotations cannot reference Secrets or ConfigMaps.
+    # The chart adds the required workload-identity pod label to services that
+    # consume bucket credentials. ServiceAccount annotations supplied by the
+    # customer's infrastructure remain supported but are not required here.
     azureTenantId: null
     azureClientId: null
 
@@ -605,6 +601,8 @@ artifactsGc:
   DeleteFilesNumWorkers: 0
 
 api:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -801,6 +799,8 @@ api:
           minReplicas: 2
 
 app:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: true
   deploymentPostfix: "bc"
   image:
@@ -1133,6 +1133,8 @@ console:
         verbs: ["get"]
 
 executor:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   deploymentPostfix: "bc"
   workerConcurrency: 10
@@ -1251,6 +1253,8 @@ executor:
           minReplicas: 2
 
 filemeta:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -1414,6 +1418,8 @@ anaconda2:
           minReplicas: 2
 
 filestream:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1521,6 +1527,8 @@ filestream:
           minReplicas: 1
 
 flat-run-fields-updater:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1806,6 +1814,8 @@ flat-run-fields-updater:
           # triggers must be provided by user when enabling KEDA
 
 history-updater:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   pubSub:
     # pubSub subscription comes from terraform
@@ -2391,6 +2401,8 @@ run-store-accelerator-run-updater:
 
 # history-reader is a gRPC service that serves run history from ClickHouse.
 history-reader:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -2643,6 +2655,8 @@ frontend:
           minReplicas: 2
 
 glue:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
@@ -2825,6 +2839,8 @@ internalSignerPreHook:
         verbs: ["get", "patch", "create", "update"]
 
 metric-observer:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -2963,6 +2979,8 @@ metric-observer:
           minReplicas: 8
 
 parquet:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: true
   deploymentPostfix: "bc"
   image:
@@ -3164,6 +3182,8 @@ parquet:
           minReplicas: 2
 
 parquet-metadata-cache:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   maxColumnChunks: 10000000
   install: false
   serviceAccount:
@@ -3293,6 +3313,8 @@ parquet-metadata-cache:
           minReplicas: 1
 
 settingsMigrationJob:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   image:
     repository: wandb/megabinary
@@ -4464,6 +4486,8 @@ bufstream:
           memory: 4Gi
 
 lumen-agent:
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'
   install: false
   kind: CronJob
   image:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -3822,6 +3822,7 @@ weave-trace:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3962,6 +3963,7 @@ weave-trace-worker:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -4073,6 +4075,7 @@ weave-evaluate-model-worker:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -4178,6 +4181,7 @@ weave-trace-agent-scoring-worker:
   deploymentPostfix: "bc"
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
+  azureStorageUseSharedServiceAccount: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,6 +396,13 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
+  # Deployment-owned Azure workload identity for Blob storage. When set, this
+  # pair takes precedence over identity values in both bucket and defaultBucket,
+  # so a user-edited CR cannot replace the infrastructure-managed identity.
+  azureStorageIdentity:
+    tenantId: ""
+    clientId: ""
+
   # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
   defaultBucket:
     # az, s3, gcs
@@ -588,6 +595,8 @@ artifactsGc:
   DeleteFilesNumWorkers: 0
 
 api:
+  azureWorkloadIdentity:
+    enabled: true
   service:
     enabled: true
     loadBalancerHealthCheckPath: "/ready"
@@ -784,6 +793,8 @@ api:
           minReplicas: 2
 
 app:
+  azureWorkloadIdentity:
+    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -1116,6 +1127,8 @@ console:
         verbs: ["get"]
 
 executor:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   deploymentPostfix: "bc"
   workerConcurrency: 10
@@ -1234,6 +1247,8 @@ executor:
           minReplicas: 2
 
 filemeta:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -1397,6 +1412,8 @@ anaconda2:
           minReplicas: 2
 
 filestream:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1504,6 +1521,8 @@ filestream:
           minReplicas: 1
 
 flat-run-fields-updater:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   deploymentPostfix: "bc"
   pubSub:
@@ -1789,6 +1808,8 @@ flat-run-fields-updater:
           # triggers must be provided by user when enabling KEDA
 
 history-updater:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   pubSub:
     # pubSub subscription comes from terraform
@@ -2374,6 +2395,8 @@ run-store-accelerator-run-updater:
 
 # history-reader is a gRPC service that serves run history from ClickHouse.
 history-reader:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2626,6 +2649,8 @@ frontend:
           minReplicas: 2
 
 glue:
+  azureWorkloadIdentity:
+    enabled: true
   envFrom:
     "{{ .Release.Name }}-bucket-configmap": "configMapRef"
     "{{ .Release.Name }}-redis-configmap": "configMapRef"
@@ -2808,6 +2833,8 @@ internalSignerPreHook:
         verbs: ["get", "patch", "create", "update"]
 
 metric-observer:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -2946,6 +2973,8 @@ metric-observer:
           minReplicas: 8
 
 parquet:
+  azureWorkloadIdentity:
+    enabled: true
   install: true
   deploymentPostfix: "bc"
   image:
@@ -3147,6 +3176,8 @@ parquet:
           minReplicas: 2
 
 parquet-metadata-cache:
+  azureWorkloadIdentity:
+    enabled: true
   maxColumnChunks: 10000000
   install: false
   serviceAccount:
@@ -3276,6 +3307,8 @@ parquet-metadata-cache:
           minReplicas: 1
 
 settingsMigrationJob:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   image:
     repository: wandb/megabinary
@@ -4447,6 +4480,8 @@ bufstream:
           memory: 4Gi
 
 lumen-agent:
+  azureWorkloadIdentity:
+    enabled: true
   install: false
   kind: CronJob
   image:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -396,9 +396,9 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
-  # Infrastructure-managed Azure workload identity for the default Blob storage
-  # bucket. A customer BYOB bucket does not inherit this identity; it uses the
-  # access key or identity values configured on global.bucket.
+  # Infrastructure-managed Azure workload identity for this deployment. The
+  # managed default bucket uses this identity. A customer Azure bucket can opt
+  # in with global.bucket.azureAuthMethod: workloadIdentity.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
   #   clientId:
   #     valueFrom:
@@ -408,6 +408,9 @@ global:
   azureStorageIdentity:
     tenantId: null
     clientId: null
+    # Principal ID is exposed to administrators for Azure role assignments.
+    # The chart does not use it for pod authentication.
+    principalId: null
 
   # Storage bucket that will be used by the application by default but can be overridden by the user in the wandb-console.
   defaultBucket:
@@ -430,6 +433,10 @@ global:
 
   # If specified, the application will use this bucket for all storage operations, and will not be overridable by the user.
   bucket:
+    # Azure only. Existing configurations default to access-key authentication.
+    # Set to workloadIdentity to use global.azureStorageIdentity.
+    azureAuthMethod: null
+    # Legacy bucket-scoped identity values remain supported.
     # azureTenantId: ""
     # azureClientId: ""
     secret:
@@ -512,6 +519,10 @@ global:
 
   weave-trace:
     enabled: false
+    # Weave stores files in ClickHouse unless this is explicitly enabled.
+    # Enable only with a Weave image that supports Azure workload identity.
+    fileStorage:
+      useDefaultBucket: false
 
   # As part of the migration away from using local, the `bypass` setting will
   # control whether the gorilla services will use the app service (and, thus, local)
@@ -3800,6 +3811,8 @@ mcp-server:
 weave-trace:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -3938,6 +3951,8 @@ weave-trace:
 weave-trace-worker:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -4047,6 +4062,8 @@ weave-trace-worker:
 weave-evaluate-model-worker:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest
@@ -4150,6 +4167,8 @@ weave-evaluate-model-worker:
 weave-trace-agent-scoring-worker:
   install: false
   deploymentPostfix: "bc"
+  podLabels:
+    azure.workload.identity/use: '{{ include `wandb.weaveTraceUsesAzureWorkloadIdentity` . }}'
   image:
     repository: wandb/weave-trace
     tag: latest

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
-digest: sha256:ccd9b6aa5e4578016214a51344e28b54ecf8afcc14a9e4bd99fee19a60247895
-generated: "2026-07-15T03:47:32.325736-05:00"
+  version: 0.12.4
+digest: sha256:8010266cd7e906d26d0e4b920fb3a01165223c7119e0e17460f6c18fe8b55b7e
+generated: "2026-07-10T11:04:10.417419-04:00"

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
+  version: 0.12.6
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.5
-digest: sha256:ccd9b6aa5e4578016214a51344e28b54ecf8afcc14a9e4bd99fee19a60247895
-generated: "2026-07-28T13:31:56.110312-05:00"
+  version: 0.12.6
+digest: sha256:e2514816c2f8ca70a4f0db5e1f76ce8a211f106d46c2d685094f7ae8da4855b6
+generated: "2026-07-29T18:00:53.549681-05:00"

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
+  version: 0.12.5
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.4
-digest: sha256:8010266cd7e906d26d0e4b920fb3a01165223c7119e0e17460f6c18fe8b55b7e
-generated: "2026-07-10T11:04:10.417419-04:00"
+  version: 0.12.5
+digest: sha256:ccd9b6aa5e4578016214a51344e28b54ecf8afcc14a9e4bd99fee19a60247895
+generated: "2026-07-28T13:31:56.110312-05:00"

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -15,4 +15,4 @@ dependencies:
   repository: file://../wandb-base
   version: 0.12.5
 digest: sha256:ccd9b6aa5e4578016214a51344e28b54ecf8afcc14a9e4bd99fee19a60247895
-generated: "2026-07-28T13:31:56.110312-05:00"
+generated: "2026-07-15T03:47:32.325736-05:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.4"
+    version: "0.12.5"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.4"
+    version: "0.12.5"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.4"
+    version: "0.12.5"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.4"
+    version: "0.12.5"
     repository: "file://../wandb-base"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.2
+version: 1.4.1
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.5"
+    version: "0.12.4"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.5"
+    version: "0.12.4"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.5"
+    version: "0.12.4"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.5"
+    version: "0.12.4"
     repository: "file://../wandb-base"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.5"
+    version: "0.12.6"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.5"
+    version: "0.12.6"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.5"
+    version: "0.12.6"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.5"
+    version: "0.12.6"
     repository: "file://../wandb-base"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.5
+version: 0.12.4
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.4
+version: 0.12.5
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.5
+version: 0.12.6
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/_deprecated.tpl
+++ b/charts/wandb-base/templates/_deprecated.tpl
@@ -70,11 +70,7 @@ Handles merging a set of pod annotations
 Handles merging a set of non-selector labels
 */}}
 {{- define "wandb-base.podLabels" -}}
-{{- $allLabels := merge (deepCopy .Values.podLabels) .Values.pod.labels .Values.global.pod.labels -}}
-{{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" . | fromYaml -}}
-{{- if $azureIdentity.enabled -}}
-{{- $_ := set $allLabels "azure.workload.identity/use" "true" -}}
-{{- end -}}
+{{- $allLabels := merge .Values.podLabels .Values.pod.labels .Values.global.pod.labels -}}
 {{- if $allLabels -}}
 {{-   range $key, $value := $allLabels }}
 {{ $key }}: {{ $value | trunc 63 | quote }}

--- a/charts/wandb-base/templates/_deprecated.tpl
+++ b/charts/wandb-base/templates/_deprecated.tpl
@@ -70,9 +70,13 @@ Handles merging a set of pod annotations
 Handles merging a set of non-selector labels
 */}}
 {{- define "wandb-base.podLabels" -}}
-  {{- $allLabels := merge .Values.podLabels .Values.pod.labels .Values.global.pod.labels -}}
-  {{- if $allLabels -}}
-    {{- range $key, $value := $allLabels }}
+{{- $allLabels := merge (deepCopy .Values.podLabels) .Values.pod.labels .Values.global.pod.labels -}}
+{{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" . | fromYaml -}}
+{{- if $azureIdentity.enabled -}}
+{{- $_ := set $allLabels "azure.workload.identity/use" "true" -}}
+{{- end -}}
+{{- if $allLabels -}}
+{{-   range $key, $value := $allLabels }}
 {{ $key }}: {{ $value | trunc 63 | quote }}
     {{- end }}
   {{- end -}}

--- a/charts/wandb-base/templates/_deprecated.tpl
+++ b/charts/wandb-base/templates/_deprecated.tpl
@@ -70,9 +70,9 @@ Handles merging a set of pod annotations
 Handles merging a set of non-selector labels
 */}}
 {{- define "wandb-base.podLabels" -}}
-{{- $allLabels := merge .Values.podLabels .Values.pod.labels .Values.global.pod.labels -}}
-{{- if $allLabels -}}
-{{-   range $key, $value := $allLabels }}
+  {{- $allLabels := merge .Values.podLabels .Values.pod.labels .Values.global.pod.labels -}}
+  {{- if $allLabels -}}
+    {{- range $key, $value := $allLabels }}
 {{ $key }}: {{ $value | trunc 63 | quote }}
     {{- end }}
   {{- end -}}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -1,18 +1,3 @@
-{{/* Resolve Azure workload identity for workloads that consume bucket envs. */}}
-{{- define "wandb-base.azureWorkloadIdentity" -}}
-{{- $identity := dict "enabled" false -}}
-{{- $usesBucketEnvs := false -}}
-{{- range (default (list) .Values.envTpls) -}}
-  {{- if contains "wandb.bucketEnvs" . -}}
-    {{- $usesBucketEnvs = true -}}
-  {{- end -}}
-{{- end -}}
-{{- if $usesBucketEnvs -}}
-  {{- $identity = include "wandb.azureStorageIdentity" . | fromYaml -}}
-{{- end -}}
-{{- $identity | toYaml -}}
-{{- end -}}
-
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -1,3 +1,12 @@
+{{/* Resolve parent-provided Azure workload identity only for opted-in workloads. */}}
+{{- define "wandb-base.azureWorkloadIdentity" -}}
+{{- $identity := dict "enabled" false -}}
+{{- if .Values.azureWorkloadIdentity.enabled -}}
+  {{- $identity = include "wandb.azureStorageIdentity" . | fromYaml -}}
+{{- end -}}
+{{- $identity | toYaml -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -1,7 +1,13 @@
-{{/* Resolve parent-provided Azure workload identity only for opted-in workloads. */}}
+{{/* Resolve Azure workload identity for workloads that consume bucket envs. */}}
 {{- define "wandb-base.azureWorkloadIdentity" -}}
 {{- $identity := dict "enabled" false -}}
-{{- if .Values.azureWorkloadIdentity.enabled -}}
+{{- $usesBucketEnvs := false -}}
+{{- range (default (list) .Values.envTpls) -}}
+  {{- if contains "wandb.bucketEnvs" . -}}
+    {{- $usesBucketEnvs = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $usesBucketEnvs -}}
   {{- $identity = include "wandb.azureStorageIdentity" . | fromYaml -}}
 {{- end -}}
 {{- $identity | toYaml -}}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -109,6 +109,10 @@ their component accounts.
   (and (not $hasCustomerBucket) (eq $defaultBucket.provider "az"))
   (and $hasCustomerBucket (eq $bucket.azureAuthMethod "workloadIdentity"))
   -}}
+  {{- $explicitSharedServiceAccount := default false .Values.azureStorageUseSharedServiceAccount -}}
+  {{- if kindIs "string" $explicitSharedServiceAccount -}}
+    {{- $explicitSharedServiceAccount = eq (tpl $explicitSharedServiceAccount . | trim) "true" -}}
+  {{- end -}}
   {{- $podLabels := default (dict) .Values.podLabels -}}
   {{- $workloadIdentity := get $podLabels "azure.workload.identity/use" | default false -}}
   {{- $enabled := false -}}
@@ -117,7 +121,7 @@ their component accounts.
   {{- else -}}
     {{- $enabled = $workloadIdentity -}}
   {{- end -}}
-{{- and $globalConfigured $usesDeploymentIdentity $enabled -}}
+{{- and $globalConfigured (or $usesDeploymentIdentity $explicitSharedServiceAccount) $enabled -}}
 {{- end }}
 
 {{- define "wandb-base.azureStorageServiceAccountName" -}}

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -85,11 +85,45 @@ Create the name of the service to use
 Create the name of the service account to use
 */}}
 {{- define "wandb-base.serviceAccountName" -}}
-  {{- if .Values.serviceAccount.create }}
+  {{- if include "wandb-base.azureStorageServiceAccountEnabled" . | trim | eq "true" }}
+{{- include "wandb-base.azureStorageServiceAccountName" . }}
+  {{- else if .Values.serviceAccount.create }}
 {{- default (include "wandb-base.fullname" .) .Values.serviceAccount.name }}
   {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
   {{- end }}
+{{- end }}
+
+{{/*
+Use the shared account only for workloads that already opt into Azure workload
+identity. This keeps legacy bucket-scoped identities and key-based BYOB on
+their component accounts.
+*/}}
+{{- define "wandb-base.azureStorageServiceAccountEnabled" -}}
+  {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $globalConfigured := and (not (empty $identity.tenantId)) (not (empty $identity.clientId)) -}}
+  {{- $bucket := default (dict) .Values.global.bucket -}}
+  {{- $hasCustomerBucket := not (empty $bucket.name) -}}
+  {{- $defaultBucket := default (dict) .Values.global.defaultBucket -}}
+  {{- $usesDeploymentIdentity := or
+  (and (not $hasCustomerBucket) (eq $defaultBucket.provider "az"))
+  (and $hasCustomerBucket (eq $bucket.azureAuthMethod "workloadIdentity"))
+  -}}
+  {{- $podLabels := default (dict) .Values.podLabels -}}
+  {{- $workloadIdentity := get $podLabels "azure.workload.identity/use" | default false -}}
+  {{- $enabled := false -}}
+  {{- if kindIs "string" $workloadIdentity -}}
+    {{- $enabled = eq (tpl $workloadIdentity . | trim) "true" -}}
+  {{- else -}}
+    {{- $enabled = $workloadIdentity -}}
+  {{- end -}}
+{{- and $globalConfigured $usesDeploymentIdentity $enabled -}}
+{{- end }}
+
+{{- define "wandb-base.azureStorageServiceAccountName" -}}
+  {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+{{- default "wandb-bucket-access" $serviceAccount.name -}}
 {{- end }}
 
 {{- define "wandb-base.deploymentRolloutStrategy" -}}

--- a/charts/wandb-base/templates/_pods.tpl
+++ b/charts/wandb-base/templates/_pods.tpl
@@ -1,5 +1,4 @@
 {{- define "wandb-base.pod" }}
-{{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" $.root | fromYaml -}}
 metadata:
   {{- if or .podData.podAnnotations .podData.podAnnotationsTpls (include "wandb-base.podAnnotations" $.root) (include "wandb-base.commonAnnotations" $.root) }}
   annotations:
@@ -15,9 +14,6 @@ metadata:
   labels:
     {{- tpl (include "wandb-base.labels" $.root | nindent 4) $.root }}
     {{- tpl (include "wandb-base.podLabels" $.root | nindent 4) $.root }}
-    {{- if $azureIdentity.enabled }}
-    azure.workload.identity/use: "true"
-    {{- end }}
 spec:
   {{- with .podData.affinity }}
   affinity:

--- a/charts/wandb-base/templates/_pods.tpl
+++ b/charts/wandb-base/templates/_pods.tpl
@@ -1,4 +1,5 @@
 {{- define "wandb-base.pod" }}
+{{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" $.root | fromYaml -}}
 metadata:
   {{- if or .podData.podAnnotations .podData.podAnnotationsTpls (include "wandb-base.podAnnotations" $.root) (include "wandb-base.commonAnnotations" $.root) }}
   annotations:
@@ -14,6 +15,9 @@ metadata:
   labels:
     {{- tpl (include "wandb-base.labels" $.root | nindent 4) $.root }}
     {{- tpl (include "wandb-base.podLabels" $.root | nindent 4) $.root }}
+    {{- if $azureIdentity.enabled }}
+    azure.workload.identity/use: "true"
+    {{- end }}
 spec:
   {{- with .podData.affinity }}
   affinity:

--- a/charts/wandb-base/templates/serviceaccount.yaml
+++ b/charts/wandb-base/templates/serviceaccount.yaml
@@ -1,23 +1,26 @@
 {{- if .Values.serviceAccount.create -}}
 {{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" . | fromYaml -}}
+{{- $serviceAccountAnnotations := deepCopy .Values.serviceAccount.annotations -}}
+{{- if and $azureIdentity.enabled (not (kindIs "map" $azureIdentity.clientId)) -}}
+{{- $_ := set $serviceAccountAnnotations "azure.workload.identity/client-id" $azureIdentity.clientId -}}
+{{- end -}}
+{{- if and $azureIdentity.enabled (not (kindIs "map" $azureIdentity.tenantId)) -}}
+{{- $_ := set $serviceAccountAnnotations "azure.workload.identity/tenant-id" $azureIdentity.tenantId -}}
+{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "wandb-base.serviceAccountName" . }}
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
-  {{- if (or .Values.serviceAccount.annotations .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .) $azureIdentity.enabled) }}
+  {{- if (or $serviceAccountAnnotations .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .)) }}
   annotations:
     {{- tpl (include "wandb-base.commonAnnotations" . | nindent 4) . }}
-    {{- if .Values.serviceAccount.annotations }}
-      {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- if $serviceAccountAnnotations }}
+      {{- toYaml $serviceAccountAnnotations | nindent 4 }}
     {{- end }}
     {{- if .Values.helmHook.enabled }}
       {{- include "wandb-base.helmHookAnnotations" . | nindent 4 }}
-    {{- end }}
-    {{- if $azureIdentity.enabled }}
-    azure.workload.identity/client-id: {{ $azureIdentity.clientId | quote }}
-    azure.workload.identity/tenant-id: {{ $azureIdentity.tenantId | quote }}
     {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/charts/wandb-base/templates/serviceaccount.yaml
+++ b/charts/wandb-base/templates/serviceaccount.yaml
@@ -1,23 +1,15 @@
 {{- if .Values.serviceAccount.create -}}
-{{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" . | fromYaml -}}
-{{- $serviceAccountAnnotations := deepCopy .Values.serviceAccount.annotations -}}
-{{- if and $azureIdentity.enabled (not (kindIs "map" $azureIdentity.clientId)) -}}
-{{- $_ := set $serviceAccountAnnotations "azure.workload.identity/client-id" $azureIdentity.clientId -}}
-{{- end -}}
-{{- if and $azureIdentity.enabled (not (kindIs "map" $azureIdentity.tenantId)) -}}
-{{- $_ := set $serviceAccountAnnotations "azure.workload.identity/tenant-id" $azureIdentity.tenantId -}}
-{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "wandb-base.serviceAccountName" . }}
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
-  {{- if (or $serviceAccountAnnotations .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .)) }}
+  {{- if (or .Values.serviceAccount.annotations .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .)) }}
   annotations:
     {{- tpl (include "wandb-base.commonAnnotations" . | nindent 4) . }}
-    {{- if $serviceAccountAnnotations }}
-      {{- toYaml $serviceAccountAnnotations | nindent 4 }}
+    {{- if .Values.serviceAccount.annotations }}
+      {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
     {{- end }}
     {{- if .Values.helmHook.enabled }}
       {{- include "wandb-base.helmHookAnnotations" . | nindent 4 }}

--- a/charts/wandb-base/templates/serviceaccount.yaml
+++ b/charts/wandb-base/templates/serviceaccount.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.serviceAccount.create -}}
+{{- $azureIdentity := include "wandb-base.azureWorkloadIdentity" . | fromYaml -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "wandb-base.serviceAccountName" . }}
   labels:
     {{- include "wandb-base.labels" . | nindent 4 }}
-  {{- if (or .Values.serviceAccount.annotations .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .)) }}
+  {{- if (or .Values.serviceAccount.annotations .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .) $azureIdentity.enabled) }}
   annotations:
     {{- tpl (include "wandb-base.commonAnnotations" . | nindent 4) . }}
     {{- if .Values.serviceAccount.annotations }}
@@ -13,6 +14,10 @@ metadata:
     {{- end }}
     {{- if .Values.helmHook.enabled }}
       {{- include "wandb-base.helmHookAnnotations" . | nindent 4 }}
+    {{- end }}
+    {{- if $azureIdentity.enabled }}
+    azure.workload.identity/client-id: {{ $azureIdentity.clientId | quote }}
+    azure.workload.identity/tenant-id: {{ $azureIdentity.tenantId | quote }}
     {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/charts/wandb-base/templates/serviceaccount.yaml
+++ b/charts/wandb-base/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create (not (include "wandb-base.azureStorageServiceAccountEnabled" . | trim | eq "true")) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -88,11 +88,6 @@ serviceAccount:
   annotations: {}
   name: ""
 
-# Enables Azure workload identity metadata when the parent chart resolves an
-# Azure storage identity for this workload.
-azureWorkloadIdentity:
-  enabled: false
-
 # Role or ClusterRole
 role:
   create: false

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -88,6 +88,11 @@ serviceAccount:
   annotations: {}
   name: ""
 
+# Enables Azure workload identity metadata when the parent chart resolves an
+# Azure storage identity for this workload.
+azureWorkloadIdentity:
+  enabled: false
+
 # Role or ClusterRole
 role:
   create: false

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2485,7 +2485,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3057,7 +3057,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3188,7 +3188,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3605,7 +3605,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4011,7 +4011,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2473,7 +2473,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3045,7 +3045,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3176,7 +3176,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3593,7 +3593,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3999,7 +3999,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2473,7 +2473,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3046,7 +3046,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3178,7 +3178,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3596,7 +3596,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4002,7 +4002,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2485,11 +2485,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3057,7 +3058,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3188,11 +3189,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3605,7 +3607,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4011,11 +4013,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2473,11 +2473,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3045,7 +3046,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3176,11 +3177,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3593,7 +3595,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3999,11 +4001,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2485,7 +2485,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3058,7 +3058,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3190,7 +3190,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3608,7 +3608,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4014,7 +4014,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -3063,6 +3063,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -3051,6 +3051,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3061,7 +3061,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3192,7 +3192,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3609,7 +3609,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4015,7 +4015,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2489,11 +2489,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3061,7 +3062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3192,11 +3193,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3609,7 +3611,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4015,11 +4017,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2477,11 +2477,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3049,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3180,11 +3181,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3597,7 +3599,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4003,11 +4005,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3182,7 +3182,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3600,7 +3600,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4006,7 +4006,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -3067,6 +3067,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -3055,6 +3055,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3049,7 +3049,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3180,7 +3180,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3597,7 +3597,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4003,7 +4003,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3062,7 +3062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3194,7 +3194,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3612,7 +3612,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4018,7 +4018,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -2796,6 +2796,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -1227,8 +1227,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-configmap
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
@@ -1240,8 +1238,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-rules
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   managed-install.yaml: |
     keyRuleSets:
@@ -2080,7 +2076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: daemonset-0.1.0
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: daemonset
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.33.0"
@@ -2221,7 +2217,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2791,7 +2787,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2923,7 +2919,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3231,7 +3227,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: instance-24.5.0
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -3330,7 +3326,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3506,7 +3502,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -3809,8 +3805,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -1459,6 +1459,18 @@ data:
   REDIS_HOST: "chartsnap-redis-master"
   REDIS_PARAMS: "?ttlInSeconds=604800"
 ---
+# Source: operator-wandb/templates/run-store-accelerator-run-updater.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-run-store-accelerator-run-updater-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+---
 # Source: operator-wandb/templates/weave-trace.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -2226,7 +2226,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "false"
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: app
@@ -2927,7 +2927,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "false"
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: parquet
@@ -3510,7 +3510,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
-            azure.workload.identity/use: "false"
+            azure.workload.identity/use: "true"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -95,9 +95,6 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    azure.workload.identity/client-id: infrastructure-client-id
-    azure.workload.identity/tenant-id: infrastructure-tenant-id
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -137,9 +134,6 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    azure.workload.identity/client-id: infrastructure-client-id
-    azure.workload.identity/tenant-id: infrastructure-tenant-id
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
@@ -177,7 +171,7 @@ metadata:
   name: chartsnap-bucket
   labels:
 data:
-  ACCESS_KEY: b3JwaGFuZWQtbWFuYWdlZC1zdG9yYWdlLWtleQ==
+  ACCESS_KEY: Y3VzdG9tZXItc3RvcmFnZS1rZXk=
 ---
 # Source: operator-wandb/templates/clickhouse.yaml
 apiVersion: v1
@@ -944,8 +938,8 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
 data:
-  BUCKET_NAME: "managed-storage-account"
-  BUCKET_PATH: "managed-container"
+  BUCKET_NAME: "customer-storage-account"
+  BUCKET_PATH: "customer-container"
   AWS_REGION: ""
   AWS_S3_KMS_ID: ""
   GORILLA_DEFAULT_REGION: "minio-local"
@@ -2232,7 +2226,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "true"
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -2292,16 +2286,12 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_TENANT_ID
+        - name: AZURE_STORAGE_KEY
           valueFrom:
             secretKeyRef:
-              key: tenant-id
-              name: azure-storage-identity
-        - name: AZURE_STORAGE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: client-id
-              name: azure-storage-identity
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2566,16 +2556,12 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_TENANT_ID
+        - name: AZURE_STORAGE_KEY
           valueFrom:
             secretKeyRef:
-              key: tenant-id
-              name: azure-storage-identity
-        - name: AZURE_STORAGE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: client-id
-              name: azure-storage-identity
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2941,7 +2927,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "true"
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -2993,16 +2979,12 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_TENANT_ID
+        - name: AZURE_STORAGE_KEY
           valueFrom:
             secretKeyRef:
-              key: tenant-id
-              name: azure-storage-identity
-        - name: AZURE_STORAGE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: client-id
-              name: azure-storage-identity
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3528,7 +3510,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
-            azure.workload.identity/use: "true"
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job
@@ -3582,16 +3564,12 @@ spec:
                   key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
                   name: gorilla-coreweave-caios
                   optional: true
-            - name: AZURE_STORAGE_TENANT_ID
+            - name: AZURE_STORAGE_KEY
               valueFrom:
                 secretKeyRef:
-                  key: tenant-id
-                  name: azure-storage-identity
-            - name: AZURE_STORAGE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  key: client-id
-                  name: azure-storage-identity
+                  key: ACCESS_KEY
+                  name: chartsnap-bucket
+                  optional: true
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -96,8 +96,8 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    azure.workload.identity/client-id: authoritative-client-id
-    azure.workload.identity/tenant-id: authoritative-tenant-id
+    azure.workload.identity/client-id: infrastructure-client-id
+    azure.workload.identity/tenant-id: infrastructure-tenant-id
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -138,8 +138,8 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    azure.workload.identity/client-id: authoritative-client-id
-    azure.workload.identity/tenant-id: authoritative-tenant-id
+    azure.workload.identity/client-id: infrastructure-client-id
+    azure.workload.identity/tenant-id: infrastructure-tenant-id
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
@@ -2292,9 +2292,15 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: authoritative-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenant-id
+              name: azure-storage-identity
         - name: AZURE_STORAGE_CLIENT_ID
-          value: authoritative-client-id
+          valueFrom:
+            secretKeyRef:
+              key: client-id
+              name: azure-storage-identity
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2560,9 +2566,15 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: authoritative-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenant-id
+              name: azure-storage-identity
         - name: AZURE_STORAGE_CLIENT_ID
-          value: authoritative-client-id
+          valueFrom:
+            secretKeyRef:
+              key: client-id
+              name: azure-storage-identity
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2981,9 +2993,15 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: authoritative-tenant-id
+          valueFrom:
+            secretKeyRef:
+              key: tenant-id
+              name: azure-storage-identity
         - name: AZURE_STORAGE_CLIENT_ID
-          value: authoritative-client-id
+          valueFrom:
+            secretKeyRef:
+              key: client-id
+              name: azure-storage-identity
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3564,9 +3582,15 @@ spec:
                   name: gorilla-coreweave-caios
                   optional: true
             - name: AZURE_STORAGE_TENANT_ID
-              value: authoritative-tenant-id
+              valueFrom:
+                secretKeyRef:
+                  key: tenant-id
+                  name: azure-storage-identity
             - name: AZURE_STORAGE_CLIENT_ID
-              value: authoritative-client-id
+              valueFrom:
+                secretKeyRef:
+                  key: client-id
+                  name: azure-storage-identity
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -2226,7 +2226,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2804,7 +2804,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2935,7 +2935,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3346,7 +3346,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3522,7 +3522,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -1232,8 +1232,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-configmap
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
@@ -1245,8 +1243,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-rules
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   managed-install.yaml: |
     keyRuleSets:
@@ -2085,7 +2081,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: daemonset-0.1.0
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: daemonset
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.33.0"
@@ -2226,7 +2222,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2804,7 +2800,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2936,7 +2932,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3248,7 +3244,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: instance-24.5.0
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -3347,7 +3343,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3523,7 +3519,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -3830,8 +3826,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -177,7 +177,6 @@ metadata:
   name: chartsnap-bucket
   labels:
 data:
-  ACCESS_KEY: b3JwaGFuZWQtbWFuYWdlZC1zdG9yYWdlLWtleQ==
 ---
 # Source: operator-wandb/templates/clickhouse.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -131,6 +131,9 @@ kind: ServiceAccount
 metadata:
   name: wandb-bucket-access
   labels:
+  annotations:
+    azure.workload.identity/client-id: infrastructure-client-id
+    azure.workload.identity/tenant-id: infrastructure-tenant-id
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -84,35 +84,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: operator-wandb/charts/app/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-app
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: app
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    azure.workload.identity/client-id: infrastructure-client-id
-    azure.workload.identity/tenant-id: infrastructure-tenant-id
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/console/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-console
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -125,22 +96,6 @@ metadata:
     app.kubernetes.io/version: "0.33.0"
     wandb.com/app-name: daemonset-0.1.0
     app.kubernetes.io/managed-by: Helm
----
-# Source: operator-wandb/charts/parquet/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-parquet
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: parquet
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    azure.workload.identity/client-id: infrastructure-client-id
-    azure.workload.identity/tenant-id: infrastructure-tenant-id
-automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
 apiVersion: v1
@@ -169,6 +124,13 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
+---
+# Source: operator-wandb/templates/azure-storage-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wandb-bucket-access
+  labels:
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1
@@ -1699,7 +1661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
-  name: chartsnap-console
+  name: wandb-bucket-access
   namespace: default
 roleRef:
   kind: ClusterRole
@@ -1805,7 +1767,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
-  name: chartsnap-app
+  name: wandb-bucket-access
   namespace: default
 roleRef:
   kind: Role
@@ -2730,7 +2692,7 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      serviceAccountName: chartsnap-app
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -2860,7 +2822,7 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      serviceAccountName: chartsnap-console
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -3169,7 +3131,7 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      serviceAccountName: chartsnap-parquet
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -3741,7 +3703,7 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
           restartPolicy: Never
-          serviceAccountName: chartsnap-parquet
+          serviceAccountName: wandb-bucket-access
           securityContext:
             fsGroup: 0
             fsGroupChangePolicy: OnRootMismatch

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -2809,6 +2809,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -1429,6 +1429,18 @@ data:
   REDIS_HOST: "chartsnap-redis-master"
   REDIS_PARAMS: "?ttlInSeconds=604800"
 ---
+# Source: operator-wandb/templates/run-store-accelerator-run-updater.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-run-store-accelerator-run-updater-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+---
 # Source: operator-wandb/templates/weave-trace.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -95,9 +95,6 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    azure.workload.identity/client-id: authoritative-client-id
-    azure.workload.identity/tenant-id: authoritative-tenant-id
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -137,9 +134,6 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    azure.workload.identity/client-id: authoritative-client-id
-    azure.workload.identity/tenant-id: authoritative-tenant-id
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
@@ -2226,7 +2220,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2792,7 +2786,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2923,7 +2917,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3328,7 +3322,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3504,7 +3498,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -105,32 +105,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: operator-wandb/charts/app/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-app
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: app
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/console/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-console
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -143,19 +117,6 @@ metadata:
     app.kubernetes.io/version: "0.33.0"
     wandb.com/app-name: daemonset-0.1.0
     app.kubernetes.io/managed-by: Helm
----
-# Source: operator-wandb/charts/parquet/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-parquet
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: parquet
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
 apiVersion: v1
@@ -172,19 +133,6 @@ metadata:
   name: chartsnap-prometheus-server
   namespace: default
 ---
-# Source: operator-wandb/charts/weave-trace/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-weave-trace
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave-trace
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/weave/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -197,6 +145,13 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
+---
+# Source: operator-wandb/templates/azure-storage-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wandb-bucket-access
+  labels:
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1
@@ -1733,7 +1688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
-  name: chartsnap-console
+  name: wandb-bucket-access
   namespace: default
 roleRef:
   kind: ClusterRole
@@ -1839,7 +1794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
-  name: chartsnap-app
+  name: wandb-bucket-access
   namespace: default
 roleRef:
   kind: Role
@@ -2774,7 +2729,7 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      serviceAccountName: chartsnap-app
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -2904,7 +2859,7 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      serviceAccountName: chartsnap-console
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -3207,7 +3162,7 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      serviceAccountName: chartsnap-parquet
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -3530,7 +3485,7 @@ spec:
           subPath: redis_ca.pem
         - mountPath: /tmp/
           name: temp-dir
-      serviceAccountName: chartsnap-weave-trace
+      serviceAccountName: wandb-bucket-access
       securityContext:
         fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
@@ -4001,7 +3956,7 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
           restartPolicy: Never
-          serviceAccountName: chartsnap-parquet
+          serviceAccountName: wandb-bucket-access
           securityContext:
             fsGroup: 0
             fsGroupChangePolicy: OnRootMismatch

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -2286,9 +2286,9 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: authoritative-tenant-id
+          value: cr-tenant-id
         - name: AZURE_STORAGE_CLIENT_ID
-          value: authoritative-client-id
+          value: cr-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2554,9 +2554,9 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: authoritative-tenant-id
+          value: cr-tenant-id
         - name: AZURE_STORAGE_CLIENT_ID
-          value: authoritative-client-id
+          value: cr-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2975,9 +2975,9 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: authoritative-tenant-id
+          value: cr-tenant-id
         - name: AZURE_STORAGE_CLIENT_ID
-          value: authoritative-client-id
+          value: cr-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3558,9 +3558,9 @@ spec:
                   name: gorilla-coreweave-caios
                   optional: true
             - name: AZURE_STORAGE_TENANT_ID
-              value: authoritative-tenant-id
+              value: cr-tenant-id
             - name: AZURE_STORAGE_CLIENT_ID
-              value: authoritative-client-id
+              value: cr-client-id
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -2853,6 +2853,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -63,6 +63,27 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
+# Source: operator-wandb/charts/weave-trace/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-weave-trace
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave-trace
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: weave-trace
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
 # Source: operator-wandb/charts/weave/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -150,6 +171,19 @@ metadata:
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
   namespace: default
+---
+# Source: operator-wandb/charts/weave-trace/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-weave-trace
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave-trace
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/weave/templates/serviceaccount.yaml
 apiVersion: v1
@@ -906,6 +940,8 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'
 ---
@@ -937,8 +973,8 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
 data:
-  BUCKET_NAME: "storage-account"
-  BUCKET_PATH: "container"
+  BUCKET_NAME: "customer-storage-account"
+  BUCKET_PATH: "customer-container"
   AWS_REGION: ""
   AWS_S3_KMS_ID: ""
   GORILLA_DEFAULT_REGION: "minio-local"
@@ -1027,7 +1063,7 @@ data:
   REACT_APP_ENVIRONMENT_NAME: "local"
   REACT_APP_ENVIRONMENT_IS_PRIVATE: "true"
   REACT_APP_ANALYTICS_DISABLED: "true"
-  WEAVE_TRACES_ENABLED: 'false'
+  WEAVE_TRACES_ENABLED: 'true'
   SERVER_FLAG_WEAVE_1_PERCENTAGE: "100"
   WEAVE_ENABLED: "true"
   OPERATOR_ENABLED: "true"
@@ -1428,6 +1464,9 @@ data:
         location /console {
           proxy_pass http://chartsnap-console:8082;
         }
+        location /traces {
+          proxy_pass http://chartsnap-weave-trace:8722;
+        }
       }
     }
 ---
@@ -1487,6 +1526,7 @@ data:
   KAFKA_BROKER_HOST: "bufstream.bufstream.svc.cluster.local"
   KAFKA_BROKER_PORT: "9092"
   WEAVE_REDIS_URL: "redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
+  WF_FILE_STORAGE_URI: "az://managed-storage-account/managed-container"
 ---
 # Source: operator-wandb/templates/weave.yaml
 apiVersion: v1
@@ -2030,6 +2070,28 @@ spec:
     wandb.com/app-name: redis-exporter-0.1.0
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: operator-wandb/charts/weave-trace/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-weave-trace
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave-trace
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8722
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: weave-trace
+    app.kubernetes.io/instance: chartsnap
+---
 # Source: operator-wandb/charts/weave/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -2286,9 +2348,9 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: cr-tenant-id
+          value: authoritative-tenant-id
         - name: AZURE_STORAGE_CLIENT_ID
-          value: cr-client-id
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2554,9 +2616,9 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: cr-tenant-id
+          value: authoritative-tenant-id
         - name: AZURE_STORAGE_CLIENT_ID
-          value: cr-client-id
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2975,9 +3037,9 @@ spec:
               name: gorilla-coreweave-caios
               optional: true
         - name: AZURE_STORAGE_TENANT_ID
-          value: cr-tenant-id
+          value: authoritative-tenant-id
         - name: AZURE_STORAGE_CLIENT_ID
-          value: cr-client-id
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3295,6 +3357,234 @@ spec:
         persistentVolumeClaim:
           claimName: chartsnap-prometheus-server
 ---
+# Source: operator-wandb/charts/weave-trace/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-weave-trace-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave-trace
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weave-trace
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: weave-trace-0.12.4
+        app.kubernetes.io/name: weave-trace
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
+    spec:
+      containers:
+      - name: weave-trace
+        args:
+        - uvicorn
+        - src.trace_server:app
+        - --host
+        - 0.0.0.0
+        - --port
+        - "8080"
+        envFrom:
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-weave-trace-configmap
+        env:
+        - name: WF_CLICKHOUSE_HOST
+          value: chartsnap-clickhouse-headless
+        - name: WF_CLICKHOUSE_PORT
+          value: "8123"
+        - name: WF_CLICKHOUSE_DATABASE
+          value: weave_trace_db
+        - name: WF_CLICKHOUSE_USER
+          value: default
+        - name: WF_CLICKHOUSE_REPLICATED
+          value: "false"
+        - name: WF_CLICKHOUSE_PASS
+          valueFrom:
+            secretKeyRef:
+              key: CLICKHOUSE_PASSWORD
+              name: chartsnap-clickhouse
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /traces/health
+            port: http
+          timeoutSeconds: 2
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /traces/health
+            port: http
+          timeoutSeconds: 2
+        startupProbe:
+          failureThreshold: 12
+          httpGet:
+            path: /traces/health
+            port: http
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+        - mountPath: /tmp/weave-trace/internal-jwt
+          name: weave-trace-internal-jwt
+      initContainers:
+      - name: weave-trace-migrate
+        args:
+        - python
+        - migrator.py
+        envFrom:
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-weave-trace-configmap
+        env:
+        - name: WF_CLICKHOUSE_HOST
+          value: chartsnap-clickhouse-headless
+        - name: WF_CLICKHOUSE_PORT
+          value: "8123"
+        - name: WF_CLICKHOUSE_DATABASE
+          value: weave_trace_db
+        - name: WF_CLICKHOUSE_USER
+          value: default
+        - name: WF_CLICKHOUSE_REPLICATED
+          value: "false"
+        - name: WF_CLICKHOUSE_PASS
+          valueFrom:
+            secretKeyRef:
+              key: CLICKHOUSE_PASSWORD
+              name: chartsnap-clickhouse
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      serviceAccountName: chartsnap-weave-trace
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave-trace
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave-trace
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - emptyDir: {}
+        name: temp-dir
+      - name: weave-trace-internal-jwt
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: internal-service
+              expirationSeconds: 600
+              path: token
+---
 # Source: operator-wandb/charts/weave/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -3558,9 +3848,9 @@ spec:
                   name: gorilla-coreweave-caios
                   optional: true
             - name: AZURE_STORAGE_TENANT_ID
-              value: cr-tenant-id
+              value: authoritative-tenant-id
             - name: AZURE_STORAGE_CLIENT_ID
-              value: cr-client-id
+              value: authoritative-client-id
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -3850,6 +4140,82 @@ data:
       fi
     done
 ---
+# Source: operator-wandb/templates/tests/test-weave.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "chartsnap-operator-wandb-test-weave"
+  annotations:
+    "helm.sh/hook": test
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  test.py: |
+    import weave
+    import json
+    from datetime import datetime
+
+    # Initialize weave
+    weave.init('mock-trace-example')
+
+    # Define a mock LLM call function
+    @weave.op()
+    def mock_llm_call(prompt: str) -> str:
+      # Instead of making an actual LLM call, we'll just return a mock response
+      mock_response = {
+        "id": "mock-llm-call-123",
+        "model": "gpt-4",
+        "created": datetime.now().isoformat(),
+        "choices": [{
+          "message": {
+            "role": "assistant",
+            "content": "This is a mock response to: " + prompt
+          }
+        }]
+      }
+
+      return json.dumps(mock_response)
+
+    # Create a mock trace
+    @weave.op()
+    def create_mock_trace():
+      # Call the mock LLM function
+      response = mock_llm_call("What is the capital of France?")
+
+      # Return the response
+      return {
+      "prompt": "What is the capital of France?",
+      "response": response,
+      "metadata": {
+        "model": "gpt-4",
+        "temperature": 0.7,
+        "max_tokens": 100
+      }
+    }
+
+    if __name__ == "__main__":
+      # Create and log the mock trace
+      result, call = create_mock_trace.call()
+
+      # Set a custom display name for the call
+      call.set_display_name("Mock LLM Call - Capital of France")
+
+      # Add feedback to the call using the correct method
+      call.feedback.add("rating", {"value": 5, "comment": "Great response! Very informative."})
+
+      # Get call information and convert datetime objects to ISO format strings
+      call_info = {
+      "id": call.id,
+      "trace_id": call.trace_id,
+      "started_at": call.started_at.isoformat() if call.started_at else None,
+      "ended_at": call.ended_at.isoformat() if call.ended_at else None,
+      "inputs": call.inputs,
+      "output": call.output
+    }
+
+    print("Mock trace created and logged successfully!")
+    print("Call information:", json.dumps(call_info, indent=2))
+---
 # Source: operator-wandb/charts/appRenamePostHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -3974,6 +4340,42 @@ spec:
     - sh
     - -c
     - "pip install wandb && wandb verify"
+  restartPolicy: Never
+---
+# Source: operator-wandb/templates/tests/test-weave.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-operator-wandb-test-weave"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: wandb-verify
+    image: us-docker.pkg.dev/wandb-production/public/python:3.12
+    env:
+    - name: WANDB_BASE_URL
+      value: "http://chartsnap-nginx:8080"
+    - name: WANDB_API_KEY
+      value: ""
+    command:
+    - sh
+    - -c
+    - "pip install weave && (timeout=240; start_time=$(date +%s); until python /tmp/test.py || [ $(($(date +%s) - start_time)) -gt $timeout ]; do echo 'weave verify failed, retrying...' && cat /tmp/debug-cli.root.log; sleep 10; done)"
+    volumeMounts:
+    - name: test-script
+      mountPath: /tmp/test.py
+      subPath: test.py
+  volumes:
+  - name: test-script
+    configMap:
+      name: "chartsnap-operator-wandb-test-weave"
   restartPolicy: Never
 ---
 # Source: operator-wandb/charts/appRenamePostHook/templates/job.yaml

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -1262,8 +1262,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-configmap
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
@@ -1275,8 +1273,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-rules
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   managed-install.yaml: |
     keyRuleSets:
@@ -2141,7 +2137,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: daemonset-0.1.0
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: daemonset
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.33.0"
@@ -2282,7 +2278,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2848,7 +2844,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2980,7 +2976,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3286,7 +3282,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: instance-24.5.0
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -3385,7 +3381,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3613,7 +3609,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3789,7 +3785,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
@@ -4090,8 +4086,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4148,8 +4142,6 @@ metadata:
   name: "chartsnap-operator-wandb-test-weave"
   annotations:
     "helm.sh/hook": test
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
 data:
   test.py: |
     import weave

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -1,53 +1,5 @@
 # chartsnap: snapshot_version=v3
 ---
-# Source: operator-wandb/charts/redis/templates/networkpolicy.yaml
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: chartsnap-redis
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: redis
-  policyTypes:
-  - Ingress
-  - Egress
-  egress:
-  - {}
-  ingress:
-  # Allow inbound connections
-  - ports:
-    - port: 6379
----
-# Source: operator-wandb/charts/anaconda2/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: anaconda2
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
 # Source: operator-wandb/charts/app/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -132,19 +84,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: operator-wandb/charts/anaconda2/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/app/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -156,6 +95,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    azure.workload.identity/client-id: "authoritative-client-id"
+    azure.workload.identity/tenant-id: "authoritative-tenant-id"
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -195,6 +137,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    azure.workload.identity/client-id: "authoritative-client-id"
+    azure.workload.identity/tenant-id: "authoritative-tenant-id"
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
@@ -210,36 +155,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
-  namespace: default
----
-# Source: operator-wandb/charts/redis/templates/master/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-automountServiceAccountToken: false
-metadata:
-  name: chartsnap-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
----
-# Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader
   namespace: default
 ---
 # Source: operator-wandb/charts/weave/templates/serviceaccount.yaml
@@ -262,8 +177,6 @@ metadata:
   name: chartsnap-bucket
   labels:
 data:
-  ACCESS_KEY: bWluaW8=
-  SECRET_KEY: dGVzdHBhc3N3b3Jk
 ---
 # Source: operator-wandb/templates/clickhouse.yaml
 apiVersion: v1
@@ -370,32 +283,6 @@ metadata:
   labels:
 data:
   SMTP_PASSWORD: ""
----
-# Source: operator-wandb/charts/mysql/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-mysql-initdb
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-data:
-  my.cnf: |
-    [mysqld]
-    binlog_format = 'ROW'
-    innodb_online_alter_log_max_size = 268435456
-    sync_binlog = 1
-    innodb_flush_log_at_trx_commit = 1
-    binlog_row_image = 'MINIMAL'
-    local-infile = 1
-    sort_buffer_size = 33554432
-  # We need RELOAD, SELECT, and LOCK TABLES for making backups
-  initdb.sql: |
-    GRANT SESSION_VARIABLES_ADMIN,RELOAD,SELECT,LOCK TABLES ON *.* TO `wandb`@`%`;
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/configmap.yaml
 apiVersion: v1
@@ -980,176 +867,6 @@ data:
   rules: |
     {}
 ---
-# Source: operator-wandb/charts/redis/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-redis-configuration
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  redis.conf: |-
-    # User-supplied common configuration:
-    # Enable AOF https://redis.io/topics/persistence#append-only-file
-    appendonly yes
-    # Disable RDB persistence, AOF persistence already enabled.
-    save ""
-    # End of common configuration
-  master.conf: |-
-    dir /data
-    # User-supplied master configuration:
-    rename-command FLUSHDB ""
-    rename-command FLUSHALL ""
-    # End of master configuration
-  replica.conf: |-
-    dir /data
-    # User-supplied replica configuration:
-    rename-command FLUSHDB ""
-    rename-command FLUSHALL ""
-    # End of replica configuration
----
-# Source: operator-wandb/charts/redis/templates/health-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-redis-health
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  ping_readiness_local.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h localhost \
-        -p $REDIS_PORT \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_liveness_local.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h localhost \
-        -p $REDIS_PORT \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
-    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ] && [ "$responseFirstWord" != "MASTERDOWN" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_readiness_master.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
-    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h $REDIS_MASTER_HOST \
-        -p $REDIS_MASTER_PORT_NUMBER \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_liveness_master.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
-    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h $REDIS_MASTER_HOST \
-        -p $REDIS_MASTER_PORT_NUMBER \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
-    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_readiness_local_and_master.sh: |-
-    script_dir="$(dirname "$0")"
-    exit_status=0
-    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
-    exit $exit_status
-  ping_liveness_local_and_master.sh: |-
-    script_dir="$(dirname "$0")"
-    exit_status=0
-    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
-    exit $exit_status
----
-# Source: operator-wandb/charts/redis/templates/scripts-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-redis-scripts
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  start-master.sh: |
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    if [[ -f /opt/bitnami/redis/mounted-etc/master.conf ]];then
-        cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
-    fi
-    if [[ -f /opt/bitnami/redis/mounted-etc/redis.conf ]];then
-        cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
-    fi
-    ARGS=("--port" "${REDIS_PORT}")
-    ARGS+=("--protected-mode" "no")
-    ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
-    ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
-    exec redis-server "${ARGS[@]}"
----
 # Source: operator-wandb/templates/anaconda2.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -1180,7 +897,7 @@ data:
   GORILLA_LICENSE_CERT_PATH: "/jwks.json"
   GORILLA_FILE_METADATA_SOURCE_IS_INTERNAL: "true"
   GORILLA_SESSION_LENGTH: "720h"
-  GORILLA_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
   GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE: "/view-spec-updater-linux"
   GORILLA_PARQUET_RPC_PATH: "/_goRPC_"
   GORILLA_ONPREM_API_KEY_PREFIX: "local"
@@ -1216,8 +933,8 @@ data:
   PARQUET_HOST: "http://chartsnap-parquet:8087"
   OPERATOR_ENABLED: "true"
   LOGGING_ENABLED: "true"
-  GORILLA_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
-  ANACONDA_ENABLED: "false"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
+  ANACONDA_ENABLED: "true"
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1
@@ -1226,9 +943,9 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
 data:
-  BUCKET_NAME: "minio:9000/bucket"
-  BUCKET_PATH: ""
-  AWS_REGION: "us-east-1"
+  BUCKET_NAME: "storage-account"
+  BUCKET_PATH: "container"
+  AWS_REGION: ""
   AWS_S3_KMS_ID: ""
   GORILLA_DEFAULT_REGION: "minio-local"
 ---
@@ -1436,7 +1153,7 @@ data:
   GORILLA_GLUE_FRONTEND_HOST: "http://localhost:8080"
   GORILLA_GLUE_LICENSE_CERT_PATH: "/jwks.json"
   # Values that correspond to existing configurations from gorilla.yaml
-  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
+  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-app:8082"
   GORILLA_GLUE_SESSION_LENGTH: "720h"
   GORILLA_GLUE_DEV: "false"
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
@@ -1515,6 +1232,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
@@ -1526,6 +1245,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-rules
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   managed-install.yaml: |
     keyRuleSets:
@@ -1792,25 +1513,6 @@ data:
   WEAVE_CACHE_CHECK_INTERVAL: "60"
   WEAVE_CACHE_SIZE_LIMIT: "20Gi"
   WEAVE_CACHE_CLEAR_PERCENT: "80"
----
-# Source: operator-wandb/charts/mysql/templates/pvc.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: chartsnap-mysql-data
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: "20Gi"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1
@@ -2094,66 +1796,6 @@ rules:
   verbs:
   - get
 ---
-# Source: operator-wandb/charts/reloader/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader-role
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - "apps"
-  resources:
-  - deployments
-  - daemonsets
-  - statefulsets
-  verbs:
-  - list
-  - get
-  - update
-  - patch
-- apiGroups:
-  - "batch"
-  resources:
-  - cronjobs
-  verbs:
-  - list
-  - get
-- apiGroups:
-  - "batch"
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - list
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
----
 # Source: operator-wandb/charts/app/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -2173,52 +1815,6 @@ roleRef:
   kind: Role
   name: chartsnap-app
   apiGroup: rbac.authorization.k8s.io
----
-# Source: operator-wandb/charts/reloader/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader-role-binding
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: chartsnap-reloader-role
-subjects:
-- kind: ServiceAccount
-  name: chartsnap-reloader
-  namespace: default
----
-# Source: operator-wandb/charts/anaconda2/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8082
-    protocol: TCP
-    targetPort: http
-  selector:
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/app/templates/service.yaml
 apiVersion: v1
@@ -2270,32 +1866,6 @@ spec:
   selector:
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
----
-# Source: operator-wandb/charts/mysql/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-mysql
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - port: 3306
-    protocol: TCP
-    targetPort: mysql
-  selector:
-    helm.sh/chart: mysql-0.1.0
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/service.yaml
 apiVersion: v1
@@ -2466,56 +2036,6 @@ spec:
     wandb.com/app-name: redis-exporter-0.1.0
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: operator-wandb/charts/redis/templates/headless-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-redis-headless
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-  - name: tcp-redis
-    port: 6379
-    targetPort: redis
-  selector:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: redis
----
-# Source: operator-wandb/charts/redis/templates/master/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/component: master
-spec:
-  type: ClusterIP
-  internalTrafficPolicy: Cluster
-  sessionAffinity: None
-  ports:
-  - name: tcp-redis
-    port: 6379
-    targetPort: redis
-    nodePort: null
-  selector:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/component: master
----
 # Source: operator-wandb/charts/weave/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -2565,7 +2085,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: daemonset-0.1.0
         app.kubernetes.io/name: daemonset
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.33.0"
@@ -2575,7 +2095,6 @@ spec:
         checksum/configmap: 9a93c1a7e19d470e13c897633e852dbfe03075bfe12f97f73b087cb1b4a5971
     spec:
       serviceAccountName: chartsnap-otel-daemonset
-      priorityClassName: wandb-global-priority
       securityContext:
         runAsUser: 1000
         runAsGroup: 0
@@ -2584,7 +2103,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: daemonset
-        image: "otel/opentelemetry-collector-contrib:0.97.0"
+        image: "us-docker.pkg.dev/wandb-production/public/otel/opentelemetry-collector-contrib:0.97.0"
         securityContext:
           capabilities:
           allowPrivilegeEscalation: false
@@ -2680,149 +2199,6 @@ spec:
           path: /var/lib/docker/containers
       hostNetwork: false
 ---
-# Source: operator-wandb/charts/anaconda2/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: anaconda2
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: anaconda2-0.12.5
-        app.kubernetes.io/name: anaconda2
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: anaconda2
-        envFrom:
-        - configMapRef:
-            name: chartsnap-anaconda2-configmap
-        env:
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: DD_AGENT_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: DD_TRACE_AGENT_HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "wandb/anaconda2:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8082
-          name: http
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ping
-            port: http
-          timeoutSeconds: 2
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ping
-            port: http
-          timeoutSeconds: 2
-        resources:
-          limits:
-            cpu: "1"
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      priorityClassName: wandb-global-priority
-      serviceAccountName: chartsnap-anaconda2
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: anaconda2
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: anaconda2
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
 # Source: operator-wandb/charts/app/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -2855,6 +2231,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: app
@@ -2914,12 +2291,10 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
+        - name: AZURE_STORAGE_TENANT_ID
+          value: authoritative-tenant-id
+        - name: AZURE_STORAGE_CLIENT_ID
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -2933,11 +2308,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
+        - name: GORILLA_STORAGE_BUCKET
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3042,8 +2419,6 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: BUCKET_QUEUE
           value: "internal://"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
@@ -3054,12 +2429,8 @@ spec:
           value: "8083"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
-        - name: GORILLA_STORAGE_BUCKET
-          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -3071,7 +2442,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/local:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -3188,12 +2559,10 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
+        - name: AZURE_STORAGE_TENANT_ID
+          value: authoritative-tenant-id
+        - name: AZURE_STORAGE_CLIENT_ID
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3207,11 +2576,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
+        - name: GORILLA_STORAGE_BUCKET
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3316,8 +2687,6 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: BUCKET_QUEUE
           value: "internal://"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
@@ -3328,12 +2697,8 @@ spec:
           value: "8083"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
-        - name: GORILLA_STORAGE_BUCKET
-          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -3345,7 +2710,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/local:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: wandb-ca-certs-root
@@ -3357,7 +2722,6 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      priorityClassName: wandb-global-priority
       serviceAccountName: chartsnap-app
       securityContext:
         fsGroup: 0
@@ -3440,10 +2804,6 @@ spec:
         - configMapRef:
             name: chartsnap-console-configmap
         env:
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3451,7 +2811,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/console:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8082
@@ -3491,7 +2851,6 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      priorityClassName: wandb-console-priority
       serviceAccountName: chartsnap-console
       securityContext:
         fsGroup: 0
@@ -3569,6 +2928,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: parquet
@@ -3620,12 +2980,10 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
+        - name: AZURE_STORAGE_TENANT_ID
+          value: authoritative-tenant-id
+        - name: AZURE_STORAGE_CLIENT_ID
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3639,13 +2997,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3748,10 +3106,6 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3759,7 +3113,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/megabinary:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8087
@@ -3800,7 +3154,6 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      priorityClassName: wandb-data-priority
       serviceAccountName: chartsnap-parquet
       securityContext:
         fsGroup: 0
@@ -3876,7 +3229,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: instance-24.5.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -3948,94 +3301,6 @@ spec:
         persistentVolumeClaim:
           claimName: chartsnap-prometheus-server
 ---
-# Source: operator-wandb/charts/reloader/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-    group: com.stakater.platform
-    provider: stakater
-    version: v1.3.0
-  name: chartsnap-reloader
-  namespace: default
-spec:
-  replicas: 1
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: chartsnap-reloader
-      release: "chartsnap"
-  template:
-    metadata:
-      labels:
-        app: chartsnap-reloader
-        chart: "reloader-1.3.0"
-        release: "chartsnap"
-        heritage: "Helm"
-        app.kubernetes.io/managed-by: "Helm"
-        group: com.stakater.platform
-        provider: stakater
-        version: v1.3.0
-    spec:
-      containers:
-      - image: "ghcr.io/stakater/reloader:v1.3.0"
-        imagePullPolicy: IfNotPresent
-        name: chartsnap-reloader
-        env:
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: '1'
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-              divisor: '1'
-        - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        ports:
-        - name: http
-          containerPort: 9090
-        livenessProbe:
-          httpGet:
-            path: /live
-            port: http
-          timeoutSeconds: 5
-          failureThreshold: 5
-          periodSeconds: 10
-          successThreshold: 1
-          initialDelaySeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: http
-          timeoutSeconds: 5
-          failureThreshold: 5
-          periodSeconds: 10
-          successThreshold: 1
-          initialDelaySeconds: 10
-        securityContext: {}
-        args:
-        - "--log-level=info"
-        - "--reload-on-create=true"
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      serviceAccountName: chartsnap-reloader
----
 # Source: operator-wandb/charts/weave/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -4081,10 +3346,6 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4092,7 +3353,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/weave-python:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9994
@@ -4144,10 +3405,6 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4155,7 +3412,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/weave-python:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -4178,7 +3435,6 @@ spec:
           name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
-      priorityClassName: wandb-global-priority
       serviceAccountName: chartsnap-weave
       securityContext:
         fsGroup: 0
@@ -4228,274 +3484,6 @@ spec:
           sizeLimit: '20Gi'
         name: cache
 ---
-# Source: operator-wandb/charts/mysql/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: chartsnap-mysql
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: chartsnap
-      helm.sh/chart: mysql-0.1.0
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/version: "1.16.0"
-      wandb.com/app-name: mysql-0.1.0
-      app.kubernetes.io/managed-by: Helm
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: mysql
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "1.16.0"
-        wandb.com/app-name: mysql-0.1.0
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      priorityClassName: wandb-database-priority
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 0
-        fsGroup: 999
-        fsGroupChangePolicy: OnRootMismatch
-        runAsNonRoot: true
-      containers:
-      - name: mysql
-        image: "mysql:latest"
-        securityContext:
-          allowPrivilegeEscalation: false
-        ports:
-        - name: mysql
-          containerPort: 3306
-          protocol: TCP
-        env:
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "chartsnap-mysql"
-              key: "MYSQL_PASSWORD"
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: "chartsnap-mysql"
-        - name: MYSQL_DATABASE
-          value: "wandb_local"
-        - name: MYSQL_USER
-          value: "wandb"
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: chartsnap-mysql
-              key: MYSQL_ROOT_PASSWORD
-        livenessProbe:
-          tcpSocket:
-            port: 3306
-        readinessProbe:
-          tcpSocket:
-            port: 3306
-        startupProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          failureThreshold: 60
-          tcpSocket:
-            port: 3306
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/mysql
-        - name: initdb
-          mountPath: /docker-entrypoint-initdb.d/initdb.sql
-          subPath: initdb.sql
-        - name: initdb
-          mountPath: /etc/mysql/my.cnf
-          subPath: my.cnf
-        resources:
-          limits:
-            cpu: 4000m
-            memory: 8Gi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-      volumes:
-      - name: initdb
-        configMap:
-          name: chartsnap-mysql-initdb
-      - name: data
-        persistentVolumeClaim:
-          claimName: chartsnap-mysql-data
----
-# Source: operator-wandb/charts/redis/templates/master/application.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: chartsnap-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/component: master
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: redis
-      app.kubernetes.io/component: master
-  serviceName: chartsnap-redis-headless
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: redis
-        app.kubernetes.io/version: 7.2.4
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/component: master
-      annotations:
-        checksum/configmap: 86bcc953bb473748a3d3dc60b7c11f34e60c93519234d4c37f42e22ada559d47
-        checksum/health: aff24913d801436ea469d8d374b2ddb3ec4c43ee7ab24663d5f8ff1a1b6991a9
-        checksum/scripts: 43cdf68c28f3abe25ce017a82f74dbf2437d1900fd69df51a55a3edf6193d141
-        checksum/secret: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-    spec:
-      securityContext:
-        fsGroup: 1001
-        fsGroupChangePolicy: Always
-        supplementalGroups: []
-        sysctls: []
-      serviceAccountName: chartsnap-redis-master
-      automountServiceAccountToken: false
-      affinity:
-        podAffinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/instance: chartsnap
-                  app.kubernetes.io/name: redis
-                  app.kubernetes.io/component: master
-              topologyKey: kubernetes.io/hostname
-            weight: 1
-        nodeAffinity:
-      enableServiceLinks: true
-      terminationGracePeriodSeconds: 30
-      containers:
-      - name: redis
-        image: docker.io/bitnamilegacy/redis:7.2.4-debian-12-r9
-        imagePullPolicy: "IfNotPresent"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: true
-          runAsUser: 1001
-          seLinuxOptions: null
-          seccompProfile:
-            type: RuntimeDefault
-        command:
-        - /bin/bash
-        args:
-        - -c
-        - /opt/bitnami/scripts/start-scripts/start-master.sh
-        env:
-        - name: BITNAMI_DEBUG
-          value: "false"
-        - name: REDIS_REPLICATION_MODE
-          value: master
-        - name: ALLOW_EMPTY_PASSWORD
-          value: "yes"
-        - name: REDIS_TLS_ENABLED
-          value: "no"
-        - name: REDIS_PORT
-          value: "6379"
-        ports:
-        - name: redis
-          containerPort: 6379
-        livenessProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          # One second longer than command timeout should prevent generation of zombie processes.
-          timeoutSeconds: 6
-          successThreshold: 1
-          failureThreshold: 5
-          exec:
-            command:
-            - sh
-            - -c
-            - /health/ping_liveness_local.sh 5
-        readinessProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          timeoutSeconds: 2
-          successThreshold: 1
-          failureThreshold: 5
-          exec:
-            command:
-            - sh
-            - -c
-            - /health/ping_readiness_local.sh 1
-        volumeMounts:
-        - name: start-scripts
-          mountPath: /opt/bitnami/scripts/start-scripts
-        - name: health
-          mountPath: /health
-        - name: redis-data
-          mountPath: /data
-        - name: config
-          mountPath: /opt/bitnami/redis/mounted-etc
-        - name: empty-dir
-          mountPath: /opt/bitnami/redis/etc/
-          subPath: app-conf-dir
-        - name: empty-dir
-          mountPath: /tmp
-          subPath: tmp-dir
-      volumes:
-      - name: start-scripts
-        configMap:
-          name: chartsnap-redis-scripts
-          defaultMode: 0755
-      - name: health
-        configMap:
-          name: chartsnap-redis-health
-          defaultMode: 0755
-      - name: config
-        configMap:
-          name: chartsnap-redis-configuration
-      - name: empty-dir
-        emptyDir: {}
-  volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: redis-data
-      labels:
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/name: redis
-        app.kubernetes.io/component: master
-    spec:
-      accessModes:
-      - "ReadWriteOnce"
-      resources:
-        requests:
-          storage: "8Gi"
----
 # Source: operator-wandb/charts/parquet/templates/cronjob.yaml
 apiVersion: batch/v1
 kind: CronJob
@@ -4521,6 +3509,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "true"
         spec:
           containers:
           - name: backfill-job
@@ -4574,12 +3563,10 @@ spec:
                   key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
                   name: gorilla-coreweave-caios
                   optional: true
-            - name: AZURE_STORAGE_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: ACCESS_KEY
-                  name: chartsnap-bucket
-                  optional: true
+            - name: AZURE_STORAGE_TENANT_ID
+              value: authoritative-tenant-id
+            - name: AZURE_STORAGE_CLIENT_ID
+              value: authoritative-client-id
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -4593,13 +3580,13 @@ spec:
                   name: chartsnap-bucket
                   optional: true
             - name: BUCKET
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: GORILLA_FILE_STORE
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: GORILLA_STORAGE_BUCKET
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -4702,14 +3689,10 @@ spec:
               value: /etc/ssl/certs/ca-certificates.crt
             - name: GORILLA_LUMEN_ADDR
               value: :16060
-            - name: GLOBAL_ADMIN_API_KEY
-              value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
             - name: GORILLA_GLUE_EXECUTE
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
-            - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-              value: "true"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -4717,7 +3700,7 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "wandb/megabinary:latest"
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -4737,7 +3720,6 @@ spec:
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
           restartPolicy: Never
-          priorityClassName: wandb-data-priority
           serviceAccountName: chartsnap-parquet
           securityContext:
             fsGroup: 0
@@ -4823,6 +3805,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -4991,7 +3975,7 @@ spec:
     - name: WANDB_BASE_URL
       value: "http://chartsnap-nginx:8080"
     - name: WANDB_API_KEY
-      value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+      value: ""
     command:
     - sh
     - -c
@@ -5031,10 +4015,6 @@ spec:
         - /cleanup-scripts/post_upgrade.sh
         envFrom:
         env:
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5042,7 +4022,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "alpine/k8s:1.31.12"
+        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -5052,7 +4032,6 @@ spec:
         - mountPath: /cleanup-scripts
           name: app-rename-cleanup
       restartPolicy: Never
-      priorityClassName: wandb-global-priority
       serviceAccountName: chartsnap-app-rename-post-hook
       securityContext:
         fsGroup: 0
@@ -5116,10 +4095,6 @@ spec:
         - /cleanup-scripts/pre_upgrade.sh
         envFrom:
         env:
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5127,7 +4102,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "alpine/k8s:1.31.12"
+        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -5137,7 +4112,6 @@ spec:
         - mountPath: /cleanup-scripts
           name: app-rename-cleanup
       restartPolicy: Never
-      priorityClassName: wandb-global-priority
       serviceAccountName: chartsnap-app-rename-pre-hook
       securityContext:
         fsGroup: 0

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -1454,6 +1454,18 @@ data:
   REDIS_HOST: "chartsnap-redis-master"
   REDIS_PARAMS: "?ttlInSeconds=604800"
 ---
+# Source: operator-wandb/templates/run-store-accelerator-run-updater.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-run-store-accelerator-run-updater-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+---
 # Source: operator-wandb/templates/weave-trace.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -1,74 +1,5 @@
 # chartsnap: snapshot_version=v3
 ---
-# Source: operator-wandb/charts/redis/templates/networkpolicy.yaml
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: chartsnap-redis
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: redis
-  policyTypes:
-  - Ingress
-  - Egress
-  egress:
-  - {}
-  ingress:
-  # Allow inbound connections
-  - ports:
-    - port: 6379
----
-# Source: operator-wandb/charts/anaconda2/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: anaconda2
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/api/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: api
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
 # Source: operator-wandb/charts/app/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -108,111 +39,6 @@ spec:
       operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/executor/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-executor
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: executor
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: executor
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/filemeta/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-filemeta
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: filemeta
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: filemeta
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/frontend/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-frontend
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: frontend
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: frontend
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/glue/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: glue
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/nginx/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-nginx
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: nginx
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
@@ -258,32 +84,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: operator-wandb/charts/anaconda2/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/api/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/app/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -295,6 +95,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    azure.workload.identity/client-id: "authoritative-client-id"
+    azure.workload.identity/tenant-id: "authoritative-tenant-id"
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/console/templates/serviceaccount.yaml
@@ -305,71 +108,6 @@ metadata:
   labels:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: console
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/executor/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-executor
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: executor
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/filemeta/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-filemeta
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: filemeta
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/frontend/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-frontend
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: frontend
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/glue/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/nginx/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-nginx
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
@@ -399,6 +137,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    azure.workload.identity/client-id: "authoritative-client-id"
+    azure.workload.identity/tenant-id: "authoritative-tenant-id"
 automountServiceAccountToken: true
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
@@ -414,36 +155,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: prometheus
   name: chartsnap-prometheus-server
-  namespace: default
----
-# Source: operator-wandb/charts/redis/templates/master/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-automountServiceAccountToken: false
-metadata:
-  name: chartsnap-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
----
-# Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader
   namespace: default
 ---
 # Source: operator-wandb/charts/weave/templates/serviceaccount.yaml
@@ -466,8 +177,6 @@ metadata:
   name: chartsnap-bucket
   labels:
 data:
-  ACCESS_KEY: bWluaW8=
-  SECRET_KEY: dGVzdHBhc3N3b3Jk
 ---
 # Source: operator-wandb/templates/clickhouse.yaml
 apiVersion: v1
@@ -499,14 +208,6 @@ data:
   GORILLA_SLACK_SECRET:
   SLACK_CLIENT_ID:
   SLACK_SECRET:
----
-# Source: operator-wandb/templates/history-reader.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: chartsnap-history-reader-secret
-  labels:
-data: {}
 ---
 # Source: operator-wandb/templates/kafka.yaml
 apiVersion: v1
@@ -555,7 +256,7 @@ metadata:
   name: "chartsnap-redis-secret"
   labels:
 data:
-  REDIS_PASSWORD: cmVkaXMxMjM=
+  REDIS_PASSWORD:
   REDIS_CA_CERT:
 ---
 # Source: operator-wandb/templates/session-key.yaml
@@ -582,32 +283,6 @@ metadata:
   labels:
 data:
   SMTP_PASSWORD: ""
----
-# Source: operator-wandb/charts/mysql/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-mysql-initdb
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-data:
-  my.cnf: |
-    [mysqld]
-    binlog_format = 'ROW'
-    innodb_online_alter_log_max_size = 268435456
-    sync_binlog = 1
-    innodb_flush_log_at_trx_commit = 1
-    binlog_row_image = 'MINIMAL'
-    local-infile = 1
-    sort_buffer_size = 33554432
-  # We need RELOAD, SELECT, and LOCK TABLES for making backups
-  initdb.sql: |
-    GRANT SESSION_VARIABLES_ADMIN,RELOAD,SELECT,LOCK TABLES ON *.* TO `wandb`@`%`;
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/configmap.yaml
 apiVersion: v1
@@ -1192,176 +867,6 @@ data:
   rules: |
     {}
 ---
-# Source: operator-wandb/charts/redis/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-redis-configuration
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  redis.conf: |-
-    # User-supplied common configuration:
-    # Enable AOF https://redis.io/topics/persistence#append-only-file
-    appendonly yes
-    # Disable RDB persistence, AOF persistence already enabled.
-    save ""
-    # End of common configuration
-  master.conf: |-
-    dir /data
-    # User-supplied master configuration:
-    rename-command FLUSHDB ""
-    rename-command FLUSHALL ""
-    # End of master configuration
-  replica.conf: |-
-    dir /data
-    # User-supplied replica configuration:
-    rename-command FLUSHDB ""
-    rename-command FLUSHALL ""
-    # End of replica configuration
----
-# Source: operator-wandb/charts/redis/templates/health-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-redis-health
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  ping_readiness_local.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h localhost \
-        -p $REDIS_PORT \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_liveness_local.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h localhost \
-        -p $REDIS_PORT \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
-    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ] && [ "$responseFirstWord" != "MASTERDOWN" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_readiness_master.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
-    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h $REDIS_MASTER_HOST \
-        -p $REDIS_MASTER_PORT_NUMBER \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_liveness_master.sh: |-
-    #!/bin/bash
-
-    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
-    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
-    response=$(
-      timeout -s 15 $1 \
-      redis-cli \
-        -h $REDIS_MASTER_HOST \
-        -p $REDIS_MASTER_PORT_NUMBER \
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
-    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ]; then
-      echo "$response"
-      exit 1
-    fi
-  ping_readiness_local_and_master.sh: |-
-    script_dir="$(dirname "$0")"
-    exit_status=0
-    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
-    exit $exit_status
-  ping_liveness_local_and_master.sh: |-
-    script_dir="$(dirname "$0")"
-    exit_status=0
-    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
-    exit $exit_status
----
-# Source: operator-wandb/charts/redis/templates/scripts-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-redis-scripts
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  start-master.sh: |
-    #!/bin/bash
-
-    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
-    if [[ -f /opt/bitnami/redis/mounted-etc/master.conf ]];then
-        cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
-    fi
-    if [[ -f /opt/bitnami/redis/mounted-etc/redis.conf ]];then
-        cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
-    fi
-    ARGS=("--port" "${REDIS_PORT}")
-    ARGS+=("--protected-mode" "no")
-    ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
-    ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
-    exec redis-server "${ARGS[@]}"
----
 # Source: operator-wandb/templates/anaconda2.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -1392,7 +897,7 @@ data:
   GORILLA_LICENSE_CERT_PATH: "/jwks.json"
   GORILLA_FILE_METADATA_SOURCE_IS_INTERNAL: "true"
   GORILLA_SESSION_LENGTH: "720h"
-  GORILLA_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
   GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE: "/view-spec-updater-linux"
   GORILLA_PARQUET_RPC_PATH: "/_goRPC_"
   GORILLA_ONPREM_API_KEY_PREFIX: "local"
@@ -1428,8 +933,8 @@ data:
   PARQUET_HOST: "http://chartsnap-parquet:8087"
   OPERATOR_ENABLED: "true"
   LOGGING_ENABLED: "true"
-  GORILLA_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
-  ANACONDA_ENABLED: "false"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
+  ANACONDA_ENABLED: "true"
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1
@@ -1438,9 +943,9 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
 data:
-  BUCKET_NAME: "minio:9000/bucket"
-  BUCKET_PATH: ""
-  AWS_REGION: "us-east-1"
+  BUCKET_NAME: "storage-account"
+  BUCKET_PATH: "container"
+  AWS_REGION: ""
   AWS_S3_KMS_ID: ""
   GORILLA_DEFAULT_REGION: "minio-local"
 ---
@@ -1648,7 +1153,7 @@ data:
   GORILLA_GLUE_FRONTEND_HOST: "http://localhost:8080"
   GORILLA_GLUE_LICENSE_CERT_PATH: "/jwks.json"
   # Values that correspond to existing configurations from gorilla.yaml
-  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
+  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-app:8082"
   GORILLA_GLUE_SESSION_LENGTH: "720h"
   GORILLA_GLUE_DEV: "false"
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
@@ -1678,20 +1183,6 @@ data:
   # Clear task dedupe key configuration
   GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
   GORILLA_GLUE_LOCAL_SERVICE_BYPASS: "false"
----
-# Source: operator-wandb/templates/history-reader.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-history-reader-configmap
-  labels:
-data:
-  GORILLA_FILE_HOST: "http://localhost:8080"
-  GORILLA_HISTORY_READER_GRPC_PORT: "9244"
-  GORILLA_HISTORY_READER_GRPC_MAX_RECV_MSG_SIZE: "4194304"
-  GORILLA_HISTORY_READER_GRPC_MAX_SEND_MSG_SIZE: "4194304"
-  GORILLA_HISTORY_READER_CACHE_SIZE: "10000"
-  GORILLA_HISTORY_READER_CACHE_TTL: "5m"
 ---
 # Source: operator-wandb/templates/history-updater.yaml
 apiVersion: v1
@@ -1730,7 +1221,7 @@ metadata:
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  GLUE_ENABLED: "false"
+  GLUE_ENABLED: "true"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
   LOCAL_K8S_SIGNER_SECRET_NAME: "chartsnap-internal-signer"
@@ -1741,6 +1232,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
@@ -1752,6 +1245,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chartsnap-lumen-rules
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   managed-install.yaml: |
     keyRuleSets:
@@ -1934,26 +1429,10 @@ data:
         proxy_set_header Host $host:8080;
         client_max_body_size 0;
         location / {
-          proxy_pass http://chartsnap-frontend:8080;
+          proxy_pass http://chartsnap-app:8080;
         }
         location /console {
           proxy_pass http://chartsnap-console:8082;
-        }
-
-        location /api {
-          proxy_pass http://chartsnap-api:8081;
-        }
-
-        location /graphql {
-          proxy_pass http://chartsnap-api:8081;
-        }
-
-        location /graphql2 {
-          proxy_pass http://chartsnap-api:8081;
-        }
-        location /bucket {
-          proxy_set_header Host minio:9000;
-          proxy_pass http://minio:9000;
         }
       }
     }
@@ -1989,18 +1468,6 @@ data:
   REDIS_HOST: "chartsnap-redis-master"
   REDIS_PARAMS: "?ttlInSeconds=604800"
 ---
-# Source: operator-wandb/templates/run-store-accelerator-run-updater.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-run-store-accelerator-run-updater-configmap
-  labels:
-data:
-  GORILLA_FILE_HOST: "http://localhost:8080"
-  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
-  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
-  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
----
 # Source: operator-wandb/templates/weave-trace.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -2015,7 +1482,7 @@ data:
   PORT: "8080"
   API_PATH_PREFIX: "/traces"
   WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
-  WANDB_BASE_URL: "http://chartsnap-api:8081/"
+  WANDB_BASE_URL: "http://chartsnap-app:8080/"
   WF_TRACE_SERVER_URL: "http://localhost:8080/traces"
   WF_ENFORCE_PASSWORD_LENGTH: "false"
   WEAVE_ENABLE_ONLINE_EVAL: "false"
@@ -2025,7 +1492,7 @@ data:
   WANDB_INTERNAL_SERVICE_TOKEN_SECRET_NAME: "weave-worker-auth"
   KAFKA_BROKER_HOST: "bufstream.bufstream.svc.cluster.local"
   KAFKA_BROKER_PORT: "9092"
-  WEAVE_REDIS_URL: "redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
+  WEAVE_REDIS_URL: "redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
 ---
 # Source: operator-wandb/templates/weave.yaml
 apiVersion: v1
@@ -2036,7 +1503,7 @@ metadata:
 data:
   GORILLA_ONPREM: "true"
   PORT: "9994"
-  WANDB_BASE_URL: "http://chartsnap-api:8081/"
+  WANDB_BASE_URL: "http://chartsnap-app:8080/"
   WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
   WEAVE_LOG_FORMAT: "json"
   WEAVE_SERVER_NUM_WORKERS: "4"
@@ -2046,25 +1513,6 @@ data:
   WEAVE_CACHE_CHECK_INTERVAL: "60"
   WEAVE_CACHE_SIZE_LIMIT: "20Gi"
   WEAVE_CACHE_CLEAR_PERCENT: "80"
----
-# Source: operator-wandb/charts/mysql/templates/pvc.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: chartsnap-mysql-data
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: "20Gi"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1
@@ -2320,34 +1768,6 @@ subjects:
   name: system:unauthenticated
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: operator-wandb/charts/api/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
----
 # Source: operator-wandb/charts/app/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2376,133 +1796,6 @@ rules:
   verbs:
   - get
 ---
-# Source: operator-wandb/charts/glue/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
----
-# Source: operator-wandb/charts/reloader/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader-role
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - "apps"
-  resources:
-  - deployments
-  - daemonsets
-  - statefulsets
-  verbs:
-  - list
-  - get
-  - update
-  - patch
-- apiGroups:
-  - "batch"
-  resources:
-  - cronjobs
-  verbs:
-  - list
-  - get
-- apiGroups:
-  - "batch"
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - list
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
----
-# Source: operator-wandb/charts/api/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-subjects:
-- kind: ServiceAccount
-  name: chartsnap-api
-  namespace: default
-roleRef:
-  kind: Role
-  name: chartsnap-api
-  apiGroup: rbac.authorization.k8s.io
----
 # Source: operator-wandb/charts/app/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -2522,94 +1815,6 @@ roleRef:
   kind: Role
   name: chartsnap-app
   apiGroup: rbac.authorization.k8s.io
----
-# Source: operator-wandb/charts/glue/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-subjects:
-- kind: ServiceAccount
-  name: chartsnap-glue
-  namespace: default
-roleRef:
-  kind: Role
-  name: chartsnap-glue
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: operator-wandb/charts/reloader/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader-role-binding
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: chartsnap-reloader-role
-subjects:
-- kind: ServiceAccount
-  name: chartsnap-reloader
-  namespace: default
----
-# Source: operator-wandb/charts/anaconda2/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8082
-    protocol: TCP
-    targetPort: http
-  selector:
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
----
-# Source: operator-wandb/charts/api/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8081
-    protocol: TCP
-    targetPort: api
-  selector:
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/app/templates/service.yaml
 apiVersion: v1
@@ -2660,75 +1865,6 @@ spec:
     protocol: TCP
   selector:
     app.kubernetes.io/name: console
-    app.kubernetes.io/instance: chartsnap
----
-# Source: operator-wandb/charts/frontend/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-frontend
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: frontend
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8080
-    protocol: TCP
-    targetPort: frontend
-  selector:
-    app.kubernetes.io/name: frontend
-    app.kubernetes.io/instance: chartsnap
----
-# Source: operator-wandb/charts/mysql/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-mysql
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - port: 3306
-    protocol: TCP
-    targetPort: mysql
-  selector:
-    helm.sh/chart: mysql-0.1.0
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
----
-# Source: operator-wandb/charts/nginx/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-nginx
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8080
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/service.yaml
@@ -2900,56 +2036,6 @@ spec:
     wandb.com/app-name: redis-exporter-0.1.0
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: operator-wandb/charts/redis/templates/headless-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-redis-headless
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-  - name: tcp-redis
-    port: 6379
-    targetPort: redis
-  selector:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: redis
----
-# Source: operator-wandb/charts/redis/templates/master/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/component: master
-spec:
-  type: ClusterIP
-  internalTrafficPolicy: Cluster
-  sessionAffinity: None
-  ports:
-  - name: tcp-redis
-    port: 6379
-    targetPort: redis
-    nodePort: null
-  selector:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/component: master
----
 # Source: operator-wandb/charts/weave/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -2999,7 +2085,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: daemonset-0.1.0
         app.kubernetes.io/name: daemonset
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.33.0"
@@ -3113,714 +2199,6 @@ spec:
           path: /var/lib/docker/containers
       hostNetwork: false
 ---
-# Source: operator-wandb/charts/anaconda2/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: anaconda2
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: anaconda2-0.12.5
-        app.kubernetes.io/name: anaconda2
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: anaconda2
-        envFrom:
-        - configMapRef:
-            name: chartsnap-anaconda2-configmap
-        env:
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: DD_AGENT_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: DD_TRACE_AGENT_HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8082
-          name: http
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ping
-            port: http
-          timeoutSeconds: 2
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ping
-            port: http
-          timeoutSeconds: 2
-        resources:
-          limits:
-            cpu: "1"
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      serviceAccountName: chartsnap-anaconda2
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: anaconda2
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: anaconda2
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
-# Source: operator-wandb/charts/api/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: api
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: api-0.12.5
-        app.kubernetes.io/name: api
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: api
-        args:
-        - gorilla
-        envFrom:
-        - configMapRef:
-            name: chartsnap-api-configmap
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - secretRef:
-            name: chartsnap-gorilla-session-key
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LIMITER
-          value: noop://
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-              name: gorilla-coreweave-observability
-              optional: true
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8081
-          name: api
-          protocol: TCP
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 30
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ready
-            port: api
-          periodSeconds: 5
-          successThreshold: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/
-          name: temp-dir
-      initContainers:
-      - name: migrate-db
-        command:
-        - bash
-        - -c
-        - |
-          LOG_FILE="/tmp/migrate.log"
-          ./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE --usage-db=$GORILLA_USAGE_STORE 2>&1 | tee -a $LOG_FILE
-          EXIT_CODE=${PIPESTATUS[0]}
-          MIGRATION_FILE_MISSING_ERROR_CODE=101
-          if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq $MIGRATION_FILE_MISSING_ERROR_CODE ]]; then
-            exit 0
-          else
-            # missing migration error log from golang-migrate@v4 -- older versions of megabinary
-            if grep -q "no migration found for version" $LOG_FILE; then
-              exit 0
-            fi
-            exit $EXIT_CODE
-          fi
-        envFrom:
-        - configMapRef:
-            name: chartsnap-api-configmap
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - secretRef:
-            name: chartsnap-gorilla-session-key
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LIMITER
-          value: noop://
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-              name: gorilla-coreweave-observability
-              optional: true
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/
-          name: temp-dir
-      serviceAccountName: chartsnap-api
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: api
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: api
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - emptyDir: {}
-        name: temp-dir
----
 # Source: operator-wandb/charts/app/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -3853,6 +2231,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: app
@@ -3912,12 +2291,10 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
+        - name: AZURE_STORAGE_TENANT_ID
+          value: authoritative-tenant-id
+        - name: AZURE_STORAGE_CLIENT_ID
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -3931,11 +2308,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
+        - name: GORILLA_STORAGE_BUCKET
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3966,25 +2345,25 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: noop://
         - name: KAFKA_CLIENT_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3996,7 +2375,7 @@ spec:
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
           value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
         - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
@@ -4038,34 +2417,20 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
         - name: BUCKET_QUEUE
           value: "internal://"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
-        - name: GORILLA_FILEMETA_ENABLED
-          value: "false"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
         - name: GORILLA_GLUE_CONTAINER_PORT
           value: "8083"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
-        - name: GORILLA_STORAGE_BUCKET
-          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -4194,12 +2559,10 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
+        - name: AZURE_STORAGE_TENANT_ID
+          value: authoritative-tenant-id
+        - name: AZURE_STORAGE_CLIENT_ID
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -4213,11 +2576,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
+        - name: GORILLA_STORAGE_BUCKET
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -4248,25 +2613,25 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: noop://
         - name: KAFKA_CLIENT_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -4278,7 +2643,7 @@ spec:
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
           value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
         - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
@@ -4320,34 +2685,20 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
         - name: BUCKET_QUEUE
           value: "internal://"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
-        - name: GORILLA_FILEMETA_ENABLED
-          value: "false"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
         - name: GORILLA_GLUE_CONTAINER_PORT
           value: "8083"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
-        - name: GORILLA_STORAGE_BUCKET
-          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -4453,16 +2804,6 @@ spec:
         - configMapRef:
             name: chartsnap-console-configmap
         env:
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4553,1141 +2894,6 @@ spec:
             path: redis_ca.pem
           optional: true
 ---
-# Source: operator-wandb/charts/executor/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-executor-bc
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: executor
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: executor
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: executor-0.12.5
-        app.kubernetes.io/name: executor
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: executor
-        args:
-        - executor
-        envFrom:
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-executor-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        - name: GORILLA_TASK_QUEUE
-          value: 'redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)&concurrency=10'
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      serviceAccountName: chartsnap-executor
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: executor
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: executor
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
-# Source: operator-wandb/charts/filemeta/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-filemeta
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: filemeta
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: filemeta
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: filemeta-0.12.5
-        app.kubernetes.io/name: filemeta
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: filemeta
-        args:
-        - filemeta
-        envFrom:
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      serviceAccountName: chartsnap-filemeta
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: filemeta
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: filemeta
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
-# Source: operator-wandb/charts/frontend/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-frontend
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: frontend
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: frontend
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: frontend-0.12.5
-        app.kubernetes.io/name: frontend
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: frontend
-        envFrom:
-        - configMapRef:
-            name: chartsnap-frontend-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        env:
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-          name: frontend
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /docker-entrypoint.d/02_patch_env_js.sh
-          name: wandb-setup-scripts
-          subPath: 02_patch_env_js.sh
-      serviceAccountName: chartsnap-frontend
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 101
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: frontend
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: frontend
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - configMap:
-          defaultMode: 493
-          items:
-          - key: 02_patch_env_js.sh
-            path: 02_patch_env_js.sh
-          name: 'chartsnap-frontend-patch-env-js'
-        name: wandb-setup-scripts
----
-# Source: operator-wandb/charts/glue/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: glue
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: glue-0.12.5
-        app.kubernetes.io/name: glue
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: glue
-        args:
-        - glue
-        envFrom:
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-glue-configmap
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 1
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/
-          name: temp-dir
-      initContainers:
-      serviceAccountName: chartsnap-glue
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: glue
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: glue
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - emptyDir: {}
-        name: temp-dir
----
-# Source: operator-wandb/charts/nginx/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-nginx
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: nginx-0.12.5
-        app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: nginx
-        envFrom:
-        env:
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "2"
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /etc/nginx/nginx.conf
-          name: nginx-config
-          subPath: nginx.conf
-      serviceAccountName: chartsnap-nginx
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: nginx
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: nginx
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - configMap:
-          name: 'chartsnap-nginx-configmap'
-        name: nginx-config
----
 # Source: operator-wandb/charts/parquet/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -5722,6 +2928,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: parquet
@@ -5773,12 +2980,10 @@ spec:
               key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
               name: gorilla-coreweave-caios
               optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
+        - name: AZURE_STORAGE_TENANT_ID
+          value: authoritative-tenant-id
+        - name: AZURE_STORAGE_CLIENT_ID
+          value: authoritative-client-id
         - name: BUCKET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -5792,13 +2997,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -5829,25 +3034,25 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: noop://
         - name: KAFKA_CLIENT_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -5859,7 +3064,7 @@ spec:
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
           value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
         - name: GORILLA_HISTORY_STORE
-          value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
           value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
         - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
@@ -5901,16 +3106,6 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6034,7 +3229,7 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: v2.47.0
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: instance-24.5.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: prometheus
     spec:
@@ -6106,94 +3301,6 @@ spec:
         persistentVolumeClaim:
           claimName: chartsnap-prometheus-server
 ---
-# Source: operator-wandb/charts/reloader/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-    group: com.stakater.platform
-    provider: stakater
-    version: v1.3.0
-  name: chartsnap-reloader
-  namespace: default
-spec:
-  replicas: 1
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: chartsnap-reloader
-      release: "chartsnap"
-  template:
-    metadata:
-      labels:
-        app: chartsnap-reloader
-        chart: "reloader-1.3.0"
-        release: "chartsnap"
-        heritage: "Helm"
-        app.kubernetes.io/managed-by: "Helm"
-        group: com.stakater.platform
-        provider: stakater
-        version: v1.3.0
-    spec:
-      containers:
-      - image: "us-docker.pkg.dev/wandb-production/public/stakater/reloader:v1.3.0"
-        imagePullPolicy: IfNotPresent
-        name: chartsnap-reloader
-        env:
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: '1'
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-              divisor: '1'
-        - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        ports:
-        - name: http
-          containerPort: 9090
-        livenessProbe:
-          httpGet:
-            path: /live
-            port: http
-          timeoutSeconds: 5
-          failureThreshold: 5
-          periodSeconds: 10
-          successThreshold: 1
-          initialDelaySeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: http
-          timeoutSeconds: 5
-          failureThreshold: 5
-          periodSeconds: 10
-          successThreshold: 1
-          initialDelaySeconds: 10
-        securityContext: {}
-        args:
-        - "--log-level=info"
-        - "--reload-on-create=true"
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      serviceAccountName: chartsnap-reloader
----
 # Source: operator-wandb/charts/weave/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -6239,16 +3346,6 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6308,16 +3405,6 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6397,273 +3484,6 @@ spec:
           sizeLimit: '20Gi'
         name: cache
 ---
-# Source: operator-wandb/charts/mysql/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: chartsnap-mysql
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: chartsnap
-      helm.sh/chart: mysql-0.1.0
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/version: "1.16.0"
-      wandb.com/app-name: mysql-0.1.0
-      app.kubernetes.io/managed-by: Helm
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: mysql
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "1.16.0"
-        wandb.com/app-name: mysql-0.1.0
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 0
-        fsGroup: 999
-        fsGroupChangePolicy: OnRootMismatch
-        runAsNonRoot: true
-      containers:
-      - name: mysql
-        image: "us-docker.pkg.dev/wandb-production/public/mysql:latest"
-        securityContext:
-          allowPrivilegeEscalation: false
-        ports:
-        - name: mysql
-          containerPort: 3306
-          protocol: TCP
-        env:
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "chartsnap-mysql"
-              key: "MYSQL_PASSWORD"
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: "chartsnap-mysql"
-        - name: MYSQL_DATABASE
-          value: "wandb_local"
-        - name: MYSQL_USER
-          value: "wandb"
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: chartsnap-mysql
-              key: MYSQL_ROOT_PASSWORD
-        livenessProbe:
-          tcpSocket:
-            port: 3306
-        readinessProbe:
-          tcpSocket:
-            port: 3306
-        startupProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          failureThreshold: 60
-          tcpSocket:
-            port: 3306
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/mysql
-        - name: initdb
-          mountPath: /docker-entrypoint-initdb.d/initdb.sql
-          subPath: initdb.sql
-        - name: initdb
-          mountPath: /etc/mysql/my.cnf
-          subPath: my.cnf
-        resources:
-          limits:
-            cpu: 4000m
-            memory: 8Gi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-      volumes:
-      - name: initdb
-        configMap:
-          name: chartsnap-mysql-initdb
-      - name: data
-        persistentVolumeClaim:
-          claimName: chartsnap-mysql-data
----
-# Source: operator-wandb/charts/redis/templates/master/application.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: chartsnap-redis-master
-  namespace: "default"
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redis
-    app.kubernetes.io/version: 7.2.4
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/component: master
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: redis
-      app.kubernetes.io/component: master
-  serviceName: chartsnap-redis-headless
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: redis
-        app.kubernetes.io/version: 7.2.4
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/component: master
-      annotations:
-        checksum/configmap: 86bcc953bb473748a3d3dc60b7c11f34e60c93519234d4c37f42e22ada559d47
-        checksum/health: aff24913d801436ea469d8d374b2ddb3ec4c43ee7ab24663d5f8ff1a1b6991a9
-        checksum/scripts: 43cdf68c28f3abe25ce017a82f74dbf2437d1900fd69df51a55a3edf6193d141
-        checksum/secret: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-    spec:
-      securityContext:
-        fsGroup: 1001
-        fsGroupChangePolicy: Always
-        supplementalGroups: []
-        sysctls: []
-      serviceAccountName: chartsnap-redis-master
-      automountServiceAccountToken: false
-      affinity:
-        podAffinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/instance: chartsnap
-                  app.kubernetes.io/name: redis
-                  app.kubernetes.io/component: master
-              topologyKey: kubernetes.io/hostname
-            weight: 1
-        nodeAffinity:
-      enableServiceLinks: true
-      terminationGracePeriodSeconds: 30
-      containers:
-      - name: redis
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/redis:7.2.4-debian-12-r9
-        imagePullPolicy: "IfNotPresent"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: false
-          runAsGroup: 0
-          runAsNonRoot: true
-          runAsUser: 1001
-          seLinuxOptions: null
-          seccompProfile:
-            type: RuntimeDefault
-        command:
-        - /bin/bash
-        args:
-        - -c
-        - /opt/bitnami/scripts/start-scripts/start-master.sh
-        env:
-        - name: BITNAMI_DEBUG
-          value: "false"
-        - name: REDIS_REPLICATION_MODE
-          value: master
-        - name: ALLOW_EMPTY_PASSWORD
-          value: "yes"
-        - name: REDIS_TLS_ENABLED
-          value: "no"
-        - name: REDIS_PORT
-          value: "6379"
-        ports:
-        - name: redis
-          containerPort: 6379
-        livenessProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          # One second longer than command timeout should prevent generation of zombie processes.
-          timeoutSeconds: 6
-          successThreshold: 1
-          failureThreshold: 5
-          exec:
-            command:
-            - sh
-            - -c
-            - /health/ping_liveness_local.sh 5
-        readinessProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          timeoutSeconds: 2
-          successThreshold: 1
-          failureThreshold: 5
-          exec:
-            command:
-            - sh
-            - -c
-            - /health/ping_readiness_local.sh 1
-        volumeMounts:
-        - name: start-scripts
-          mountPath: /opt/bitnami/scripts/start-scripts
-        - name: health
-          mountPath: /health
-        - name: redis-data
-          mountPath: /data
-        - name: config
-          mountPath: /opt/bitnami/redis/mounted-etc
-        - name: empty-dir
-          mountPath: /opt/bitnami/redis/etc/
-          subPath: app-conf-dir
-        - name: empty-dir
-          mountPath: /tmp
-          subPath: tmp-dir
-      volumes:
-      - name: start-scripts
-        configMap:
-          name: chartsnap-redis-scripts
-          defaultMode: 0755
-      - name: health
-        configMap:
-          name: chartsnap-redis-health
-          defaultMode: 0755
-      - name: config
-        configMap:
-          name: chartsnap-redis-configuration
-      - name: empty-dir
-        emptyDir: {}
-  volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: redis-data
-      labels:
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/name: redis
-        app.kubernetes.io/component: master
-    spec:
-      accessModes:
-      - "ReadWriteOnce"
-      resources:
-        requests:
-          storage: "8Gi"
----
 # Source: operator-wandb/charts/parquet/templates/cronjob.yaml
 apiVersion: batch/v1
 kind: CronJob
@@ -6689,6 +3509,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "true"
         spec:
           containers:
           - name: backfill-job
@@ -6742,12 +3563,10 @@ spec:
                   key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
                   name: gorilla-coreweave-caios
                   optional: true
-            - name: AZURE_STORAGE_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: ACCESS_KEY
-                  name: chartsnap-bucket
-                  optional: true
+            - name: AZURE_STORAGE_TENANT_ID
+              value: authoritative-tenant-id
+            - name: AZURE_STORAGE_CLIENT_ID
+              value: authoritative-client-id
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -6761,13 +3580,13 @@ spec:
                   name: chartsnap-bucket
                   optional: true
             - name: BUCKET
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: GORILLA_FILE_STORE
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: GORILLA_STORAGE_BUCKET
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: az://$(BUCKET_NAME)/$(BUCKET_PATH)
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -6798,25 +3617,25 @@ spec:
                   name: chartsnap-redis-secret
                   optional: true
             - name: REDIS
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_AUDITOR_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_FILE_METADATA_SOURCE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_LOCKER
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_METADATA_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_SETTINGS_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_USAGE_METRICS_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_TASK_QUEUE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: noop://
             - name: KAFKA_CLIENT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -6828,7 +3647,7 @@ spec:
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
               value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
             - name: GORILLA_HISTORY_STORE
-              value: historyreader://chartsnap-history-reader:9244,http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+              value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
             - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
               value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
             - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
@@ -6870,20 +3689,10 @@ spec:
               value: /etc/ssl/certs/ca-certificates.crt
             - name: GORILLA_LUMEN_ADDR
               value: :16060
-            - name: BUCKET_PROXY
-              value: "true"
-            - name: GLOBAL_ADMIN_API_KEY
-              value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-            - name: GORILLA_FILE_STORE_IS_PROXIED
-              value: "true"
             - name: GORILLA_GLUE_EXECUTE
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
-            - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-              value: "true"
-            - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-              value: "true"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -6996,6 +3805,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-5"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
 data:
   pre_upgrade.sh: |
     #!/bin/bash
@@ -7164,7 +3975,7 @@ spec:
     - name: WANDB_BASE_URL
       value: "http://chartsnap-nginx:8080"
     - name: WANDB_API_KEY
-      value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+      value: ""
     command:
     - sh
     - -c
@@ -7204,16 +4015,6 @@ spec:
         - /cleanup-scripts/post_upgrade.sh
         envFrom:
         env:
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -7294,16 +4095,6 @@ spec:
         - /cleanup-scripts/pre_upgrade.sh
         envFrom:
         env:
-        - name: BUCKET_PROXY
-          value: "true"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
-          value: "true"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -152,6 +152,8 @@ kind: ServiceAccount
 metadata:
   name: wandb-bucket-access
   labels:
+  annotations:
+    azure.workload.identity/client-id: authoritative-client-id
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2840,7 +2840,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3440,7 +3440,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3588,7 +3588,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3724,7 +3724,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4237,7 +4237,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4710,7 +4710,7 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2840,7 +2840,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2848,6 +2848,7 @@ spec:
         app-common-label: "app-common-label-value"
         global-common-label: "global-common-label-value"
         app-pod-label: "app-pod-label-value"
+        azure.workload.identity/use: "false"
         global-pod-label: "global-pod-label-value"
     spec:
       containers:
@@ -3440,7 +3441,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3588,7 +3589,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3724,12 +3725,13 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         global-common-label: "global-common-label-value"
+        azure.workload.identity/use: "false"
         global-pod-label: "global-pod-label-value"
     spec:
       containers:
@@ -4237,7 +4239,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4710,12 +4712,13 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
             global-common-label: "global-common-label-value"
+            azure.workload.identity/use: "false"
             global-pod-label: "global-pod-label-value"
         spec:
           containers:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2840,7 +2840,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3441,7 +3441,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3590,7 +3590,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3726,7 +3726,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4240,7 +4240,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4713,7 +4713,7 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2853,7 +2853,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3454,7 +3454,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3603,7 +3603,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3739,7 +3739,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4253,7 +4253,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4726,7 +4726,7 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2853,7 +2853,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3453,7 +3453,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3601,7 +3601,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3737,7 +3737,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4250,7 +4250,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4723,7 +4723,7 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -3460,6 +3460,7 @@ spec:
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         global-common-label: "global-common-label-value"
+        azure.workload.identity/use: "false"
         global-pod-label: "global-pod-label-value"
     spec:
       containers:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2853,7 +2853,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2861,6 +2861,7 @@ spec:
         app-common-label: "app-common-label-value"
         global-common-label: "global-common-label-value"
         app-pod-label: "app-pod-label-value"
+        azure.workload.identity/use: "false"
         global-pod-label: "global-pod-label-value"
     spec:
       containers:
@@ -3453,7 +3454,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3601,7 +3602,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3737,12 +3738,13 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         global-common-label: "global-common-label-value"
+        azure.workload.identity/use: "false"
         global-pod-label: "global-pod-label-value"
     spec:
       containers:
@@ -4250,7 +4252,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4723,12 +4725,13 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
             global-common-label: "global-common-label-value"
+            azure.workload.identity/use: "false"
             global-pod-label: "global-pod-label-value"
         spec:
           containers:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -3447,6 +3447,7 @@ spec:
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         global-common-label: "global-common-label-value"
+        azure.workload.identity/use: "false"
         global-pod-label: "global-pod-label-value"
     spec:
       containers:

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3257,7 +3257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3429,11 +3429,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4031,11 +4032,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4668,7 +4670,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4828,11 +4830,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5143,11 +5146,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5438,11 +5442,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.5
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filestream
@@ -5755,11 +5760,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -6058,7 +6064,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6218,11 +6224,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6550,11 +6557,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: metric-observer-0.12.5
+        helm.sh/chart: metric-observer-0.12.4
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: metric-observer
@@ -6870,7 +6878,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7020,11 +7028,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -7546,7 +7555,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8053,11 +8062,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3269,7 +3269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3441,11 +3441,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4043,11 +4044,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4680,7 +4682,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4840,11 +4842,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5155,11 +5158,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5450,11 +5454,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.5
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filestream
@@ -5767,11 +5772,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -6070,7 +6076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6230,11 +6236,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6562,11 +6569,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: metric-observer-0.12.5
+        helm.sh/chart: metric-observer-0.12.4
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: metric-observer
@@ -6882,7 +6890,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7032,11 +7040,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -7558,7 +7567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8065,11 +8074,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3269,7 +3269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3441,7 +3441,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4044,7 +4044,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4682,7 +4682,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4843,7 +4843,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5159,7 +5159,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5455,7 +5455,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5773,7 +5773,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6077,7 +6077,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6237,7 +6237,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6570,7 +6570,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: metric-observer-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6891,7 +6891,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7041,7 +7041,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7568,7 +7568,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8075,7 +8075,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3269,7 +3269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3441,7 +3441,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4043,7 +4043,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4680,7 +4680,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4840,7 +4840,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5155,7 +5155,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5450,7 +5450,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filestream-0.12.5
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5767,7 +5767,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6070,7 +6070,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6230,7 +6230,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6562,7 +6562,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: metric-observer-0.12.5
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6882,7 +6882,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7032,7 +7032,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7558,7 +7558,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8065,7 +8065,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3257,7 +3257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3429,7 +3429,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4032,7 +4032,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4670,7 +4670,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4831,7 +4831,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5147,7 +5147,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5443,7 +5443,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5761,7 +5761,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6065,7 +6065,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6225,7 +6225,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6558,7 +6558,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: metric-observer-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6879,7 +6879,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7029,7 +7029,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7556,7 +7556,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8063,7 +8063,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3257,7 +3257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3429,7 +3429,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4031,7 +4031,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4668,7 +4668,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4828,7 +4828,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5143,7 +5143,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5438,7 +5438,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filestream-0.12.5
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5755,7 +5755,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6058,7 +6058,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6218,7 +6218,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6550,7 +6550,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: metric-observer-0.12.5
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6870,7 +6870,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7020,7 +7020,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7546,7 +7546,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8053,7 +8053,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -4675,6 +4675,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -4687,6 +4687,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -3168,6 +3168,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3870,6 +3871,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4163,6 +4165,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -4572,6 +4575,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5013,6 +5017,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5980,6 +5985,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -3156,6 +3156,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3858,6 +3859,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4151,6 +4153,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -4560,6 +4563,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5001,6 +5005,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5968,6 +5973,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -3719,6 +3719,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -3731,6 +3731,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3128,7 +3128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3278,11 +3278,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3836,11 +3837,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4429,7 +4431,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4567,11 +4569,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4860,11 +4863,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5131,7 +5135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5269,11 +5273,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5577,7 +5582,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5705,11 +5710,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6209,7 +6215,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6672,11 +6678,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3140,7 +3140,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3290,11 +3290,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3848,11 +3849,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4441,7 +4443,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4579,11 +4581,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4872,11 +4875,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5143,7 +5147,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5281,11 +5285,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5589,7 +5594,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5717,11 +5722,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6221,7 +6227,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6684,11 +6690,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -4448,6 +4448,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3128,7 +3128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3278,7 +3278,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3836,7 +3836,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4429,7 +4429,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4567,7 +4567,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4860,7 +4860,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5131,7 +5131,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5269,7 +5269,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5577,7 +5577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5705,7 +5705,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6209,7 +6209,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6672,7 +6672,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -4436,6 +4436,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3140,7 +3140,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3290,7 +3290,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3849,7 +3849,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4443,7 +4443,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4582,7 +4582,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4876,7 +4876,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5148,7 +5148,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5286,7 +5286,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5595,7 +5595,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5723,7 +5723,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6228,7 +6228,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6691,7 +6691,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3128,7 +3128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3278,7 +3278,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3837,7 +3837,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4431,7 +4431,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4570,7 +4570,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4864,7 +4864,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5136,7 +5136,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5274,7 +5274,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5583,7 +5583,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5711,7 +5711,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6216,7 +6216,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6679,7 +6679,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -4426,6 +4426,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3826,7 +3826,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4419,7 +4419,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,7 +4557,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4850,7 +4850,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5121,7 +5121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,7 +5259,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5567,7 +5567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,7 +5695,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6199,7 +6199,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6662,7 +6662,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -4414,6 +4414,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3815,7 +3815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4409,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4548,7 +4548,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4842,7 +4842,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5114,7 +5114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5252,7 +5252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5561,7 +5561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5689,7 +5689,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6194,7 +6194,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6657,7 +6657,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3268,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3826,11 +3827,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4419,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,11 +4559,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4850,11 +4853,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5121,7 +5125,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,11 +5263,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5567,7 +5572,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,11 +5700,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6199,7 +6205,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6662,11 +6668,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3827,7 +3827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4421,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4560,7 +4560,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4854,7 +4854,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5126,7 +5126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5264,7 +5264,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5573,7 +5573,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5701,7 +5701,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6206,7 +6206,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6669,7 +6669,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,11 +3256,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3814,11 +3815,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4407,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,11 +4547,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4838,11 +4841,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5109,7 +5113,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,11 +5251,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5555,7 +5560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,11 +5688,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6187,7 +6193,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6650,11 +6656,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3814,7 +3814,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4407,7 +4407,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,7 +4545,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4838,7 +4838,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5109,7 +5109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,7 +5247,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5555,7 +5555,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,7 +5683,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6187,7 +6187,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6650,7 +6650,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -4426,6 +4426,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3826,7 +3826,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4419,7 +4419,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,7 +4557,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4850,7 +4850,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5121,7 +5121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,7 +5259,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5567,7 +5567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,7 +5695,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6199,7 +6199,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6662,7 +6662,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -4414,6 +4414,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3815,7 +3815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4409,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4548,7 +4548,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4842,7 +4842,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5114,7 +5114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5252,7 +5252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5561,7 +5561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5689,7 +5689,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6194,7 +6194,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6657,7 +6657,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3268,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3826,11 +3827,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4419,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,11 +4559,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4850,11 +4853,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5121,7 +5125,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,11 +5263,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5567,7 +5572,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,11 +5700,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6199,7 +6205,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6662,11 +6668,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3827,7 +3827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4421,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4560,7 +4560,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4854,7 +4854,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5126,7 +5126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5264,7 +5264,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5573,7 +5573,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5701,7 +5701,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6206,7 +6206,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6669,7 +6669,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,11 +3256,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3814,11 +3815,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4407,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,11 +4547,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4838,11 +4841,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5109,7 +5113,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,11 +5251,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5555,7 +5560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,11 +5688,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6187,7 +6193,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6650,11 +6656,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3814,7 +3814,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4407,7 +4407,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,7 +4545,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4838,7 +4838,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5109,7 +5109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,7 +5247,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5555,7 +5555,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,7 +5683,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6187,7 +6187,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6650,7 +6650,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3061,7 +3061,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3192,7 +3192,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3609,7 +3609,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4015,7 +4015,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2489,11 +2489,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3061,7 +3062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3192,11 +3193,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3609,7 +3611,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4015,11 +4017,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2477,11 +2477,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3049,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3180,11 +3181,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3597,7 +3599,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4003,11 +4005,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3182,7 +3182,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3600,7 +3600,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4006,7 +4006,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -3067,6 +3067,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -3055,6 +3055,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3049,7 +3049,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3180,7 +3180,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3597,7 +3597,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4003,7 +4003,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3062,7 +3062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3194,7 +3194,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3612,7 +3612,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4018,7 +4018,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2523,7 +2523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3096,7 +3096,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3225,7 +3225,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3512,7 +3512,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3930,7 +3930,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4336,7 +4336,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -3089,6 +3089,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2523,7 +2523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3095,7 +3095,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3223,7 +3223,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3509,7 +3509,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3926,7 +3926,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4332,7 +4332,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2523,11 +2523,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3095,7 +3096,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3223,11 +3224,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -3509,11 +3511,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3926,7 +3929,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4332,11 +4335,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2511,11 +2511,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3083,7 +3084,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3211,11 +3212,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -3497,11 +3499,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3914,7 +3917,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4320,11 +4323,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -3101,6 +3101,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2511,7 +2511,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3084,7 +3084,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3213,7 +3213,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3500,7 +3500,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3918,7 +3918,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4324,7 +4324,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2511,7 +2511,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3083,7 +3083,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3211,7 +3211,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3497,7 +3497,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3914,7 +3914,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4320,7 +4320,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2523,7 +2523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3096,7 +3096,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3228,7 +3228,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3507,7 +3507,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3925,7 +3925,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4331,7 +4331,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -3089,6 +3089,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2523,11 +2523,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3095,7 +3096,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3226,11 +3227,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -3504,11 +3506,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3921,7 +3924,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4327,11 +4330,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2511,7 +2511,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3084,7 +3084,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3216,7 +3216,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3495,7 +3495,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3913,7 +3913,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4319,7 +4319,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -3101,6 +3101,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2511,7 +2511,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3083,7 +3083,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3214,7 +3214,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3492,7 +3492,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3909,7 +3909,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4315,7 +4315,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2511,11 +2511,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3083,7 +3084,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3214,11 +3215,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -3492,11 +3494,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3909,7 +3912,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4315,11 +4318,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2523,7 +2523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3095,7 +3095,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3226,7 +3226,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3504,7 +3504,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3921,7 +3921,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4327,7 +4327,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2489,11 +2489,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3061,7 +3062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3192,11 +3193,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3601,7 +3603,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3975,11 +3977,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2477,11 +2477,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3049,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3180,11 +3181,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3589,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3963,11 +3965,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3061,7 +3061,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3192,7 +3192,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3601,7 +3601,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3975,7 +3975,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3049,7 +3049,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3180,7 +3180,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3589,7 +3589,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3963,7 +3963,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3182,7 +3182,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3592,7 +3592,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3966,7 +3966,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -3067,6 +3067,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -3055,6 +3055,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3062,7 +3062,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3194,7 +3194,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3604,7 +3604,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3978,7 +3978,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -2996,7 +2996,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3146,7 +3146,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3710,7 +3710,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3849,7 +3849,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4143,7 +4143,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4415,7 +4415,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4553,7 +4553,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4867,7 +4867,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4995,7 +4995,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5500,7 +5500,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5963,7 +5963,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -3008,7 +3008,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3158,11 +3158,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3721,7 +3722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3859,11 +3860,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4152,11 +4154,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -4423,7 +4426,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4561,11 +4564,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -4874,7 +4878,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5002,11 +5006,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5506,7 +5511,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5969,11 +5974,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -3008,7 +3008,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3158,7 +3158,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3721,7 +3721,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3859,7 +3859,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4152,7 +4152,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4423,7 +4423,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4561,7 +4561,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4874,7 +4874,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5002,7 +5002,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5506,7 +5506,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5969,7 +5969,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -2996,7 +2996,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3146,11 +3146,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3709,7 +3710,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3847,11 +3848,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4140,11 +4142,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -4411,7 +4414,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4549,11 +4552,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -4862,7 +4866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4990,11 +4994,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5494,7 +5499,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5957,11 +5962,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -3008,7 +3008,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3158,7 +3158,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3722,7 +3722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3861,7 +3861,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4155,7 +4155,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4427,7 +4427,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4565,7 +4565,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4879,7 +4879,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5007,7 +5007,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5512,7 +5512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5975,7 +5975,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -2996,7 +2996,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3146,7 +3146,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3709,7 +3709,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3847,7 +3847,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4140,7 +4140,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4411,7 +4411,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4549,7 +4549,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4862,7 +4862,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4990,7 +4990,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5494,7 +5494,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5957,7 +5957,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -3727,6 +3727,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -3715,6 +3715,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3268,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3831,11 +3832,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4420,7 +4422,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4558,11 +4560,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4851,11 +4854,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5122,7 +5126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5260,11 +5264,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5573,7 +5578,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5701,11 +5706,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6205,7 +6211,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6668,11 +6674,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,11 +3256,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3819,11 +3820,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4408,7 +4410,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4546,11 +4548,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4839,11 +4842,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5110,7 +5114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5248,11 +5252,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5561,7 +5566,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5689,11 +5694,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6193,7 +6199,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6656,11 +6662,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3832,7 +3832,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4422,7 +4422,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4561,7 +4561,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4855,7 +4855,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5127,7 +5127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5265,7 +5265,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5579,7 +5579,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5707,7 +5707,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6212,7 +6212,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6675,7 +6675,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3819,7 +3819,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4408,7 +4408,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4546,7 +4546,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4839,7 +4839,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5110,7 +5110,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5248,7 +5248,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5561,7 +5561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5689,7 +5689,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6193,7 +6193,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6656,7 +6656,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3820,7 +3820,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4410,7 +4410,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4549,7 +4549,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4843,7 +4843,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5115,7 +5115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5253,7 +5253,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5567,7 +5567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,7 +5695,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6200,7 +6200,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6663,7 +6663,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -4415,6 +4415,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3831,7 +3831,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4420,7 +4420,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4558,7 +4558,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4851,7 +4851,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5122,7 +5122,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5260,7 +5260,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5573,7 +5573,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5701,7 +5701,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6205,7 +6205,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6668,7 +6668,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -4427,6 +4427,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2542,11 +2542,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3114,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3245,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3420,11 +3421,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3837,7 +3839,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4243,11 +4245,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3114,7 +3114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3244,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3420,7 +3420,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3837,7 +3837,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4243,7 +4243,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -3132,6 +3132,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2554,7 +2554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3127,7 +3127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3258,7 +3258,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3434,7 +3434,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3852,7 +3852,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4258,7 +4258,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2554,7 +2554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3126,7 +3126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3432,7 +3432,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3849,7 +3849,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4255,7 +4255,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -3120,6 +3120,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3115,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3246,7 +3246,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3422,7 +3422,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3840,7 +3840,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4246,7 +4246,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2554,11 +2554,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3126,7 +3127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3257,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3432,11 +3433,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3849,7 +3851,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4255,11 +4257,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2542,11 +2542,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3114,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3245,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3420,11 +3421,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3837,7 +3839,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4243,11 +4245,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3114,7 +3114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3244,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3420,7 +3420,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3837,7 +3837,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4243,7 +4243,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -3132,6 +3132,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2554,7 +2554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3127,7 +3127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3258,7 +3258,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3434,7 +3434,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3852,7 +3852,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4258,7 +4258,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2554,7 +2554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3126,7 +3126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3432,7 +3432,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3849,7 +3849,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4255,7 +4255,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -3120,6 +3120,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3115,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3246,7 +3246,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3422,7 +3422,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3840,7 +3840,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4246,7 +4246,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2554,11 +2554,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3126,7 +3127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3257,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3432,11 +3433,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3849,7 +3851,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4255,11 +4257,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -3132,6 +3132,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2554,7 +2554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3127,7 +3127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3258,7 +3258,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3432,7 +3432,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3850,7 +3850,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4256,7 +4256,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2554,7 +2554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3126,7 +3126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3430,7 +3430,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3847,7 +3847,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4253,7 +4253,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3115,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3246,7 +3246,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3420,7 +3420,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3838,7 +3838,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4244,7 +4244,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2554,11 +2554,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3126,7 +3127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3257,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3430,11 +3431,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3847,7 +3849,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4253,11 +4255,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -3120,6 +3120,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3114,7 +3114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3244,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3418,7 +3418,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3835,7 +3835,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4241,7 +4241,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2542,11 +2542,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3114,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3245,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3418,11 +3419,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3835,7 +3837,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4241,11 +4243,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3436,11 +3436,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3994,11 +3995,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4587,7 +4589,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4725,11 +4727,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5036,7 +5039,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5244,7 +5247,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5372,11 +5375,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5876,7 +5880,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6123,7 +6127,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6933,11 +6937,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3448,7 +3448,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4006,7 +4006,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4599,7 +4599,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4737,7 +4737,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5048,7 +5048,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5256,7 +5256,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5384,7 +5384,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5888,7 +5888,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6135,7 +6135,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6945,7 +6945,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -4606,6 +4606,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -4594,6 +4594,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -5897,6 +5897,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -5885,6 +5885,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3448,11 +3448,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4006,11 +4007,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4599,7 +4601,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4737,11 +4739,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5048,7 +5051,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: mcp-server-0.12.5
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5256,7 +5259,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5384,11 +5387,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5888,7 +5892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6135,7 +6139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6945,11 +6949,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3436,7 +3436,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3995,7 +3995,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4589,7 +4589,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4728,7 +4728,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5040,7 +5040,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5248,7 +5248,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5376,7 +5376,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5881,7 +5881,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6129,7 +6129,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6939,7 +6939,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3448,7 +3448,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4007,7 +4007,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4601,7 +4601,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4740,7 +4740,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5052,7 +5052,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: mcp-server-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5260,7 +5260,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5388,7 +5388,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5893,7 +5893,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6141,7 +6141,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6951,7 +6951,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3436,7 +3436,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3994,7 +3994,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4587,7 +4587,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4725,7 +4725,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5036,7 +5036,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: mcp-server-0.12.5
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5244,7 +5244,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5372,7 +5372,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5876,7 +5876,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6123,7 +6123,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6933,7 +6933,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -4426,6 +4426,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3826,7 +3826,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4419,7 +4419,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,7 +4557,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4850,7 +4850,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5121,7 +5121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,7 +5259,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5567,7 +5567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,7 +5695,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6199,7 +6199,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6662,7 +6662,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -4414,6 +4414,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3815,7 +3815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4409,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4548,7 +4548,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4842,7 +4842,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5114,7 +5114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5252,7 +5252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5561,7 +5561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5689,7 +5689,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6194,7 +6194,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6657,7 +6657,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3268,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3826,11 +3827,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4419,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,11 +4559,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4850,11 +4853,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5121,7 +5125,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,11 +5263,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5567,7 +5572,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,11 +5700,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6199,7 +6205,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6662,11 +6668,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3827,7 +3827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4421,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4560,7 +4560,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4854,7 +4854,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5126,7 +5126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5264,7 +5264,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5573,7 +5573,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5701,7 +5701,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6206,7 +6206,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6669,7 +6669,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,11 +3256,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3814,11 +3815,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4407,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,11 +4547,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4838,11 +4841,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5109,7 +5113,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,11 +5251,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5555,7 +5560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,11 +5688,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6187,7 +6193,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6650,11 +6656,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3814,7 +3814,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4407,7 +4407,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,7 +4545,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4838,7 +4838,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5109,7 +5109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,7 +5247,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5555,7 +5555,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,7 +5683,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6187,7 +6187,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6650,7 +6650,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3116,7 +3116,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3266,11 +3266,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3844,11 +3845,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4457,7 +4459,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4595,11 +4597,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4888,11 +4891,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5159,7 +5163,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5297,11 +5301,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5605,7 +5610,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5733,11 +5738,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6237,7 +6243,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6700,11 +6706,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3116,7 +3116,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3266,7 +3266,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3845,7 +3845,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4459,7 +4459,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4598,7 +4598,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4892,7 +4892,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5164,7 +5164,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5302,7 +5302,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5611,7 +5611,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5739,7 +5739,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6244,7 +6244,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6707,7 +6707,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -4464,6 +4464,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3128,7 +3128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3278,7 +3278,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3857,7 +3857,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4471,7 +4471,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4610,7 +4610,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4904,7 +4904,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5176,7 +5176,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5314,7 +5314,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5623,7 +5623,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5751,7 +5751,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6256,7 +6256,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6719,7 +6719,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -4476,6 +4476,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3116,7 +3116,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3266,7 +3266,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3844,7 +3844,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4457,7 +4457,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4595,7 +4595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4888,7 +4888,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5159,7 +5159,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5297,7 +5297,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5605,7 +5605,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5733,7 +5733,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6237,7 +6237,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6700,7 +6700,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3128,7 +3128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3278,11 +3278,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3856,11 +3857,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4469,7 +4471,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4607,11 +4609,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4900,11 +4903,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5171,7 +5175,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5309,11 +5313,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5617,7 +5622,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5745,11 +5750,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6249,7 +6255,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6712,11 +6718,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3128,7 +3128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3278,7 +3278,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3856,7 +3856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4469,7 +4469,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4607,7 +4607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4900,7 +4900,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5171,7 +5171,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5309,7 +5309,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5617,7 +5617,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5745,7 +5745,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6249,7 +6249,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6712,7 +6712,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3591,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3741,11 +3741,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4379,11 +4380,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4972,7 +4974,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5110,11 +5112,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5403,11 +5406,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5674,7 +5678,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5812,11 +5816,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6160,7 +6165,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6288,11 +6293,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6811,7 +6817,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7058,7 +7064,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7868,11 +7874,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -4979,6 +4979,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -6834,6 +6834,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -4991,6 +4991,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3603,7 +3603,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3753,7 +3753,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4391,7 +4391,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4984,7 +4984,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5122,7 +5122,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5415,7 +5415,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5686,7 +5686,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5824,7 +5824,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6172,7 +6172,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6300,7 +6300,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6823,7 +6823,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7070,7 +7070,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7880,7 +7880,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3591,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3741,7 +3741,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4380,7 +4380,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4974,7 +4974,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5113,7 +5113,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5407,7 +5407,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5679,7 +5679,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5817,7 +5817,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6166,7 +6166,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6294,7 +6294,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6818,7 +6818,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7066,7 +7066,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7876,7 +7876,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3603,7 +3603,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3753,7 +3753,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4392,7 +4392,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4986,7 +4986,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5125,7 +5125,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5419,7 +5419,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5691,7 +5691,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5829,7 +5829,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6178,7 +6178,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6306,7 +6306,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6830,7 +6830,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7078,7 +7078,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7888,7 +7888,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3603,7 +3603,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3753,11 +3753,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4391,11 +4392,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4984,7 +4986,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5122,11 +5124,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5415,11 +5418,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5686,7 +5690,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5824,11 +5828,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6172,7 +6177,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6300,11 +6305,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6823,7 +6829,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7070,7 +7076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7880,11 +7886,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -6822,6 +6822,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3591,7 +3591,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3741,7 +3741,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4379,7 +4379,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4972,7 +4972,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5110,7 +5110,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5403,7 +5403,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5674,7 +5674,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5812,7 +5812,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6160,7 +6160,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6288,7 +6288,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6811,7 +6811,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7058,7 +7058,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7868,7 +7868,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -4262,6 +4262,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -4250,6 +4250,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3024,7 +3024,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3662,7 +3662,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4255,7 +4255,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4394,7 +4394,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4532,7 +4532,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4880,7 +4880,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5008,7 +5008,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5512,7 +5512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5975,7 +5975,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3012,7 +3012,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3651,7 +3651,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4245,7 +4245,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4385,7 +4385,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4523,7 +4523,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4872,7 +4872,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5000,7 +5000,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5505,7 +5505,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5968,7 +5968,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3024,11 +3024,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3662,11 +3663,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4255,7 +4257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4394,7 +4396,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4532,11 +4534,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -4880,7 +4883,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5008,11 +5011,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5512,7 +5516,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5975,11 +5979,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3024,7 +3024,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3663,7 +3663,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4257,7 +4257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4397,7 +4397,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4535,7 +4535,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4884,7 +4884,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5012,7 +5012,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5517,7 +5517,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5980,7 +5980,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3012,7 +3012,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3650,7 +3650,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4243,7 +4243,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4382,7 +4382,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4520,7 +4520,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4868,7 +4868,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4996,7 +4996,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5500,7 +5500,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5963,7 +5963,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3012,11 +3012,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3650,11 +3651,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4243,7 +4245,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4382,7 +4384,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4520,11 +4522,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -4868,7 +4871,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4996,11 +4999,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5500,7 +5504,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5963,11 +5967,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
+++ b/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
@@ -3590,6 +3590,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4168,6 +4169,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4781,6 +4783,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console
@@ -4929,6 +4932,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5232,6 +5236,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5515,6 +5520,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5954,6 +5960,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6410,6 +6417,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -8012,6 +8020,7 @@ spec:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -4749,6 +4749,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3391,7 +3391,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3551,7 +3551,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4129,7 +4129,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4742,7 +4742,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4890,7 +4890,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5193,7 +5193,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5476,7 +5476,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5767,7 +5767,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5915,7 +5915,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6233,7 +6233,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6371,7 +6371,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6885,7 +6885,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7668,7 +7668,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -4737,6 +4737,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3379,7 +3379,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3539,11 +3539,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4117,11 +4118,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4730,7 +4732,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4878,11 +4880,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5181,11 +5184,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5464,11 +5468,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5755,7 +5760,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5903,11 +5908,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6221,7 +6227,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6359,11 +6365,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6873,7 +6880,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7656,11 +7663,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3391,7 +3391,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3551,7 +3551,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4130,7 +4130,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4744,7 +4744,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4893,7 +4893,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5197,7 +5197,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5481,7 +5481,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5773,7 +5773,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5921,7 +5921,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6240,7 +6240,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6378,7 +6378,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6893,7 +6893,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7676,7 +7676,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3379,7 +3379,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3539,7 +3539,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4118,7 +4118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4732,7 +4732,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4881,7 +4881,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5185,7 +5185,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5469,7 +5469,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5761,7 +5761,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5909,7 +5909,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6228,7 +6228,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6366,7 +6366,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6881,7 +6881,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7664,7 +7664,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3391,7 +3391,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3551,11 +3551,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4129,11 +4130,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4742,7 +4744,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4890,11 +4892,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5193,11 +5196,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5476,11 +5480,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5767,7 +5772,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5915,11 +5920,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6233,7 +6239,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6371,11 +6377,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6885,7 +6892,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7668,11 +7675,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3379,7 +3379,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3539,7 +3539,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4117,7 +4117,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4730,7 +4730,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4878,7 +4878,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5181,7 +5181,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5464,7 +5464,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5755,7 +5755,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5903,7 +5903,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6221,7 +6221,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6359,7 +6359,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6873,7 +6873,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7656,7 +7656,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -4482,6 +4482,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3855,7 +3855,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4477,7 +4477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4616,7 +4616,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4910,7 +4910,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5182,7 +5182,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5320,7 +5320,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5629,7 +5629,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5757,7 +5757,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6262,7 +6262,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6725,7 +6725,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3854,7 +3854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4475,7 +4475,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4613,7 +4613,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4906,7 +4906,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5177,7 +5177,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5315,7 +5315,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5623,7 +5623,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5751,7 +5751,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6255,7 +6255,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6718,7 +6718,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3842,7 +3842,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4463,7 +4463,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4601,7 +4601,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4894,7 +4894,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5165,7 +5165,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5303,7 +5303,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5611,7 +5611,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5739,7 +5739,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6243,7 +6243,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6706,7 +6706,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,11 +3256,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3842,11 +3843,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4463,7 +4465,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4601,11 +4603,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4894,11 +4897,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5165,7 +5169,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5303,11 +5307,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5611,7 +5616,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5739,11 +5744,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6243,7 +6249,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6706,11 +6712,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -4470,6 +4470,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3843,7 +3843,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4465,7 +4465,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4604,7 +4604,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4898,7 +4898,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5170,7 +5170,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5308,7 +5308,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5617,7 +5617,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5745,7 +5745,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6250,7 +6250,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6713,7 +6713,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3268,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3854,11 +3855,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4475,7 +4477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4613,11 +4615,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4906,11 +4909,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5177,7 +5181,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5315,11 +5319,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5623,7 +5628,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5751,11 +5756,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6255,7 +6261,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6718,11 +6724,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -2783,11 +2783,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3341,11 +3342,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3934,7 +3936,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4073,7 +4075,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4212,7 +4214,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4340,11 +4342,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4756,7 +4759,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5219,11 +5222,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -2795,11 +2795,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3353,11 +3354,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3946,7 +3948,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4085,7 +4087,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4224,7 +4226,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4352,11 +4354,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4768,7 +4771,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5231,11 +5234,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -3953,6 +3953,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -2795,7 +2795,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3353,7 +3353,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3946,7 +3946,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4085,7 +4085,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4224,7 +4224,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4352,7 +4352,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4768,7 +4768,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5231,7 +5231,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -2783,7 +2783,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3342,7 +3342,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3936,7 +3936,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4076,7 +4076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4215,7 +4215,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4343,7 +4343,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4760,7 +4760,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5223,7 +5223,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -2795,7 +2795,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3354,7 +3354,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3948,7 +3948,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4088,7 +4088,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4227,7 +4227,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4355,7 +4355,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4772,7 +4772,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5235,7 +5235,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -3941,6 +3941,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -2783,7 +2783,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3341,7 +3341,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3934,7 +3934,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4073,7 +4073,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4212,7 +4212,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4340,7 +4340,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4756,7 +4756,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5219,7 +5219,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3320,7 +3320,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3959,7 +3959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4553,7 +4553,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4693,7 +4693,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4831,7 +4831,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5180,7 +5180,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5308,7 +5308,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5744,7 +5744,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6554,7 +6554,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3308,11 +3308,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3946,11 +3947,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4539,7 +4541,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4678,7 +4680,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4816,11 +4818,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5164,7 +5167,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5292,11 +5295,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5727,7 +5731,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6537,11 +6541,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3320,11 +3320,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3958,11 +3959,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4551,7 +4553,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4690,7 +4692,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4828,11 +4830,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5176,7 +5179,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5304,11 +5307,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5739,7 +5743,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6549,11 +6553,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3308,7 +3308,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3947,7 +3947,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4541,7 +4541,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4681,7 +4681,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4819,7 +4819,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5168,7 +5168,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5296,7 +5296,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5732,7 +5732,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6542,7 +6542,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3308,7 +3308,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3946,7 +3946,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4539,7 +4539,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4678,7 +4678,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4816,7 +4816,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5164,7 +5164,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5292,7 +5292,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5727,7 +5727,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6537,7 +6537,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -4558,6 +4558,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3320,7 +3320,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3958,7 +3958,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4551,7 +4551,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4690,7 +4690,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4828,7 +4828,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5176,7 +5176,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5304,7 +5304,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5739,7 +5739,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6549,7 +6549,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -4546,6 +4546,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -3717,6 +3717,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2607,7 +2607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3150,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3722,7 +3722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3853,7 +3853,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4270,7 +4270,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4708,7 +4708,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2595,11 +2595,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3138,11 +3139,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3710,7 +3712,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3841,11 +3843,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4258,7 +4261,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4696,11 +4699,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2607,11 +2607,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3150,11 +3151,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3722,7 +3724,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3853,11 +3855,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4270,7 +4273,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4708,11 +4711,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -3729,6 +3729,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2607,7 +2607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3151,7 +3151,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3724,7 +3724,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3856,7 +3856,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4274,7 +4274,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4712,7 +4712,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2595,7 +2595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3138,7 +3138,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3710,7 +3710,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3841,7 +3841,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4258,7 +4258,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4696,7 +4696,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2595,7 +2595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3139,7 +3139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3712,7 +3712,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3844,7 +3844,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4262,7 +4262,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4700,7 +4700,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2595,11 +2595,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3138,11 +3139,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3710,7 +3712,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3843,11 +3845,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4260,7 +4263,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4698,11 +4701,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2595,7 +2595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3139,7 +3139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3712,7 +3712,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3846,7 +3846,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4264,7 +4264,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4702,7 +4702,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2595,7 +2595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3138,7 +3138,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3710,7 +3710,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3843,7 +3843,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4260,7 +4260,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4698,7 +4698,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -3717,6 +3717,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -3729,6 +3729,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2607,7 +2607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3151,7 +3151,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3724,7 +3724,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3858,7 +3858,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4276,7 +4276,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4714,7 +4714,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2607,7 +2607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3150,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3722,7 +3722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3855,7 +3855,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4272,7 +4272,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4710,7 +4710,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2607,11 +2607,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3150,11 +3151,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3722,7 +3724,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3855,11 +3857,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4272,7 +4275,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4710,11 +4713,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2595,11 +2595,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3138,11 +3139,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3710,7 +3712,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3843,11 +3845,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4260,7 +4263,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4698,11 +4701,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2595,7 +2595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3139,7 +3139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3712,7 +3712,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3846,7 +3846,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4264,7 +4264,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4702,7 +4702,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2595,7 +2595,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3138,7 +3138,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3710,7 +3710,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3843,7 +3843,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4260,7 +4260,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4698,7 +4698,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -3717,6 +3717,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -3729,6 +3729,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2607,7 +2607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3151,7 +3151,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3724,7 +3724,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3858,7 +3858,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4276,7 +4276,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4714,7 +4714,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2607,7 +2607,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3150,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3722,7 +3722,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3855,7 +3855,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4272,7 +4272,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4710,7 +4710,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2607,11 +2607,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3150,11 +3151,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3722,7 +3724,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3855,11 +3857,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4272,7 +4275,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4710,11 +4713,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2706,7 +2706,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2848,11 +2848,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3425,7 +3426,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3560,11 +3561,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4058,7 +4060,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4509,11 +4511,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2718,7 +2718,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2860,7 +2860,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3438,7 +3438,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3574,7 +3574,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4073,7 +4073,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4524,7 +4524,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -3443,6 +3443,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2706,7 +2706,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2848,7 +2848,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3426,7 +3426,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3562,7 +3562,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4061,7 +4061,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4512,7 +4512,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2718,7 +2718,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2860,7 +2860,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3437,7 +3437,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3572,7 +3572,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4070,7 +4070,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4521,7 +4521,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -3431,6 +3431,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2718,7 +2718,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2860,11 +2860,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3437,7 +3438,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3572,11 +3573,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4070,7 +4072,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4521,11 +4523,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2706,7 +2706,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2848,7 +2848,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3425,7 +3425,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3560,7 +3560,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4058,7 +4058,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4509,7 +4509,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -2994,11 +2994,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3537,11 +3538,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4109,7 +4111,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4237,11 +4239,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4525,11 +4528,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.5
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filestream
@@ -4813,11 +4817,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5088,11 +5093,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5391,11 +5397,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5808,7 +5815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6374,11 +6381,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -2994,7 +2994,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3538,7 +3538,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4111,7 +4111,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4240,7 +4240,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
@@ -4529,7 +4529,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
@@ -4818,7 +4818,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
@@ -5094,7 +5094,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5398,7 +5398,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5816,7 +5816,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6382,7 +6382,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2866,7 +2866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -3006,7 +3006,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3550,7 +3550,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4123,7 +4123,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4252,7 +4252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
@@ -4541,7 +4541,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
@@ -4830,7 +4830,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
@@ -5106,7 +5106,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5410,7 +5410,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5828,7 +5828,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6394,7 +6394,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -2994,7 +2994,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3537,7 +3537,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4109,7 +4109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4237,7 +4237,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
@@ -4525,7 +4525,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filestream-0.12.5
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
@@ -4813,7 +4813,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
@@ -5088,7 +5088,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5391,7 +5391,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5808,7 +5808,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6374,7 +6374,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2866,7 +2866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -3006,11 +3006,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3549,11 +3550,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4121,7 +4123,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4249,11 +4251,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4537,11 +4540,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.5
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filestream
@@ -4825,11 +4829,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5100,11 +5105,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5403,11 +5409,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5820,7 +5827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6386,11 +6393,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -4116,6 +4116,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2866,7 +2866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -3006,7 +3006,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3549,7 +3549,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4121,7 +4121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4249,7 +4249,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
@@ -4537,7 +4537,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filestream-0.12.5
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
@@ -4825,7 +4825,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
@@ -5100,7 +5100,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5403,7 +5403,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5820,7 +5820,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6386,7 +6386,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -4128,6 +4128,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -2994,11 +2994,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3537,11 +3538,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4109,7 +4111,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4237,11 +4239,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4525,11 +4528,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.5
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filestream
@@ -4813,11 +4817,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5088,11 +5093,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5391,11 +5397,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5808,7 +5815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6374,11 +6381,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -4116,6 +4116,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -2994,7 +2994,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3537,7 +3537,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4109,7 +4109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4237,7 +4237,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
@@ -4525,7 +4525,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filestream-0.12.5
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
@@ -4813,7 +4813,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
@@ -5088,7 +5088,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5391,7 +5391,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5808,7 +5808,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6374,7 +6374,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -2994,7 +2994,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3538,7 +3538,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4111,7 +4111,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4240,7 +4240,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
@@ -4529,7 +4529,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
@@ -4818,7 +4818,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
@@ -5094,7 +5094,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5398,7 +5398,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5816,7 +5816,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6382,7 +6382,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2866,7 +2866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -3006,11 +3006,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3549,11 +3550,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4121,7 +4123,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4249,11 +4251,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4537,11 +4540,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.5
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filestream
@@ -4825,11 +4829,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.5
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: flat-run-fields-updater
@@ -5100,11 +5105,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5403,11 +5409,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5820,7 +5827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6386,11 +6393,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -4128,6 +4128,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2866,7 +2866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -3006,7 +3006,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3550,7 +3550,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4123,7 +4123,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4252,7 +4252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
@@ -4541,7 +4541,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
@@ -4830,7 +4830,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
@@ -5106,7 +5106,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5410,7 +5410,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5828,7 +5828,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6394,7 +6394,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2866,7 +2866,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -3006,7 +3006,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3549,7 +3549,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4121,7 +4121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4249,7 +4249,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
@@ -4537,7 +4537,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filestream-0.12.5
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
@@ -4825,7 +4825,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: flat-run-fields-updater-0.12.5
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
@@ -5100,7 +5100,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5403,7 +5403,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5820,7 +5820,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6386,7 +6386,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2579,7 +2579,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3152,7 +3152,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3284,7 +3284,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3704,7 +3704,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4114,7 +4114,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4259,7 +4259,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2567,7 +2567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3140,7 +3140,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3272,7 +3272,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3692,7 +3692,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4102,7 +4102,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4247,7 +4247,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -3145,6 +3145,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -3157,6 +3157,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2567,7 +2567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3139,7 +3139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3270,7 +3270,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3689,7 +3689,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4099,7 +4099,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4243,7 +4243,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2579,7 +2579,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3151,7 +3151,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3282,7 +3282,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3701,7 +3701,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4111,7 +4111,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4255,7 +4255,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2579,11 +2579,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3151,7 +3152,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3282,11 +3283,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3701,7 +3703,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4111,11 +4113,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4255,11 +4258,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2567,11 +2567,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3139,7 +3140,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3270,11 +3271,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3689,7 +3691,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4099,11 +4101,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4243,11 +4246,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2577,7 +2577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3149,7 +3149,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3280,7 +3280,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3699,7 +3699,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4109,7 +4109,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4253,7 +4253,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2577,11 +2577,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3149,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3280,11 +3281,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3699,7 +3701,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4109,11 +4111,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4253,11 +4256,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2565,7 +2565,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3137,7 +3137,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3687,7 +3687,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4097,7 +4097,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4241,7 +4241,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -3143,6 +3143,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2565,11 +2565,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3137,7 +3138,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3269,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3687,7 +3689,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4097,11 +4099,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4241,11 +4244,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -3155,6 +3155,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2565,7 +2565,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3138,7 +3138,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3270,7 +3270,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3690,7 +3690,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4100,7 +4100,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4245,7 +4245,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2577,7 +2577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3150,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3282,7 +3282,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3702,7 +3702,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4112,7 +4112,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4257,7 +4257,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2577,7 +2577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3149,7 +3149,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3280,7 +3280,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3699,7 +3699,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4109,7 +4109,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4253,7 +4253,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2577,11 +2577,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3149,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3280,11 +3281,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3699,7 +3701,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4109,11 +4111,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4253,11 +4256,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2589,7 +2589,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3162,7 +3162,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3294,7 +3294,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3714,7 +3714,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4124,7 +4124,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4269,7 +4269,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2589,11 +2589,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3161,7 +3162,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3292,11 +3293,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3711,7 +3713,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4121,11 +4123,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4265,11 +4268,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2589,7 +2589,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3161,7 +3161,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3292,7 +3292,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3711,7 +3711,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4121,7 +4121,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4265,7 +4265,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -3155,6 +3155,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2577,7 +2577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3150,7 +3150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3282,7 +3282,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3702,7 +3702,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4112,7 +4112,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4257,7 +4257,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -3167,6 +3167,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -3136,6 +3136,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2546,7 +2546,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3119,7 +3119,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3251,7 +3251,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3669,7 +3669,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4079,7 +4079,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4208,7 +4208,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -3124,6 +3124,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2546,11 +2546,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3118,7 +3119,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3249,11 +3250,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3666,7 +3668,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4076,11 +4078,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4204,11 +4207,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2546,7 +2546,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3249,7 +3249,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3666,7 +3666,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4076,7 +4076,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4204,7 +4204,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2558,7 +2558,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3131,7 +3131,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3263,7 +3263,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3681,7 +3681,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4091,7 +4091,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4220,7 +4220,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2558,7 +2558,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3130,7 +3130,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3261,7 +3261,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3678,7 +3678,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4088,7 +4088,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4216,7 +4216,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2558,11 +2558,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3130,7 +3131,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3261,11 +3262,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3678,7 +3680,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4088,11 +4090,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4216,11 +4219,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2560,7 +2560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3132,7 +3132,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3263,7 +3263,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3680,7 +3680,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4090,7 +4090,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4218,7 +4218,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2548,7 +2548,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3121,7 +3121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3253,7 +3253,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3671,7 +3671,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4081,7 +4081,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4210,7 +4210,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2560,11 +2560,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3132,7 +3133,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3263,11 +3264,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3680,7 +3682,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4090,11 +4092,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4218,11 +4221,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -3138,6 +3138,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2548,7 +2548,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3120,7 +3120,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3251,7 +3251,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3668,7 +3668,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4078,7 +4078,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: lumen-agent-0.12.5
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4206,7 +4206,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2560,7 +2560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3133,7 +3133,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3265,7 +3265,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3683,7 +3683,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4093,7 +4093,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4222,7 +4222,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2548,11 +2548,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3120,7 +3121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3251,11 +3252,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3668,7 +3670,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4078,11 +4080,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.5
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: collector
@@ -4206,11 +4209,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -3126,6 +3126,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2679,11 +2679,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3253,11 +3254,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3862,7 +3864,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4012,11 +4014,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4439,7 +4442,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4916,11 +4919,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2691,11 +2691,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3265,11 +3266,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3874,7 +3876,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4024,11 +4026,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4451,7 +4454,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4928,11 +4931,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -3869,6 +3869,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2691,7 +2691,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3266,7 +3266,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3876,7 +3876,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4027,7 +4027,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4455,7 +4455,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4932,7 +4932,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2679,7 +2679,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3254,7 +3254,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3864,7 +3864,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4015,7 +4015,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4443,7 +4443,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4920,7 +4920,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2691,7 +2691,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3265,7 +3265,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3874,7 +3874,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4024,7 +4024,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4451,7 +4451,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4928,7 +4928,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2679,7 +2679,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3253,7 +3253,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3862,7 +3862,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4012,7 +4012,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4439,7 +4439,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4916,7 +4916,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -3881,6 +3881,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2596,7 +2596,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3140,7 +3140,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3713,7 +3713,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3845,7 +3845,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4263,7 +4263,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4701,7 +4701,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2608,11 +2608,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3151,11 +3152,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3723,7 +3725,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3854,11 +3856,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4271,7 +4274,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4709,11 +4712,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2608,7 +2608,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3152,7 +3152,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3725,7 +3725,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3857,7 +3857,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4275,7 +4275,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4713,7 +4713,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2596,7 +2596,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3139,7 +3139,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3711,7 +3711,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3842,7 +3842,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4259,7 +4259,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4697,7 +4697,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2596,11 +2596,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3139,11 +3140,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3711,7 +3713,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3842,11 +3844,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4259,7 +4262,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4697,11 +4700,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -3718,6 +3718,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -3730,6 +3730,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2608,7 +2608,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3151,7 +3151,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3723,7 +3723,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3854,7 +3854,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4271,7 +4271,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4709,7 +4709,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -3785,6 +3785,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2623,7 +2623,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3186,7 +3186,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3778,7 +3778,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3909,7 +3909,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4326,7 +4326,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4764,7 +4764,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2611,7 +2611,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3174,7 +3174,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3766,7 +3766,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3897,7 +3897,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4314,7 +4314,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4752,7 +4752,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2623,7 +2623,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3187,7 +3187,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3780,7 +3780,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3912,7 +3912,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4330,7 +4330,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4768,7 +4768,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2623,11 +2623,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3186,11 +3187,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3778,7 +3780,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3909,11 +3911,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4326,7 +4329,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4764,11 +4767,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -3773,6 +3773,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2611,11 +2611,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3174,11 +3175,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3766,7 +3768,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3897,11 +3899,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4314,7 +4317,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4752,11 +4755,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2611,7 +2611,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3175,7 +3175,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3768,7 +3768,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3900,7 +3900,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4318,7 +4318,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4756,7 +4756,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -3785,6 +3785,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2623,7 +2623,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3186,7 +3186,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3778,7 +3778,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3909,7 +3909,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4326,7 +4326,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4764,7 +4764,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2611,7 +2611,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3174,7 +3174,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3766,7 +3766,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3897,7 +3897,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4314,7 +4314,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4752,7 +4752,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2623,7 +2623,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3187,7 +3187,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3780,7 +3780,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3912,7 +3912,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4330,7 +4330,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4768,7 +4768,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2623,11 +2623,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3186,11 +3187,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3778,7 +3780,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3909,11 +3911,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4326,7 +4329,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4764,11 +4767,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -3773,6 +3773,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2611,11 +2611,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3174,11 +3175,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3766,7 +3768,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3897,11 +3899,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4314,7 +4317,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4752,11 +4755,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2611,7 +2611,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3175,7 +3175,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3768,7 +3768,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3900,7 +3900,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4318,7 +4318,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4756,7 +4756,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -3434,6 +3434,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2719,7 +2719,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2862,11 +2862,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3440,7 +3441,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3576,11 +3577,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4075,7 +4077,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4528,11 +4530,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -3446,6 +3446,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2719,7 +2719,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2862,7 +2862,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3440,7 +3440,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3576,7 +3576,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4075,7 +4075,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4528,7 +4528,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2707,7 +2707,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2850,7 +2850,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3429,7 +3429,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3566,7 +3566,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4066,7 +4066,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4519,7 +4519,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2707,7 +2707,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2850,11 +2850,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3428,7 +3429,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3564,11 +3565,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -4063,7 +4065,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4516,11 +4518,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2719,7 +2719,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2862,7 +2862,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3441,7 +3441,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3578,7 +3578,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4078,7 +4078,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4531,7 +4531,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2484,7 +2484,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3067,7 +3067,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3199,7 +3199,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3622,7 +3622,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4028,7 +4028,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2496,7 +2496,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3078,7 +3078,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3209,7 +3209,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3631,7 +3631,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4037,7 +4037,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2484,7 +2484,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3066,7 +3066,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3197,7 +3197,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3619,7 +3619,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4025,7 +4025,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -3084,6 +3084,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2484,11 +2484,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3066,7 +3067,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3197,11 +3198,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3619,7 +3621,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4025,11 +4027,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2496,7 +2496,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3079,7 +3079,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3211,7 +3211,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3634,7 +3634,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4040,7 +4040,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2496,11 +2496,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3078,7 +3079,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3209,11 +3210,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3631,7 +3633,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4037,11 +4039,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -3072,6 +3072,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3065,7 +3065,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3196,7 +3196,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3615,7 +3615,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4021,7 +4021,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3054,7 +3054,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3186,7 +3186,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3606,7 +3606,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4012,7 +4012,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2489,7 +2489,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3066,7 +3066,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3198,7 +3198,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3618,7 +3618,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4024,7 +4024,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2489,11 +2489,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3065,7 +3066,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3196,11 +3197,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3615,7 +3617,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4021,11 +4023,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -3059,6 +3059,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -3071,6 +3071,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2477,7 +2477,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3053,7 +3053,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3184,7 +3184,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3603,7 +3603,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4009,7 +4009,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2477,11 +2477,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3053,7 +3054,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3184,11 +3185,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3603,7 +3605,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4009,11 +4011,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2980,7 +2980,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3135,7 +3135,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3687,7 +3687,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4279,7 +4279,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4425,7 +4425,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4700,7 +4700,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5015,7 +5015,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5524,7 +5524,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5997,7 +5997,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -4274,6 +4274,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2980,7 +2980,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3135,7 +3135,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3688,7 +3688,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4281,7 +4281,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4428,7 +4428,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4704,7 +4704,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5020,7 +5020,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5530,7 +5530,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6003,7 +6003,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2980,7 +2980,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3135,11 +3135,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3687,11 +3688,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4279,7 +4281,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4425,11 +4427,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -4700,11 +4703,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5015,11 +5019,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5524,7 +5529,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5997,11 +6002,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -4286,6 +4286,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2968,7 +2968,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3123,11 +3123,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3675,11 +3676,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4267,7 +4269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4413,11 +4415,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -4688,11 +4691,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5003,11 +5007,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -5512,7 +5517,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5985,11 +5990,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2968,7 +2968,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3123,7 +3123,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3675,7 +3675,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4267,7 +4267,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4413,7 +4413,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4688,7 +4688,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5003,7 +5003,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5512,7 +5512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5985,7 +5985,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2968,7 +2968,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3123,7 +3123,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3676,7 +3676,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4269,7 +4269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4416,7 +4416,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4692,7 +4692,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5008,7 +5008,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5518,7 +5518,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5991,7 +5991,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -4426,6 +4426,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3814,7 +3814,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4407,7 +4407,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,7 +4545,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4838,7 +4838,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5109,7 +5109,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,7 +5247,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5555,7 +5555,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,7 +5683,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6187,7 +6187,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6652,7 +6652,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,11 +3256,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3814,11 +3815,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4407,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4545,11 +4547,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4838,11 +4841,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5109,7 +5113,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5247,11 +5251,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5555,7 +5560,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5683,11 +5688,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6187,7 +6193,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6652,11 +6658,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -4414,6 +4414,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3826,7 +3826,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4419,7 +4419,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,7 +4557,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4850,7 +4850,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5121,7 +5121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,7 +5259,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5567,7 +5567,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,7 +5695,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6199,7 +6199,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6664,7 +6664,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,7 +3268,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3827,7 +3827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4421,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4560,7 +4560,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4854,7 +4854,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5126,7 +5126,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5264,7 +5264,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5573,7 +5573,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5701,7 +5701,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6206,7 +6206,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6671,7 +6671,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3106,7 +3106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3256,7 +3256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3815,7 +3815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4409,7 +4409,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4548,7 +4548,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4842,7 +4842,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5114,7 +5114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5252,7 +5252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5561,7 +5561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5689,7 +5689,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6194,7 +6194,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6659,7 +6659,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3118,7 +3118,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3268,11 +3268,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -3826,11 +3827,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4419,7 +4421,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4557,11 +4559,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -4850,11 +4853,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5121,7 +5125,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5259,11 +5263,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5567,7 +5572,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,11 +5700,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6199,7 +6205,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6664,11 +6670,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2529,7 +2529,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3102,7 +3102,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3234,7 +3234,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3652,7 +3652,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3900,7 +3900,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4338,7 +4338,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -3668,6 +3668,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2529,7 +2529,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3101,7 +3101,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3232,7 +3232,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3649,7 +3649,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3896,7 +3896,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4334,7 +4334,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -3119,6 +3119,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -3107,6 +3107,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -3656,6 +3656,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2541,7 +2541,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3114,7 +3114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3246,7 +3246,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3664,7 +3664,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3912,7 +3912,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4350,7 +4350,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2541,11 +2541,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3113,7 +3114,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,11 +3245,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3661,7 +3663,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3908,7 +3910,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4346,11 +4348,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2541,7 +2541,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3113,7 +3113,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3244,7 +3244,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3661,7 +3661,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3908,7 +3908,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4346,7 +4346,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2529,11 +2529,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -3101,7 +3102,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3232,11 +3233,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -3649,7 +3651,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3896,7 +3898,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4334,11 +4336,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3452,7 +3452,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3602,7 +3602,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4216,7 +4216,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4815,7 +4815,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4953,7 +4953,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5249,7 +5249,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5523,7 +5523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5661,7 +5661,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5997,7 +5997,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6125,7 +6125,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6632,7 +6632,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7445,7 +7445,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -4822,6 +4822,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3464,7 +3464,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3614,11 +3614,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4228,11 +4229,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4827,7 +4829,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4965,11 +4967,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5261,11 +5264,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5535,7 +5539,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5673,11 +5677,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6009,7 +6014,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6137,11 +6142,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6644,7 +6650,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7457,11 +7463,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3464,7 +3464,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3614,7 +3614,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4228,7 +4228,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4827,7 +4827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4965,7 +4965,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5261,7 +5261,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5535,7 +5535,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5673,7 +5673,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6009,7 +6009,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6137,7 +6137,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6644,7 +6644,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7457,7 +7457,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3464,7 +3464,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3614,7 +3614,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4229,7 +4229,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4829,7 +4829,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4968,7 +4968,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5265,7 +5265,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5540,7 +5540,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5678,7 +5678,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6015,7 +6015,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6143,7 +6143,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6651,7 +6651,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7464,7 +7464,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3452,7 +3452,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3602,7 +3602,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4217,7 +4217,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4817,7 +4817,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4956,7 +4956,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5253,7 +5253,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5528,7 +5528,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5666,7 +5666,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6003,7 +6003,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6131,7 +6131,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6639,7 +6639,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7452,7 +7452,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -4834,6 +4834,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3452,7 +3452,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3602,11 +3602,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4216,11 +4217,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4815,7 +4817,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4953,11 +4955,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5249,11 +5252,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5523,7 +5527,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5661,11 +5665,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5997,7 +6002,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6125,11 +6130,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6632,7 +6638,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7445,11 +7451,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3868,7 +3868,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4018,7 +4018,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4577,7 +4577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5171,7 +5171,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5310,7 +5310,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5604,7 +5604,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5876,7 +5876,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6014,7 +6014,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6323,7 +6323,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6451,7 +6451,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6956,7 +6956,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7108,7 +7108,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7269,7 +7269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7517,7 +7517,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8627,7 +8627,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3856,7 +3856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4006,7 +4006,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4564,7 +4564,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5157,7 +5157,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5295,7 +5295,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5588,7 +5588,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5859,7 +5859,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5997,7 +5997,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6305,7 +6305,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6433,7 +6433,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6937,7 +6937,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-evaluate-model-worker-0.12.5
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7088,7 +7088,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-worker-0.12.5
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7248,7 +7248,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7495,7 +7495,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8605,7 +8605,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3868,7 +3868,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4018,11 +4018,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4576,11 +4577,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -5169,7 +5171,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5307,11 +5309,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5600,11 +5603,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5871,7 +5875,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6009,11 +6013,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6317,7 +6322,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6445,11 +6450,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6949,7 +6955,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.12.5
+        helm.sh/chart: weave-evaluate-model-worker-0.12.4
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7100,7 +7106,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.12.5
+        helm.sh/chart: weave-trace-worker-0.12.4
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7260,7 +7266,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7507,7 +7513,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8617,11 +8623,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -6948,6 +6948,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-evaluate-model-worker
@@ -7099,6 +7100,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace-worker
@@ -7259,6 +7261,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -5176,6 +5176,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -6960,6 +6960,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-evaluate-model-worker
@@ -7111,6 +7112,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace-worker
@@ -7271,6 +7273,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3856,7 +3856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4006,7 +4006,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4565,7 +4565,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5159,7 +5159,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5298,7 +5298,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5592,7 +5592,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5864,7 +5864,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6002,7 +6002,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6311,7 +6311,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6439,7 +6439,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6944,7 +6944,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7096,7 +7096,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7257,7 +7257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7505,7 +7505,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8615,7 +8615,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3868,7 +3868,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4018,7 +4018,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4576,7 +4576,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5169,7 +5169,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5307,7 +5307,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5600,7 +5600,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5871,7 +5871,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6009,7 +6009,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6317,7 +6317,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6445,7 +6445,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6949,7 +6949,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-evaluate-model-worker-0.12.5
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7100,7 +7100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-worker-0.12.5
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7260,7 +7260,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7507,7 +7507,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8617,7 +8617,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -5164,6 +5164,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3856,7 +3856,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4006,11 +4006,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4564,11 +4565,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -5157,7 +5159,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5295,11 +5297,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5588,11 +5591,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5859,7 +5863,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5997,11 +6001,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6305,7 +6310,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6433,11 +6438,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6937,7 +6943,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.12.5
+        helm.sh/chart: weave-evaluate-model-worker-0.12.4
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7088,7 +7094,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.12.5
+        helm.sh/chart: weave-trace-worker-0.12.4
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7248,7 +7254,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7495,7 +7501,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8605,11 +8611,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3561,7 +3561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3711,11 +3711,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4269,11 +4270,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4862,7 +4864,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5000,11 +5002,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5293,11 +5296,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5564,7 +5568,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5702,11 +5706,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -6010,7 +6015,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6138,11 +6143,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6642,7 +6648,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6889,7 +6895,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7699,11 +7705,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -6653,6 +6653,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -4857,6 +4857,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -6641,6 +6641,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: weave-trace

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3549,7 +3549,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3699,7 +3699,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4258,7 +4258,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4852,7 +4852,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4991,7 +4991,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5285,7 +5285,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5557,7 +5557,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5695,7 +5695,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6004,7 +6004,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6132,7 +6132,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6637,7 +6637,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6885,7 +6885,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7695,7 +7695,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3549,7 +3549,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3699,7 +3699,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4257,7 +4257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4850,7 +4850,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4988,7 +4988,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5281,7 +5281,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5552,7 +5552,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5690,7 +5690,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5998,7 +5998,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6126,7 +6126,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6630,7 +6630,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6877,7 +6877,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7687,7 +7687,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -4869,6 +4869,7 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: console

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3561,7 +3561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3711,7 +3711,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4270,7 +4270,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4864,7 +4864,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5003,7 +5003,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5297,7 +5297,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5569,7 +5569,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5707,7 +5707,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6016,7 +6016,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6144,7 +6144,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6649,7 +6649,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6897,7 +6897,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7707,7 +7707,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.4
+            helm.sh/chart: '###CHART_VERSION###'
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3549,7 +3549,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.5
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3699,11 +3699,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.5
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: api
@@ -4257,11 +4258,12 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.5
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: app
@@ -4850,7 +4852,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.5
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4988,11 +4990,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.5
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: executor
@@ -5281,11 +5284,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.5
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: filemeta
@@ -5552,7 +5556,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.5
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5690,11 +5694,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.5
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: glue
@@ -5998,7 +6003,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.5
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6126,11 +6131,12 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.5
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
     spec:
       containers:
       - name: parquet
@@ -6630,7 +6636,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.5
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6877,7 +6883,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.5
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7687,11 +7693,12 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.5
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"
             app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
         spec:
           containers:
           - name: backfill-job

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3561,7 +3561,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: anaconda2-0.12.5
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3711,7 +3711,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: api-0.12.5
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4269,7 +4269,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: app-0.12.5
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4862,7 +4862,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: console-0.12.5
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5000,7 +5000,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: executor-0.12.5
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5293,7 +5293,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: filemeta-0.12.5
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5564,7 +5564,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: frontend-0.12.5
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5702,7 +5702,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: glue-0.12.5
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6010,7 +6010,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: nginx-0.12.5
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6138,7 +6138,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: parquet-0.12.5
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6642,7 +6642,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-trace-0.12.5
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6889,7 +6889,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: weave-0.12.5
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7699,7 +7699,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: '###CHART_VERSION###'
+            helm.sh/chart: parquet-0.12.5
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/azure-byob-access-key.yaml
+++ b/test-configs/operator-wandb/azure-byob-access-key.yaml
@@ -1,0 +1,26 @@
+global:
+  host: "http://localhost:8080"
+  repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
+  imageRegistry: "us-docker.pkg.dev/wandb-production/public"
+  bucket:
+    provider: "az"
+    name: "customer-storage-account"
+    path: "customer-container"
+    accessKey: "customer-storage-key"
+  azureStorageIdentity:
+    tenantId: "default-bucket-tenant-id"
+    clientId: "default-bucket-client-id"
+  size: "testing"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: false
+
+redis:
+  install: false
+
+reloader:
+  install: false

--- a/test-configs/operator-wandb/azure-workload-identity-refs.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity-refs.yaml
@@ -32,11 +32,9 @@ redis:
 reloader:
   install: false
 
-# ServiceAccount annotations cannot use valueFrom. Verify that an annotation
-# supplied independently by infrastructure is preserved in reference mode.
+# Verify that ServiceAccount annotations supplied independently by customer
+# infrastructure remain supported in reference mode.
 app:
-  podLabels:
-    azure.workload.identity/use: "true"
   serviceAccount:
     annotations:
       azure.workload.identity/client-id: "infrastructure-client-id"

--- a/test-configs/operator-wandb/azure-workload-identity-refs.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity-refs.yaml
@@ -1,0 +1,49 @@
+global:
+  host: "http://localhost:8080"
+  repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
+  imageRegistry: "us-docker.pkg.dev/wandb-production/public"
+  bucket:
+    provider: "az"
+    name: "storage-account"
+    path: "container"
+  azureStorageIdentity:
+    tenantId:
+      valueFrom:
+        secretKeyRef:
+          name: "azure-storage-identity"
+          key: "tenant-id"
+    clientId:
+      valueFrom:
+        secretKeyRef:
+          name: "azure-storage-identity"
+          key: "client-id"
+  size: "testing"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: false
+
+redis:
+  install: false
+
+reloader:
+  install: false
+
+# ServiceAccount annotations cannot use valueFrom. Verify that an annotation
+# supplied independently by infrastructure is preserved in reference mode.
+app:
+  podLabels:
+    azure.workload.identity/use: "true"
+  serviceAccount:
+    annotations:
+      azure.workload.identity/client-id: "infrastructure-client-id"
+      azure.workload.identity/tenant-id: "infrastructure-tenant-id"
+
+parquet:
+  serviceAccount:
+    annotations:
+      azure.workload.identity/client-id: "infrastructure-client-id"
+      azure.workload.identity/tenant-id: "infrastructure-tenant-id"

--- a/test-configs/operator-wandb/azure-workload-identity-refs.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity-refs.yaml
@@ -2,10 +2,11 @@ global:
   host: "http://localhost:8080"
   repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
   imageRegistry: "us-docker.pkg.dev/wandb-production/public"
-  bucket:
+  defaultBucket:
     provider: "az"
-    name: "storage-account"
-    path: "container"
+    name: "managed-storage-account"
+    path: "managed-container"
+    accessKey: "orphaned-managed-storage-key"
   azureStorageIdentity:
     tenantId:
       valueFrom:

--- a/test-configs/operator-wandb/azure-workload-identity-refs.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity-refs.yaml
@@ -6,6 +6,8 @@ global:
     provider: "az"
     name: "managed-storage-account"
     path: "managed-container"
+    # Deliberately stale: workload identity must prevent this managed key
+    # from being rendered or used.
     accessKey: "orphaned-managed-storage-key"
   azureStorageIdentity:
     tenantId:

--- a/test-configs/operator-wandb/azure-workload-identity-refs.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity-refs.yaml
@@ -20,6 +20,10 @@ global:
         secretKeyRef:
           name: "azure-storage-identity"
           key: "client-id"
+    serviceAccount:
+      annotations:
+        azure.workload.identity/client-id: "infrastructure-client-id"
+        azure.workload.identity/tenant-id: "infrastructure-tenant-id"
   size: "testing"
 
 ingress:
@@ -34,17 +38,3 @@ redis:
 
 reloader:
   install: false
-
-# Verify that ServiceAccount annotations supplied independently by customer
-# infrastructure remain supported in reference mode.
-app:
-  serviceAccount:
-    annotations:
-      azure.workload.identity/client-id: "infrastructure-client-id"
-      azure.workload.identity/tenant-id: "infrastructure-tenant-id"
-
-parquet:
-  serviceAccount:
-    annotations:
-      azure.workload.identity/client-id: "infrastructure-client-id"
-      azure.workload.identity/tenant-id: "infrastructure-tenant-id"

--- a/test-configs/operator-wandb/azure-workload-identity.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity.yaml
@@ -25,13 +25,3 @@ redis:
 
 reloader:
   install: false
-
-# Verify that authoritative literal identity settings replace, rather than
-# duplicate, metadata already supplied by infrastructure values.
-app:
-  podLabels:
-    azure.workload.identity/use: "false"
-  serviceAccount:
-    annotations:
-      azure.workload.identity/client-id: "infrastructure-client-id"
-      azure.workload.identity/tenant-id: "infrastructure-tenant-id"

--- a/test-configs/operator-wandb/azure-workload-identity.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity.yaml
@@ -1,0 +1,27 @@
+global:
+  host: "http://localhost:8080"
+  repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
+  imageRegistry: "us-docker.pkg.dev/wandb-production/public"
+  bucket:
+    provider: "az"
+    name: "storage-account"
+    path: "container"
+    azureTenantId: "cr-tenant-id"
+    azureClientId: "cr-client-id"
+  azureStorageIdentity:
+    tenantId: "authoritative-tenant-id"
+    clientId: "authoritative-client-id"
+  size: "testing"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: false
+
+redis:
+  install: false
+
+reloader:
+  install: false

--- a/test-configs/operator-wandb/azure-workload-identity.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity.yaml
@@ -25,3 +25,13 @@ redis:
 
 reloader:
   install: false
+
+# Verify that authoritative literal identity settings replace, rather than
+# duplicate, metadata already supplied by infrastructure values.
+app:
+  podLabels:
+    azure.workload.identity/use: "false"
+  serviceAccount:
+    annotations:
+      azure.workload.identity/client-id: "infrastructure-client-id"
+      azure.workload.identity/tenant-id: "infrastructure-tenant-id"

--- a/test-configs/operator-wandb/azure-workload-identity.yaml
+++ b/test-configs/operator-wandb/azure-workload-identity.yaml
@@ -4,14 +4,24 @@ global:
   imageRegistry: "us-docker.pkg.dev/wandb-production/public"
   bucket:
     provider: "az"
-    name: "storage-account"
-    path: "container"
-    azureTenantId: "cr-tenant-id"
-    azureClientId: "cr-client-id"
+    name: "customer-storage-account"
+    path: "customer-container"
+    azureAuthMethod: "workloadIdentity"
+  defaultBucket:
+    provider: "az"
+    name: "managed-storage-account"
+    path: "managed-container"
   azureStorageIdentity:
     tenantId: "authoritative-tenant-id"
     clientId: "authoritative-client-id"
+  weave-trace:
+    enabled: true
+    fileStorage:
+      useDefaultBucket: true
   size: "testing"
+
+weave-trace:
+  install: true
 
 ingress:
   install: false

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -6,7 +6,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.5
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -27,7 +27,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.5
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -48,7 +48,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.5
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.5
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -95,7 +95,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.5
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -108,7 +108,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.5
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -121,7 +121,7 @@ kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: orchestrator-1.4.2
+    helm.sh/chart: orchestrator-1.4.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -136,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: orchestrator-1.4.2
+    helm.sh/chart: orchestrator-1.4.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.5
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -369,7 +369,7 @@ kind: Service
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.5
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -391,7 +391,7 @@ kind: Service
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.5
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -495,7 +495,7 @@ kind: Deployment
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.5
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -516,7 +516,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: identity-0.12.5
+        helm.sh/chart: identity-0.12.4
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -628,7 +628,7 @@ kind: Deployment
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.5
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -649,7 +649,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: web-0.12.5
+        helm.sh/chart: web-0.12.4
         app.kubernetes.io/name: web
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -714,7 +714,7 @@ kind: Deployment
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.5
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -735,7 +735,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.5
+        helm.sh/chart: workspace-engine-0.12.4
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -865,7 +865,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.5
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -897,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: orchestrator-1.4.2
+    helm.sh/chart: orchestrator-1.4.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -944,7 +944,7 @@ kind: Job
 metadata:
   name: chartsnap-auth-migrate
   labels:
-    helm.sh/chart: identity-0.12.5
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -959,7 +959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: identity-0.12.5
+        helm.sh/chart: identity-0.12.4
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -1061,7 +1061,7 @@ kind: Job
 metadata:
   name: chartsnap-authz-apply-schema
   labels:
-    helm.sh/chart: workspace-engine-0.12.5
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1076,7 +1076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.5
+        helm.sh/chart: workspace-engine-0.12.4
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -1193,7 +1193,7 @@ kind: Job
 metadata:
   name: chartsnap-migrate
   labels:
-    helm.sh/chart: workspace-engine-0.12.5
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1208,7 +1208,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.5
+        helm.sh/chart: workspace-engine-0.12.4
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -6,7 +6,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: identity-0.12.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -27,7 +27,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: web-0.12.5
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -48,7 +48,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: workspace-engine-0.12.5
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: identity-0.12.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -95,7 +95,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: web-0.12.5
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -108,7 +108,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: workspace-engine-0.12.5
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: identity-0.12.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -369,7 +369,7 @@ kind: Service
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: web-0.12.5
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -391,7 +391,7 @@ kind: Service
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: workspace-engine-0.12.5
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -495,7 +495,7 @@ kind: Deployment
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: identity-0.12.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -516,7 +516,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: identity-0.12.5
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -628,7 +628,7 @@ kind: Deployment
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: web-0.12.5
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -649,7 +649,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: web-0.12.5
         app.kubernetes.io/name: web
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -714,7 +714,7 @@ kind: Deployment
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: workspace-engine-0.12.5
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -735,7 +735,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: workspace-engine-0.12.5
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -865,7 +865,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: web-0.12.5
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -944,7 +944,7 @@ kind: Job
 metadata:
   name: chartsnap-auth-migrate
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: identity-0.12.5
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -959,7 +959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: identity-0.12.5
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -1061,7 +1061,7 @@ kind: Job
 metadata:
   name: chartsnap-authz-apply-schema
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: workspace-engine-0.12.5
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1076,7 +1076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: workspace-engine-0.12.5
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -1193,7 +1193,7 @@ kind: Job
 metadata:
   name: chartsnap-migrate
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: workspace-engine-0.12.5
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1208,7 +1208,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: '###CHART_VERSION###'
+        helm.sh/chart: workspace-engine-0.12.5
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -6,7 +6,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -27,7 +27,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -48,7 +48,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -95,7 +95,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -108,7 +108,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -121,7 +121,7 @@ kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: orchestrator-1.4.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -136,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: orchestrator-1.4.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -369,7 +369,7 @@ kind: Service
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -391,7 +391,7 @@ kind: Service
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -495,7 +495,7 @@ kind: Deployment
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -516,7 +516,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: identity-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -628,7 +628,7 @@ kind: Deployment
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -649,7 +649,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: web-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: web
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -714,7 +714,7 @@ kind: Deployment
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -735,7 +735,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -865,7 +865,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -897,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: orchestrator-1.4.1
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -944,7 +944,7 @@ kind: Job
 metadata:
   name: chartsnap-auth-migrate
   labels:
-    helm.sh/chart: identity-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -959,7 +959,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: identity-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -1061,7 +1061,7 @@ kind: Job
 metadata:
   name: chartsnap-authz-apply-schema
   labels:
-    helm.sh/chart: workspace-engine-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1076,7 +1076,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -1193,7 +1193,7 @@ kind: Job
 metadata:
   name: chartsnap-migrate
   labels:
-    helm.sh/chart: workspace-engine-0.12.4
+    helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -1208,7 +1208,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.4
+        helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -121,7 +121,7 @@ kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: orchestrator-1.4.2
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -136,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: orchestrator-1.4.2
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -897,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: '###CHART_VERSION###'
+    helm.sh/chart: orchestrator-1.4.2
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION
## Summary

This chart adds a deployment-wide Azure storage identity while preserving existing key-based and legacy BYOB behavior.

- `global.azureStorageIdentity` holds the deployment tenant, client, principal, and shared ServiceAccount contract
- the chart creates one `wandb-bucket-access` ServiceAccount by default, or uses an externally created account with `create: false`
- `wandb-base`, Weave, and Bufstream storage consumers select the shared account and keep their RoleBindings aligned
- literal client IDs are applied to the ServiceAccount annotation automatically; reference-valued client IDs require an explicit literal annotation or an external account
- `global.bucket.azureAuthMethod` lets an Azure customer bucket select `accessKey` or `workloadIdentity`
- existing bucket-scoped tenant/client IDs and explicit storage-account keys remain supported
- both Azure credential fields are omitted from the Secret when workload identity is selected

Weave file storage remains off by default. `global.weave-trace.fileStorage.useDefaultBucket` maps only the managed `global.defaultBucket` to `WF_FILE_STORAGE_URI`; it rejects bucket paths containing an object prefix. Mixed access-key BYOB plus Weave default-bucket identity is covered explicitly.

Grant the deployment identity `Reader` and `Storage Blob Data Contributor` on the storage account. Existing Azure BYOB continues to use storage-account keys unless it explicitly selects `workloadIdentity`.

The operator chart remains at feature release `0.44.0`.

## Verification

- focused Azure storage Helm suite: 25 passed
- template formatter and 16 Python tests
- template maintainability check
- `ct lint`
- full operator-wandb snapshot suite with Helm 3.20.1

## Azure QA validation

Validated on 2026-07-30 with chart prerelease `0.44.0-PR606-13c71a2b` and Core prerelease `0.84.0-azure-sas-blob-test.1`.

- W&B SDK run files and artifacts used Azure user-delegation SAS for GET and PUT
- sibling blob access returned HTTP 403
- allowlisted Weave storage wrote to the managed Azure default bucket
- non-allowlisted Weave storage remained inline
- disabling the feature restored the original account-key SAS behavior; every `wandb verify` check passed on the restored runtime

The final follow-up commit adds regression coverage only; it does not change rendered chart output.

## Rollout

Release this chart before enabling wandb/core#49026. Keep the Core migration disabled for existing installations until they are explicitly selected for rollout.

Jira: WB-38011

Companion PRs: wandb/core#49026, wandb/docs#2967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure Storage workload identity support, including shared service accounts, credential references, and automatic workload identity labeling.
  * Added configuration options for Azure tenant/client IDs and access-key or workload-identity authentication.
  * Added Azure BYOB and workload identity deployment configurations.
  * Improved Weave Trace storage URI handling for Azure-backed storage.

* **Bug Fixes**
  * Prevented unnecessary Azure access keys and secrets from being rendered when workload identity is enabled.

* **Tests**
  * Added comprehensive coverage for Azure authentication, service accounts, RBAC, and storage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->