### PR TITLE
fix: Lumen misc chart fixes processor, notebook

### DIFF
--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: wandb-base
   repository: file://../wandb-base
   version: 0.12.3
-digest: sha256:e85be54f732f7beb4b958781f19c4bf5d0456d4b9e93ff7e7054adf12715d7ec
-generated: "2026-06-26T15:58:33.860785-05:00"
+digest: sha256:f996aeb5449178585664e12a9d53cc5ed2e2830fc6fc1561f6c4c0c8afde4d0e
+generated: "2026-07-06T12:05:12.893621-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -12,10 +12,10 @@ maintainers:
 
 dependencies:
   - name: wandb-base
-    alias: lumen-processor
+    alias: processor
     version: "0.12.3"
     repository: file://../wandb-base
   - name: wandb-base
-    alias: lumen-notebook
+    alias: notebook
     version: "0.12.3"
     repository: file://../wandb-base

--- a/charts/lumen/templates/_lumen.tpl
+++ b/charts/lumen/templates/_lumen.tpl
@@ -1,7 +1,11 @@
-{{- define "lumen.audience" -}}
+{{- define "wandb.lumen.audience" -}}
 {{- dig "lumen" "gcpWorkloadIdentity" "audience" "" .Values.global -}}
 {{- end -}}
 
-{{- define "lumen.dataRoot" -}}
+{{- define "wandb.lumen.dataRoot" -}}
 {{- dig "lumen" "dataRoot" "" .Values.global -}}
+{{- end -}}
+
+{{- define "wandb.lumen.stagingPath" -}}
+/vol/staging
 {{- end -}}

--- a/charts/lumen/templates/_volumes.tpl
+++ b/charts/lumen/templates/_volumes.tpl
@@ -1,0 +1,9 @@
+{{- define "wandb.lumenStagingVolumeMount" }}
+- name: lumen-staging-dir
+  mountPath: {{ include "wandb.lumen.stagingPath" . }}
+{{- end }}
+
+{{- define "wandb.lumenStagingVolume" }}
+- name: lumen-staging-dir
+  emptyDir: { }
+{{- end }}

--- a/charts/lumen/templates/configmap.yaml
+++ b/charts/lumen/templates/configmap.yaml
@@ -6,3 +6,14 @@ metadata:
 data:
   LUMEN_DATA_ROOT: {{ $bucket | quote }}
   LUMEN_STAGING_ROOT: "file://{{ include "wandb.lumen.stagingPath" . }}"
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-marimo-configmap
+data:
+  XDG_CONFIG_HOME: "{{ include "wandb.lumen.stagingPath" . }}/.config"
+  XDG_STATE_HOME: "{{ include "wandb.lumen.stagingPath" . }}/.local/state"
+  XDG_CACHE_HOME: "{{ include "wandb.lumen.stagingPath" . }}/.cache"

--- a/charts/lumen/templates/configmap.yaml
+++ b/charts/lumen/templates/configmap.yaml
@@ -1,8 +1,8 @@
-{{- $bucket := include "lumen.dataRoot" . -}}
+{{- $bucket := include "wandb.lumen.dataRoot" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-lumen-configmap
+  name: {{ .Release.Name }}-configmap
 data:
   LUMEN_DATA_ROOT: {{ $bucket | quote }}
-  LUMEN_STAGING_ROOT: "/vol/staging"
+  LUMEN_STAGING_ROOT: "file://{{ include "wandb.lumen.stagingPath" . }}"

--- a/charts/lumen/templates/wif.yaml
+++ b/charts/lumen/templates/wif.yaml
@@ -1,4 +1,4 @@
-{{- $audience := include "lumen.audience" . -}}
+{{- $audience := include "wandb.lumen.audience" . -}}
 {{- if $audience }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -13,8 +13,7 @@ processor:
   kind: CronJob
   image:
     repository: us-docker.pkg.dev/wandb-production/public/wandb/lumen
-    tag: latest
-    pullPolicy: Always
+    tag: v0.1.5
   serviceAccount:
     annotations: {}
   globalOptOut:
@@ -66,8 +65,7 @@ notebook:
   replicaCount: 1
   image:
     repository: us-docker.pkg.dev/wandb-production/public/wandb/lumen
-    tag: latest
-    pullPolicy: Always
+    tag: v0.1.5
   serviceAccount:
     annotations: {}
   globalOptOut:

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -9,7 +9,7 @@ global:
 
 # Processor: hourly CronJob that moves agent exports to inbound, processes,
 # and writes parquet to the data root.
-lumen-processor:
+processor:
   kind: CronJob
   image:
     repository: us-docker.pkg.dev/wandb-production/public/wandb/lumen
@@ -24,10 +24,12 @@ lumen-processor:
   service:
     enabled: false
   cronJobs:
-    lumen-processor:
+    processor:
       enabled: true
       schedule: "15 * * * *"
       concurrencyPolicy: "Forbid"
+      volumesTpls:
+        - '{{ include "wandb.lumenStagingVolume" . }}'
       failedJobsHistoryLimit: 1
       successfulJobsHistoryLimit: 1
       startingDeadlineSeconds: 300
@@ -47,7 +49,9 @@ lumen-processor:
                 resourceFieldRef:
                   resource: limits.cpu
           envFrom:
-            "{{ .Release.Name }}-lumen-configmap": "configMapRef"
+            "{{ .Release.Name }}-configmap": "configMapRef"
+          volumeMountsTpls:
+            - '{{ include "wandb.lumenStagingVolumeMount" . }}'
           resources:
             requests:
               cpu: 1
@@ -57,7 +61,7 @@ lumen-processor:
               memory: 4Gi
 
 # Notebook: marimo UI for browsing the parquet data root.
-lumen-notebook:
+notebook:
   kind: Deployment
   replicaCount: 1
   image:
@@ -70,6 +74,8 @@ lumen-notebook:
     volumes: true
   podDisruptionBudget:
     enabled: false
+  volumesTpls:
+    - '{{ include "wandb.lumenStagingVolume" . }}'
   service:
     enabled: true
     ports:
@@ -90,7 +96,9 @@ lumen-notebook:
             resourceFieldRef:
               resource: limits.cpu
       envFrom:
-        "{{ .Release.Name }}-lumen-configmap": "configMapRef"
+        "{{ .Release.Name }}-configmap": "configMapRef"
+      volumeMountsTpls:
+        - '{{ include "wandb.lumenStagingVolumeMount" . }}'
       ports:
         - containerPort: 8080
           name: marimo

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -97,6 +97,7 @@ notebook:
               resource: limits.cpu
       envFrom:
         "{{ .Release.Name }}-configmap": "configMapRef"
+        "{{ .Release.Name }}-marimo-configmap": "configMapRef"
       volumeMountsTpls:
         - '{{ include "wandb.lumenStagingVolumeMount" . }}'
       ports:

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.42.9
+version: 0.43.0
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -3945,8 +3945,7 @@ lumen-agent:
   kind: CronJob
   image:
     repository: us-docker.pkg.dev/wandb-production/public/wandb/lumen
-    tag: latest
-    pullPolicy: Always
+    tag: v0.1.5
   serviceAccount:
     name: lumen
     annotations: {}

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -146,7 +146,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -2039,7 +2039,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -2095,7 +2095,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
@@ -4077,7 +4077,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   concurrencyPolicy: Forbid
@@ -4095,7 +4095,7 @@ spec:
             helm.sh/chart: lumen-agent-0.12.3
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/version: "latest"
+            app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
         spec:
           containers:
@@ -4152,8 +4152,8 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:latest"
-            imagePullPolicy: Always
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
             resources:
               limits:
                 cpu: 2

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -146,7 +146,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -2039,7 +2039,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -2095,7 +2095,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
@@ -4075,7 +4075,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   concurrencyPolicy: Forbid
@@ -4093,7 +4093,7 @@ spec:
             helm.sh/chart: lumen-agent-0.12.3
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/version: "latest"
+            app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
         spec:
           containers:
@@ -4150,8 +4150,8 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:latest"
-            imagePullPolicy: Always
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
             resources:
               limits:
                 cpu: 2

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -146,7 +146,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -2039,7 +2039,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -2095,7 +2095,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
@@ -4087,7 +4087,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   concurrencyPolicy: Forbid
@@ -4105,7 +4105,7 @@ spec:
             helm.sh/chart: lumen-agent-0.12.3
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/version: "latest"
+            app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
         spec:
           containers:
@@ -4162,8 +4162,8 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:latest"
-            imagePullPolicy: Always
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
             resources:
               limits:
                 cpu: 2

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -146,7 +146,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -2018,7 +2018,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -2074,7 +2074,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
@@ -4052,7 +4052,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   concurrencyPolicy: Forbid
@@ -4070,7 +4070,7 @@ spec:
             helm.sh/chart: lumen-agent-0.12.3
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/version: "latest"
+            app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
         spec:
           containers:
@@ -4127,8 +4127,8 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:latest"
-            imagePullPolicy: Always
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
             resources:
               limits:
                 cpu: 2

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -146,7 +146,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -2020,7 +2020,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -2076,7 +2076,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
@@ -4054,7 +4054,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   concurrencyPolicy: Forbid
@@ -4072,7 +4072,7 @@ spec:
             helm.sh/chart: lumen-agent-0.12.3
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/version: "latest"
+            app.kubernetes.io/version: "v0.1.5"
             app.kubernetes.io/managed-by: Helm
         spec:
           containers:
@@ -4129,8 +4129,8 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:latest"
-            imagePullPolicy: Always
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
             resources:
               limits:
                 cpu: 2


### PR DESCRIPTION
Create an `emptyDir` mount for lumen staging dir for processor & notebook; also, some misc naming changes to prevent k8s workloads from having "lumen-lumen" in the name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shared staging directory used by both processing and notebook workloads.
  * Split configuration into separate app and notebook settings for cleaner runtime setup.
  * Enabled scheduled processing jobs with defined concurrency behavior.

* **Bug Fixes**
  * Updated chart metadata and resource names for improved Helm deployment consistency.
  * Standardized configuration references and environment paths across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->