### PR TITLE
fix: Lumen capacity tweaks

### DIFF
--- a/.github/workflows/test-lumen.yaml
+++ b/.github/workflows/test-lumen.yaml
@@ -1,0 +1,89 @@
+name: Test lumen Chart
+
+on:
+  pull_request:
+    paths:
+      - charts/lumen/**
+      - charts/wandb-base/**
+      - test-configs/lumen/**
+
+jobs:
+  snapshots:
+    name: Snapshot testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.20.1
+      - name: Helm snapshot build and test
+        run: |
+          helm plugin install https://github.com/origranot/helm-cascade
+          helm cascade build ./charts/lumen/
+          helm plugin install https://github.com/jlandowner/helm-chartsnap
+          ./snapshots.sh run lumen
+
+  test:
+    name: Test Chart
+    strategy:
+      fail-fast: false
+      max-parallel: 9
+      matrix:
+        k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
+        configuration:
+          [
+            "default",
+            "gcp-workload-identity",
+            "onprem",
+          ]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.k8s-version }}-${{ matrix.configuration }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.20.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        with:
+          version: v3.12.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          version: v0.27.0
+          cluster_name: chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }}
+          node_image: kindest/node:${{ matrix.k8s-version }}
+        if: env.ACT || steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        if: env.ACT || steps.list-changed.outputs.changed == 'true'
+        run: |
+          ct install --namespace default \
+          --charts ./charts/lumen \
+          --config ct.yaml \
+          --helm-extra-args '--kube-context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} --timeout 600s' \
+          --helm-extra-set-args '--values test-configs/lumen/${{ matrix.configuration }}.yaml'

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -27,13 +27,13 @@ processor:
       enabled: true
       schedule: "15 * * * *"
       concurrencyPolicy: "Forbid"
+      failedJobsHistoryLimit: 3
+      restartPolicy: "OnFailure"
+      backoffLimit: 5
+      successfulJobsHistoryLimit: 5
+      startingDeadlineSeconds: 300
       volumesTpls:
         - '{{ include "wandb.lumenStagingVolume" . }}'
-      failedJobsHistoryLimit: 1
-      successfulJobsHistoryLimit: 1
-      startingDeadlineSeconds: 300
-      ttlSecondsAfterFinished: 300
-      backoffLimit: 0
       containers:
         collector:
           command: ["/app/entrypoint.sh", "processor"]
@@ -53,11 +53,11 @@ processor:
             - '{{ include "wandb.lumenStagingVolumeMount" . }}'
           resources:
             requests:
-              cpu: 1
-              memory: 4Gi
+              cpu: 10
+              memory: 24Gi
             limits:
-              cpu: 2
-              memory: 4Gi
+              cpu: 14
+              memory: 48Gi
 
 # Notebook: marimo UI for browsing the parquet data root.
 notebook:
@@ -103,8 +103,8 @@ notebook:
           name: marimo
       resources:
         requests:
-          cpu: 1
-          memory: 2Gi
-        limits:
           cpu: 2
-          memory: 4Gi
+          memory: 12Gi
+        limits:
+          cpu: 8
+          memory: 24Gi

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -53,11 +53,11 @@ processor:
             - '{{ include "wandb.lumenStagingVolumeMount" . }}'
           resources:
             requests:
-              cpu: 10
-              memory: 24Gi
+              cpu: 8
+              memory: 12Gi
             limits:
-              cpu: 14
-              memory: 48Gi
+              cpu: 12
+              memory: 24Gi
 
 # Notebook: marimo UI for browsing the parquet data root.
 notebook:

--- a/test-configs/lumen/.chartsnap.yaml
+++ b/test-configs/lumen/.chartsnap.yaml
@@ -1,0 +1,15 @@
+# Mask the helm.sh/chart labels so bumping the chart (or subchart) version
+# doesn't churn every snapshot. The rest of the rendered output is deterministic
+# for the lumen chart (no randAlphaNum secrets), so nothing else needs masking.
+dynamicFields:
+  - jsonPath:
+      - /metadata/labels/helm.sh~1chart
+    value: "###CHART_VERSION###"
+  - kind: Deployment
+    jsonPath:
+      - /spec/template/metadata/labels/helm.sh~1chart
+    value: "###CHART_VERSION###"
+  - kind: CronJob
+    jsonPath:
+      - /spec/jobTemplate/spec/template/metadata/labels/helm.sh~1chart
+    value: "###CHART_VERSION###"

--- a/test-configs/lumen/__snapshots__/default.snap
+++ b/test-configs/lumen/__snapshots__/default.snap
@@ -1,0 +1,269 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: lumen/charts/notebook/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/charts/processor/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  LUMEN_DATA_ROOT: ""
+  LUMEN_STAGING_ROOT: "file:///vol/staging"
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-marimo-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  XDG_CONFIG_HOME: "/vol/staging/.config"
+  XDG_STATE_HOME: "/vol/staging/.local/state"
+  XDG_CACHE_HOME: "/vol/staging/.cache"
+---
+# Source: lumen/charts/notebook/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: marimo
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: lumen/charts/notebook/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notebook
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: notebook
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "v0.1.5"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: notebook
+        command:
+        - /app/entrypoint.sh
+        - marimo
+        envFrom:
+        - configMapRef:
+            name: chartsnap-configmap
+        - configMapRef:
+            name: chartsnap-marimo-configmap
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: marimo
+        resources:
+          limits:
+            cpu: 8
+            memory: 24Gi
+          requests:
+            cpu: 2
+            memory: 12Gi
+        volumeMounts:
+        - name: lumen-staging-dir
+          mountPath: /vol/staging
+      serviceAccountName: chartsnap-notebook
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: lumen-staging-dir
+        emptyDir: {}
+---
+# Source: lumen/charts/processor/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "15 * * * *"
+  suspend: false
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 5
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: processor
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/version: "v0.1.5"
+            app.kubernetes.io/managed-by: Helm
+        spec:
+          containers:
+          - name: collector
+            command:
+            - /app/entrypoint.sh
+            - processor
+            envFrom:
+            - configMapRef:
+                name: chartsnap-configmap
+            env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 12
+                memory: 24Gi
+              requests:
+                cpu: 8
+                memory: 12Gi
+            volumeMounts:
+            - name: lumen-staging-dir
+              mountPath: /vol/staging
+          restartPolicy: OnFailure
+          serviceAccountName: chartsnap-processor
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          volumes:
+          - name: lumen-staging-dir
+            emptyDir: {}

--- a/test-configs/lumen/__snapshots__/gcp-workload-identity.snap
+++ b/test-configs/lumen/__snapshots__/gcp-workload-identity.snap
@@ -60,7 +60,7 @@ data:
   credential-config.json: |
     {
       "type": "external_account",
-      "audience": "//iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider",
+      "audience": "//iam.googleapis.com/projects/00000/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider",
       "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
       "token_url": "https://sts.googleapis.com/v1/token",
       "credential_source": {

--- a/test-configs/lumen/__snapshots__/gcp-workload-identity.snap
+++ b/test-configs/lumen/__snapshots__/gcp-workload-identity.snap
@@ -1,0 +1,289 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: lumen/charts/notebook/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/charts/processor/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  LUMEN_DATA_ROOT: "gs://wandb-lumen-example"
+  LUMEN_STAGING_ROOT: "file:///vol/staging"
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-marimo-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  XDG_CONFIG_HOME: "/vol/staging/.config"
+  XDG_STATE_HOME: "/vol/staging/.local/state"
+  XDG_CACHE_HOME: "/vol/staging/.cache"
+---
+# Source: lumen/templates/wif.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-gcp-wif
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  credential-config.json: |
+    {
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "file": "/var/run/secrets/tokens/gcp-ksa/token",
+        "format": { "type": "text" }
+      }
+    }
+---
+# Source: lumen/charts/notebook/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: marimo
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: lumen/charts/notebook/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notebook
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: notebook
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "v0.1.5"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: notebook
+        command:
+        - /app/entrypoint.sh
+        - marimo
+        envFrom:
+        - configMapRef:
+            name: chartsnap-configmap
+        - configMapRef:
+            name: chartsnap-marimo-configmap
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: marimo
+        resources:
+          limits:
+            cpu: 8
+            memory: 24Gi
+          requests:
+            cpu: 2
+            memory: 12Gi
+        volumeMounts:
+        - name: lumen-staging-dir
+          mountPath: /vol/staging
+      serviceAccountName: chartsnap-notebook
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: lumen-staging-dir
+        emptyDir: {}
+---
+# Source: lumen/charts/processor/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "15 * * * *"
+  suspend: false
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 5
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: processor
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/version: "v0.1.5"
+            app.kubernetes.io/managed-by: Helm
+        spec:
+          containers:
+          - name: collector
+            command:
+            - /app/entrypoint.sh
+            - processor
+            envFrom:
+            - configMapRef:
+                name: chartsnap-configmap
+            env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 12
+                memory: 24Gi
+              requests:
+                cpu: 8
+                memory: 12Gi
+            volumeMounts:
+            - name: lumen-staging-dir
+              mountPath: /vol/staging
+          restartPolicy: OnFailure
+          serviceAccountName: chartsnap-processor
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          volumes:
+          - name: lumen-staging-dir
+            emptyDir: {}

--- a/test-configs/lumen/__snapshots__/onprem.snap
+++ b/test-configs/lumen/__snapshots__/onprem.snap
@@ -1,0 +1,269 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: lumen/charts/notebook/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/charts/processor/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  LUMEN_DATA_ROOT: "s3://customer-onprem-bucket/lumen"
+  LUMEN_STAGING_ROOT: "file:///vol/staging"
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-marimo-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  XDG_CONFIG_HOME: "/vol/staging/.config"
+  XDG_STATE_HOME: "/vol/staging/.local/state"
+  XDG_CACHE_HOME: "/vol/staging/.cache"
+---
+# Source: lumen/charts/notebook/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: marimo
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: lumen/charts/notebook/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notebook
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: notebook
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "v0.1.5"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: notebook
+        command:
+        - /app/entrypoint.sh
+        - marimo
+        envFrom:
+        - configMapRef:
+            name: chartsnap-configmap
+        - configMapRef:
+            name: chartsnap-marimo-configmap
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: marimo
+        resources:
+          limits:
+            cpu: 8
+            memory: 24Gi
+          requests:
+            cpu: 2
+            memory: 12Gi
+        volumeMounts:
+        - name: lumen-staging-dir
+          mountPath: /vol/staging
+      serviceAccountName: chartsnap-notebook
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: lumen-staging-dir
+        emptyDir: {}
+---
+# Source: lumen/charts/processor/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "15 * * * *"
+  suspend: false
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 5
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: processor
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/version: "v0.1.5"
+            app.kubernetes.io/managed-by: Helm
+        spec:
+          containers:
+          - name: collector
+            command:
+            - /app/entrypoint.sh
+            - processor
+            envFrom:
+            - configMapRef:
+                name: chartsnap-configmap
+            env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 12
+                memory: 24Gi
+              requests:
+                cpu: 8
+                memory: 12Gi
+            volumeMounts:
+            - name: lumen-staging-dir
+              mountPath: /vol/staging
+          restartPolicy: OnFailure
+          serviceAccountName: chartsnap-processor
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          volumes:
+          - name: lumen-staging-dir
+            emptyDir: {}

--- a/test-configs/lumen/default.yaml
+++ b/test-configs/lumen/default.yaml
@@ -1,0 +1,5 @@
+# Snapshot test values for the lumen chart: out-of-the-box defaults.
+# No data root and no GCP workload identity audience, so the WIF ConfigMap
+# is not rendered and LUMEN_DATA_ROOT stays empty.
+global:
+  repositoryPrefix: ""

--- a/test-configs/lumen/gcp-workload-identity.yaml
+++ b/test-configs/lumen/gcp-workload-identity.yaml
@@ -6,4 +6,4 @@ global:
   lumen:
     dataRoot: gs://wandb-lumen-example
     gcpWorkloadIdentity:
-      audience: //iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider
+      audience: //iam.googleapis.com/projects/00000/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider

--- a/test-configs/lumen/gcp-workload-identity.yaml
+++ b/test-configs/lumen/gcp-workload-identity.yaml
@@ -1,0 +1,9 @@
+# Snapshot test values for the lumen chart: GCP Workload Identity Federation.
+# Setting global.lumen.gcpWorkloadIdentity.audience renders the WIF ConfigMap
+# (credential-config.json) and a gs:// data root flows into LUMEN_DATA_ROOT.
+global:
+  repositoryPrefix: ""
+  lumen:
+    dataRoot: gs://wandb-lumen-example
+    gcpWorkloadIdentity:
+      audience: //iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider

--- a/test-configs/lumen/onprem.yaml
+++ b/test-configs/lumen/onprem.yaml
@@ -1,0 +1,9 @@
+# Snapshot test values for the lumen chart: on-prem / S3-compatible storage.
+# An s3:// data root with no GCP audience, so LUMEN_DATA_ROOT is populated but
+# the WIF ConfigMap is not rendered.
+global:
+  repositoryPrefix: ""
+  lumen:
+    dataRoot: s3://customer-onprem-bucket/lumen
+    gcpWorkloadIdentity:
+      audience: ""


### PR DESCRIPTION
Adjust cronjob configs and requests/limits for lumen notebook/processor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Helm chart validation for the Lumen chart across multiple Kubernetes versions and configurations.
  * Added snapshot coverage for default, on-premises, and GCP Workload Identity deployments.

* **Improvements**
  * Updated processor CronJob job history/behavior and timeout settings.
  * Increased processor and notebook CPU and memory resources for larger workloads.

* **Tests**
  * Stabilized chart snapshots by masking version-specific chart labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->