### PR TITLE
feat(weave): wire weave-trace file-payload storage to the wandb bucket

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.42.6
+version: 0.42.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -96,6 +96,57 @@ Global values will override any chart-specific values.
       optional: true
 {{- end -}}
 
+{{/*
+  weave-trace file-payload storage. Reuses the wandb bucket (global.bucket /
+  global.defaultBucket) for the URI and credentials. S3/Azure reuse the bucket
+  secret; GCS uses workload identity (ADC) since its client needs a service
+  account, not the S3-interop HMAC key gorilla uses. CoreWeave/MinIO
+  S3-compatible endpoints are unsupported (the server has no endpoint override).
+*/}}
+{{- define "wandb.weave.fileStorageEnvs" -}}
+{{- if .Values.global.weave.fileStorage.enabled -}}
+{{- $bucket := include "wandb.bucket" . | fromYaml -}}
+{{- $scheme := dict "s3" "s3" "gcs" "gs" "az" "az" | dig $bucket.provider "" -}}
+{{- if and $scheme $bucket.name -}}
+{{- $uri := printf "%s://%s" $scheme $bucket.name -}}
+{{- if $bucket.path -}}{{- $uri = printf "%s/%s" $uri $bucket.path -}}{{- end }}
+- name: WF_FILE_STORAGE_URI
+  value: {{ $uri | quote }}
+{{- if eq $bucket.provider "s3" }}
+- name: WF_FILE_STORAGE_AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bucket.secretName | quote }}
+      key: {{ $bucket.accessKeyName | quote }}
+      optional: true
+- name: WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bucket.secretName | quote }}
+      key: {{ $bucket.secretKeyName | quote }}
+      optional: true
+{{- if $bucket.region }}
+- name: WF_FILE_STORAGE_AWS_REGION
+  value: {{ $bucket.region | quote }}
+{{- end }}
+{{- if $bucket.kmsKey }}
+- name: WF_FILE_STORAGE_AWS_KMS_KEY
+  value: {{ $bucket.kmsKey | quote }}
+{{- end }}
+{{- else if eq $bucket.provider "az" }}
+- name: WF_FILE_STORAGE_AZURE_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $bucket.secretName | quote }}
+      key: {{ $bucket.accessKeyName | quote }}
+      optional: true
+{{- else if eq $bucket.provider "gcs" }}
+{{- /* GCS authenticates via workload identity (ADC); bind the weave-trace SA. */ -}}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "wandb.statsigEnvs" -}}
 {{- if eq .Values.global.statsig.apiKey "" }}
 - name: GORILLA_STATSIG_KEY

--- a/charts/operator-wandb/templates/weave-trace.yaml
+++ b/charts/operator-wandb/templates/weave-trace.yaml
@@ -26,4 +26,8 @@ data:
   KAFKA_BROKER_HOST: "{{ include "wandb.kafka.brokerHost" . }}"
   KAFKA_BROKER_PORT: "{{ include "wandb.kafka.brokerPort" . }}"
   WEAVE_REDIS_URL: "{{ include "wandb.redis.connectionString" . | trim }}"
+  {{- if .Values.global.weave.fileStorage.enabled }}
+  WF_FILE_STORAGE_PROJECT_ALLOW_LIST: {{ join "," .Values.global.weave.fileStorage.projectAllowList | quote }}
+  WF_FILE_STORAGE_PROJECT_RAMP_PCT: {{ .Values.global.weave.fileStorage.projectRampPct | quote }}
+  {{- end }}
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -385,6 +385,19 @@ global:
       accessKeyName: "ACCESS_KEY"
       secretKeyName: "SECRET_KEY"
 
+  weave:
+    # weave-trace file-payload (attachment) storage. Reuses the bucket above for
+    # the URI + creds. GCS authenticates via workload identity; bind the
+    # weave-trace service account to a GCP SA with object read/write.
+    # Opt-in: the server talks to real AWS S3 / GCS / Azure only (no endpoint
+    # override), so leave disabled for MinIO or S3-compatible object stores.
+    fileStorage:
+      enabled: false
+      # Percent of projects (0-100) that route file payloads to the bucket.
+      projectRampPct: 100
+      # Project IDs always routed to the bucket regardless of ramp.
+      projectAllowList: []
+
   redis:
     host: ""
     port: 6379
@@ -3062,6 +3075,7 @@ weave-trace:
   envTpls:
     - '{{ include "wandb.clickhouseEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
+    - '{{ include "wandb.weave.fileStorageEnvs" . }}'
   initContainers:
     weave-trace-migrate:
       args: ["python", "migrator.py"]
@@ -3199,6 +3213,7 @@ weave-trace-worker:
   envTpls:
     - '{{ include "wandb.clickhouseConfigEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
+    - '{{ include "wandb.weave.fileStorageEnvs" . }}'
   env:
     WANDB_INTERNAL_SERVICE_TOKEN:
       valueFrom:
@@ -3308,6 +3323,7 @@ weave-evaluate-model-worker:
   envTpls:
     - '{{ include "wandb.clickhouseConfigEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
+    - '{{ include "wandb.weave.fileStorageEnvs" . }}'
   env:
     WANDB_INTERNAL_SERVICE_TOKEN:
       valueFrom:


### PR DESCRIPTION
Helm-charts counterpart to wandb/core#45284 (which granted the SaaS weave-trace SA GCS perms). That PR was small because the core chart already wires the storage env; operator-wandb wired none, so weave-trace + workers cannot write file payloads at all.

## Summary
- Add `wandb.weave.fileStorageEnvs` deriving `WF_FILE_STORAGE_URI` + per-provider creds from the existing wandb bucket (`global.bucket`/`defaultBucket`). S3/Azure reuse the bucket secret; GCS uses workload identity (ADC), since its client needs a service account, not gorilla’s S3-interop HMAC key.
- Wire it into the trace server and both workers; add `WF_FILE_STORAGE_PROJECT_ALLOW_LIST` / `_RAMP_PCT` gating.
- Opt-in (`global.weave.fileStorage.enabled=false`): the server talks to real AWS S3 / GCS / Azure only (no endpoint override), so MinIO/S3-compatible stores stay off.

## Testing
helm template across s3/gcs/az + disabled; existing weave-trace-with-worker test config renders unchanged.