### PR TITLE
chore: verify declarative environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+<!-- Verify declarative environment setup -->
+
 ## Prerequisites
 
 - Helm v3.16.3 or later


### PR DESCRIPTION
## Summary

Trivial README comment to verify the Devin declarative environment setup for this repo.

- `helm`, `ct`, and `yamllint` are available via Linuxbrew
- `helm dep build` ran via `./helm-dep-build.sh`
- `ct lint --config ct.yaml --all` ran (pre-existing maintainer validation 404s for "wandb" org, unrelated to this change)

Link to Devin session: https://app.devin.ai/sessions/fb62bccd975e453ab2f963d551bdc6d6
Requested by: @wandbjake