### PR TITLE
fix(weave): switch to jemalloc to fix post-load memory retention

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.42.8
+version: 0.42.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -3207,6 +3207,16 @@ weave-trace:
   envTpls:
     - '{{ include "wandb.clickhouseEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
+  # Use jemalloc instead of glibc malloc. Without this, glibc holds onto
+  # freed memory for hours after a load spike, leading to OOMKill cascades
+  # when load picks back up. jemalloc's dirty_decay_ms / muzzy_decay_ms
+  # return pages to the OS automatically. Validated 2026-05-20: post-load
+  # RSS drops from ~7 GiB to ~1 GiB within 30s with these settings, versus
+  # glibc holding 7 GiB indefinitely. Requires image >= 2026-05-21
+  # (wandb/weave-trace must bundle jemalloc at /usr/lib/libjemalloc.so.2).
+  env:
+    LD_PRELOAD: "/usr/lib/libjemalloc.so.2"
+    MALLOC_CONF: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
   initContainers:
     weave-trace-migrate:
       args: ["python", "migrator.py"]
@@ -3344,7 +3354,18 @@ weave-trace-worker:
   envTpls:
     - '{{ include "wandb.clickhouseConfigEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
+  # Use jemalloc instead of glibc malloc. Without this, glibc holds onto
+  # freed memory for hours after a load spike, leading to OOMKill cascades
+  # when load picks back up. jemalloc's dirty_decay_ms / muzzy_decay_ms
+  # return pages to the OS automatically. Validated 2026-05-20 on the
+  # weave-trace deployment: post-load RSS drops from ~7 GiB to ~1 GiB
+  # within 30s with these settings, versus glibc holding 7 GiB
+  # indefinitely. Worker shares the same image and benefits from the same
+  # allocator behavior. Requires image >= 2026-05-21 (wandb/weave-trace
+  # must bundle jemalloc at /usr/lib/libjemalloc.so.2).
   env:
+    LD_PRELOAD: "/usr/lib/libjemalloc.so.2"
+    MALLOC_CONF: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
     WANDB_INTERNAL_SERVICE_TOKEN:
       valueFrom:
         secretKeyRef:
@@ -3453,7 +3474,18 @@ weave-evaluate-model-worker:
   envTpls:
     - '{{ include "wandb.clickhouseConfigEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
+  # Use jemalloc instead of glibc malloc. Without this, glibc holds onto
+  # freed memory for hours after a load spike, leading to OOMKill cascades
+  # when load picks back up. jemalloc's dirty_decay_ms / muzzy_decay_ms
+  # return pages to the OS automatically. Validated 2026-05-20 on the
+  # weave-trace deployment: post-load RSS drops from ~7 GiB to ~1 GiB
+  # within 30s with these settings, versus glibc holding 7 GiB
+  # indefinitely. Worker shares the same image and benefits from the same
+  # allocator behavior. Requires image >= 2026-05-21 (wandb/weave-trace
+  # must bundle jemalloc at /usr/lib/libjemalloc.so.2).
   env:
+    LD_PRELOAD: "/usr/lib/libjemalloc.so.2"
+    MALLOC_CONF: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
     WANDB_INTERNAL_SERVICE_TOKEN:
       valueFrom:
         secretKeyRef:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -5939,6 +5939,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6032,6 +6036,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -6898,6 +6898,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6991,6 +6995,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -3516,6 +3516,10 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3610,6 +3614,10 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -6979,6 +6979,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         - name: WANDB_INTERNAL_SERVICE_TOKEN
           valueFrom:
             secretKeyRef:
@@ -7130,6 +7134,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         - name: WANDB_INTERNAL_SERVICE_TOKEN
           valueFrom:
             secretKeyRef:
@@ -7295,6 +7303,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -7388,6 +7400,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -6677,6 +6677,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6770,6 +6774,10 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: LD_PRELOAD
+          value: "/usr/lib/libjemalloc.so.2"
+        - name: MALLOC_CONF
+          value: "background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:30000,narenas:8"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary

Turn on jemalloc via `LD_PRELOAD` in the chart's deployment values for the weave-trace, weave-trace-worker, and weave-evaluate-model-worker deployments. Fixes the post-load memory retention issue where weave-trace processes hold 7+ GiB RSS indefinitely after a load spike drains, leading to OOMKill cascades when load picks back up.


Image requirement: `wandb/weave-trace` >= 2026-05-21 (bundles jemalloc at `/usr/lib/libjemalloc.so.2`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated runtime memory settings for trace, worker, and evaluation worker components to improve application stability and memory behavior.
  * Enabled a different memory allocation setup for these components, with tuned defaults included in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->