### PR TITLE
fix: correct identity port

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/orchestrator/templates/_authjwt.tpl
+++ b/charts/orchestrator/templates/_authjwt.tpl
@@ -6,7 +6,7 @@ identity stamps (its BASE_URL = global.fqdn); AUTH_AUDIENCE must equal identity'
 AUTH_JWT_AUDIENCE (both sourced from global.jwt.audience).
 */}}
 {{- define "orchestrator.authJwtEnvVars" -}}
-{{ include "orchestrator.envVar" (dict "name" "AUTH_JWKS_URL" "value" (printf "http://%s-identity:8080/api/auth/jwks" .Release.Name)) }}
+{{ include "orchestrator.envVar" (dict "name" "AUTH_JWKS_URL" "value" (printf "http://%s-identity:8081/api/auth/jwks" .Release.Name)) }}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_VALID_ISSUERS" "value" .Values.global.fqdn) }}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_AUDIENCE" "value" .Values.global.jwt.audience) }}
 {{- end -}}

--- a/charts/orchestrator/templates/_authjwt.tpl
+++ b/charts/orchestrator/templates/_authjwt.tpl
@@ -6,7 +6,7 @@ identity stamps (its BASE_URL = global.fqdn); AUTH_AUDIENCE must equal identity'
 AUTH_JWT_AUDIENCE (both sourced from global.jwt.audience).
 */}}
 {{- define "orchestrator.authJwtEnvVars" -}}
-{{ include "orchestrator.envVar" (dict "name" "AUTH_JWKS_URL" "value" (printf "http://%s-identity:8081/api/auth/jwks" .Release.Name)) }}
+{{ include "orchestrator.envVar" (dict "name" "AUTH_JWKS_URL" "value" (printf "http://%s-identity:%v/api/auth/jwks" .Release.Name .Values.global.jwt.identityPort)) }}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_VALID_ISSUERS" "value" .Values.global.fqdn) }}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_AUDIENCE" "value" .Values.global.jwt.audience) }}
 {{- end -}}

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -111,6 +111,10 @@ global:
   # engine pins it for verification (AUTH_AUDIENCE). One value so they can't drift.
   jwt:
     audience: "workspace-engine"
+    # Port the identity service listens on / serves JWKS. Drives the engine's
+    # AUTH_JWKS_URL and the identity PORT env. (The identity container/service
+    # ports are static values — keep them equal to this if you override it.)
+    identityPort: 8081
 
   # Redis — used by identity + engine for cross-pod SpiceDB read-after-write
   # (REDIS_URL is assembled from these).
@@ -183,7 +187,7 @@ identity:
   env:
     BASE_URL: "{{ .Values.global.fqdn }}"
     AUTH_URL: "{{ .Values.global.fqdn }}"
-    PORT: "8080"
+    PORT: "{{ .Values.global.jwt.identityPort }}"
     # Engine Connect API for tRPC engine calls.
     CONNECT_URL: "http://{{ .Release.Name }}-workspace-engine:8081"
     # Audience stamped on issued JWTs; the engine pins the same value (AUTH_AUDIENCE).
@@ -199,7 +203,7 @@ identity:
     identity:
       ports:
         - name: http
-          containerPort: 8080
+          containerPort: 8081
       resources:
         requests:
           cpu: 250m
@@ -223,7 +227,7 @@ identity:
   service:
     enabled: true
     ports:
-      - port: 8080
+      - port: 8081
         targetPort: http
         protocol: TCP
         name: http


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the authentication JWKS URL configuration to point to the identity service on the correct port.
  * Standardized the identity service port across Helm values and Kubernetes service/container settings to ensure consistent JWKS access.
  * Bumped the orchestrator Helm chart version to reflect the configuration update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->