### PR TITLE
feat: opt-in leader election for gorilla migrate initContainers

### DIFF
--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
-digest: sha256:f996aeb5449178585664e12a9d53cc5ed2e2830fc6fc1561f6c4c0c8afde4d0e
-generated: "2026-07-06T12:05:12.893621-05:00"
+  version: 0.12.4
+digest: sha256:6c378616605bdde9cb62aa59528ac25bbb43f26b7e08610e58316d4be125561c
+generated: "2026-07-07T12:40:38.971107-07:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,16 +61,16 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -79,36 +79,36 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:195486c3d0cd6ec20d8bc84088907799f83c03e081f32af5ec37b40437ce808d
-generated: "2026-06-30T17:30:39.725847-05:00"
+digest: sha256:8575cf295ce8ecbff6838cf1eb5c12ea45237ed7e5e46cdb658bd4b776715b56
+generated: "2026-07-07T12:22:22.581531-07:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.1
+version: 0.43.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: console
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,15 +109,15 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: filestream
-    version: "0.12.3"
+    version: "0.12.4"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -137,47 +137,47 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -619,6 +619,12 @@ api:
     - '{{ include "wandb.registrySearchEnvs" . }}'
     - '{{ include "wandb.runStoreAcceleratorEnvs" . }}'
     - '{{ include "wandb.lumen.gorillaEnvs" .}}'
+  # Serializes migrate-db against other concurrent migrate copies in the
+  # namespace via a Kubernetes Lease. leaseName must match the migrate
+  # binary's lease name.
+  leaderElection:
+    enabled: false
+    leaseName: gorilla-migrate-leader
   initContainers:
     init-db:
       enabled: false
@@ -640,6 +646,12 @@ api:
             fi
             exit $EXIT_CODE
           fi
+      env:
+        GORILLA_LEADER_ELECTION_ENABLED: '{{ .Values.leaderElection.enabled }}'
+        GORILLA_LEADER_ELECTION_NAMESPACE:
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumeMounts:
         - name: temp-dir
           mountPath: /tmp/
@@ -2303,6 +2315,12 @@ glue:
     - '{{ include "wandb.registrySearchEnvs" . }}'
     - '{{ include "wandb.runStoreAcceleratorEnvs" . }}'
     - '{{ include "wandb.lumen.gorillaEnvs" .}}'
+  # Serializes migrate-db against other concurrent migrate copies in the
+  # namespace via a Kubernetes Lease. leaseName must match the migrate
+  # binary's lease name.
+  leaderElection:
+    enabled: false
+    leaseName: gorilla-migrate-leader
   initContainers:
     init-db:
       enabled: false
@@ -2324,6 +2342,12 @@ glue:
             fi
             exit $EXIT_CODE
           fi
+      env:
+        GORILLA_LEADER_ELECTION_ENABLED: '{{ .Values.leaderElection.enabled }}'
+        GORILLA_LEADER_ELECTION_NAMESPACE:
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumeMounts:
         - name: temp-dir
           mountPath: /tmp/

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 1.4.7
+version: 1.4.8
 appVersion: "1.0.0"
 maintainers:
   - name: wandb

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -26,6 +26,16 @@ role:
         - patch
         - update
         - watch
+    # The operator must hold lease permissions itself to grant them to
+    # components that enable leaderElection (RBAC escalation prevention).
+    - apiGroups:
+        - coordination.k8s.io
+      resources:
+        - leases
+      verbs:
+        - create
+        - get
+        - update
     - apiGroups:
         - ""
       resources:

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
+  version: 0.12.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.3
-digest: sha256:f587639b5e2723eda83f880578aaaf7b1efebd8bbbc5fa5c0b78d9793cb721f0
-generated: "2026-06-26T13:00:25.281355-05:00"
+  version: 0.12.4
+digest: sha256:cacd0c5539600e06bf59055669952dc9d78390387470ff8414dee8ebc49db6b4
+generated: "2026-07-07T12:21:57.820932-07:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.0.0
 
 maintainers:
@@ -18,14 +18,14 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.3"
+    version: "0.12.4"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.3"
+    version: "0.12.4"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.3"
+    version: "0.12.4"
     repository: "file://../wandb-base"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.3
+version: 0.12.4
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/leader-election-rbac.yaml
+++ b/charts/wandb-base/templates/leader-election-rbac.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.leaderElection.enabled }}
+# Grants the component's ServiceAccount the Lease permissions used by
+# client-go leader election. `create` cannot be scoped by resourceName,
+# so it is granted in a separate unscoped rule.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "wandb-base.fullname" . }}-leader-election
+  labels:
+    {{- include "wandb-base.labels" . | nindent 4 }}
+  {{- if (or .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .)) }}
+  annotations:
+    {{- tpl (include "wandb-base.commonAnnotations" . | nindent 4) . }}
+    {{- if .Values.helmHook.enabled }}
+      {{- include "wandb-base.helmHookAnnotations" . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    {{- with .Values.leaderElection.leaseName }}
+    resourceNames: ["{{ . }}"]
+    {{- end }}
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "wandb-base.fullname" . }}-leader-election
+  labels:
+    {{- include "wandb-base.labels" . | nindent 4 }}
+  {{- if (or .Values.helmHook.enabled (include "wandb-base.commonAnnotations" .)) }}
+  annotations:
+    {{- tpl (include "wandb-base.commonAnnotations" . | nindent 4) . }}
+    {{- if .Values.helmHook.enabled }}
+      {{- include "wandb-base.helmHookAnnotations" . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "wandb-base.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "wandb-base.fullname" . }}-leader-election
+{{- end }}

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -94,6 +94,13 @@ role:
   type: "Role"
   rules: []
 
+# Grants the ServiceAccount RBAC to contend for a coordination.k8s.io Lease
+# (see leader-election-rbac.yaml). When leaseName is set, get/update are
+# restricted to that Lease.
+leaderElection:
+  enabled: false
+  leaseName: ""
+
 podAnnotations: {}
 podAnnotationsTpls: []
 podLabels: {}

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2474,7 +2474,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3046,7 +3046,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3177,7 +3177,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3586,7 +3586,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3992,7 +3992,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2478,7 +2478,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3181,7 +3181,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3590,7 +3590,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3996,7 +3996,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -2869,7 +2869,7 @@ spec:
         app-common-annotation: app-common-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3469,7 +3469,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3617,7 +3617,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3753,7 +3753,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4267,7 +4267,7 @@ spec:
         global-pod-annotation: global-pod-annotation-value
         global-common-annotation: global-common-annotation-value
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4740,7 +4740,7 @@ spec:
             global-pod-annotation: global-pod-annotation-value
             global-common-annotation: global-common-annotation-value
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3242,7 +3242,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3414,7 +3414,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3907,6 +3907,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: GORILLA_PUBSUB_INSECURE
           value: "true"
         - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
@@ -4016,7 +4022,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4653,7 +4659,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4813,7 +4819,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5128,7 +5134,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5423,7 +5429,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.3
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5740,7 +5746,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.3
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6043,7 +6049,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6203,7 +6209,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6669,6 +6675,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: GORILLA_PUBSUB_INSECURE
           value: "true"
         - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
@@ -6780,7 +6792,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: metric-observer-0.12.3
+        helm.sh/chart: metric-observer-0.12.4
         app.kubernetes.io/name: metric-observer
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7100,7 +7112,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7250,7 +7262,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7777,7 +7789,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8284,7 +8296,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3113,7 +3113,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3263,7 +3263,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3728,6 +3728,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3821,7 +3827,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4414,7 +4420,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4552,7 +4558,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4845,7 +4851,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5116,7 +5122,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5254,7 +5260,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5692,6 +5698,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5785,7 +5797,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5913,7 +5925,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6418,7 +6430,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6881,7 +6893,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3241,7 +3241,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3706,6 +3706,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3799,7 +3805,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4392,7 +4398,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4530,7 +4536,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4823,7 +4829,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5094,7 +5100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5232,7 +5238,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5670,6 +5676,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5763,7 +5775,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5891,7 +5903,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6396,7 +6408,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6859,7 +6871,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3241,7 +3241,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3706,6 +3706,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3799,7 +3805,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4392,7 +4398,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4530,7 +4536,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4823,7 +4829,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5094,7 +5100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5232,7 +5238,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5670,6 +5676,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5763,7 +5775,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5891,7 +5903,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6396,7 +6408,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6859,7 +6871,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2478,7 +2478,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3181,7 +3181,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3590,7 +3590,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3996,7 +3996,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2512,7 +2512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3084,7 +3084,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3212,7 +3212,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3498,7 +3498,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3907,7 +3907,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4313,7 +4313,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2512,7 +2512,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3084,7 +3084,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3215,7 +3215,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.3
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3491,7 +3491,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3900,7 +3900,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4306,7 +4306,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2478,7 +2478,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3050,7 +3050,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3181,7 +3181,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3590,7 +3590,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3964,7 +3964,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -2981,7 +2981,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3131,7 +3131,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3598,6 +3598,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3694,7 +3700,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3832,7 +3838,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4125,7 +4131,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4396,7 +4402,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4534,7 +4540,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4974,6 +4980,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5070,7 +5082,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5198,7 +5210,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5703,7 +5715,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6166,7 +6178,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3241,7 +3241,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3708,6 +3708,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3804,7 +3810,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4393,7 +4399,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4531,7 +4537,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4824,7 +4830,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5095,7 +5101,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5233,7 +5239,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5673,6 +5679,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5769,7 +5781,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5897,7 +5909,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6402,7 +6414,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6865,7 +6877,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2543,7 +2543,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3115,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3245,7 +3245,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.3
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3421,7 +3421,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3830,7 +3830,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4236,7 +4236,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2543,7 +2543,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3115,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3245,7 +3245,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.3
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3421,7 +3421,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3830,7 +3830,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4236,7 +4236,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2543,7 +2543,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3115,7 +3115,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3245,7 +3245,7 @@ spec:
     metadata:
       annotations:
       labels:
-        helm.sh/chart: mcp-server-0.12.3
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -3419,7 +3419,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3828,7 +3828,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4234,7 +4234,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3420,7 +3420,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3885,6 +3885,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3978,7 +3984,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4571,7 +4577,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4709,7 +4715,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5147,6 +5153,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5243,7 +5255,7 @@ spec:
         ad.datadoghq.com/mcp-server.tags: "[\"product:wandb\",\"component:mcp-server\",\"deployment_type:dedicated-cloud\",\"customer:acme\",\"team:ml-platform\",\"region:us-west1\"]"
         ad.datadoghq.com/mcp-server.logs: "[{\"service\":\"wandb-mcp-server-onprem\",\"source\":\"python\"}]"
       labels:
-        helm.sh/chart: mcp-server-0.12.3
+        helm.sh/chart: mcp-server-0.12.4
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "0.3.5"
@@ -5451,7 +5463,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5579,7 +5591,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6084,7 +6096,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.3
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6331,7 +6343,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7141,7 +7153,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3241,7 +3241,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3706,6 +3706,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3799,7 +3805,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4392,7 +4398,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4530,7 +4536,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4823,7 +4829,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5094,7 +5100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5232,7 +5238,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5670,6 +5676,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5763,7 +5775,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5891,7 +5903,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6396,7 +6408,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6859,7 +6871,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3101,7 +3101,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3251,7 +3251,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3736,6 +3736,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3829,7 +3835,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4442,7 +4448,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4580,7 +4586,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4873,7 +4879,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5144,7 +5150,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5282,7 +5288,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5720,6 +5726,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5813,7 +5825,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5941,7 +5953,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6446,7 +6458,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6909,7 +6921,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3575,7 +3575,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3725,7 +3725,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4270,6 +4270,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4363,7 +4369,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4956,7 +4962,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5094,7 +5100,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5387,7 +5393,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5658,7 +5664,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5796,7 +5802,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6314,6 +6320,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6407,7 +6419,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6535,7 +6547,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7059,7 +7071,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.3
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7306,7 +7318,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8116,7 +8128,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -2997,7 +2997,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3542,6 +3542,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3635,7 +3641,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4228,7 +4234,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4367,7 +4373,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4505,7 +4511,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5023,6 +5029,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5116,7 +5128,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5244,7 +5256,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5749,7 +5761,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6212,7 +6224,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3364,7 +3364,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3524,7 +3524,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3999,6 +3999,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
           value: "true"
         - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
@@ -4102,7 +4108,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4715,7 +4721,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4863,7 +4869,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5166,7 +5172,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5449,7 +5455,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.3
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5740,7 +5746,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5888,7 +5894,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6336,6 +6342,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_STORE
           value: "true"
         - name: GORILLA_RUN_STORE_ONPREM_MIGRATE_CREATE_RUN_TABLES
@@ -6439,7 +6451,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6577,7 +6589,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7092,7 +7104,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7875,7 +7887,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3241,7 +3241,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3734,6 +3734,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3827,7 +3833,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4448,7 +4454,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4586,7 +4592,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4879,7 +4885,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5150,7 +5156,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5288,7 +5294,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5726,6 +5732,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5819,7 +5831,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5947,7 +5959,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6452,7 +6464,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6915,7 +6927,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2596,7 +2596,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3044,6 +3044,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3137,7 +3143,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3709,7 +3715,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3840,7 +3846,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4249,7 +4255,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4687,7 +4693,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2596,7 +2596,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3044,6 +3044,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3137,7 +3143,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3709,7 +3715,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3842,7 +3848,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4251,7 +4257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4689,7 +4695,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2596,7 +2596,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3044,6 +3044,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3137,7 +3143,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3709,7 +3715,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3842,7 +3848,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4251,7 +4257,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4689,7 +4695,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2710,7 +2710,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2852,7 +2852,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3429,7 +3429,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3564,7 +3564,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4063,7 +4063,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4514,7 +4514,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2836,7 +2836,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacdigest12"
@@ -2976,7 +2976,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3424,6 +3424,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3517,7 +3523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4089,7 +4095,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4217,7 +4223,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "execdigest12"
@@ -4503,7 +4509,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.3
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestream12"
@@ -4791,7 +4797,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.3
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "frfudigest12"
@@ -5064,7 +5070,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5485,6 +5491,12 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5580,7 +5592,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5989,7 +6001,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6555,7 +6567,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2836,7 +2836,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "anacondatag"
@@ -2976,7 +2976,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3424,6 +3424,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3517,7 +3523,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4089,7 +4095,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4217,7 +4223,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "executortag"
@@ -4503,7 +4509,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filestream-0.12.3
+        helm.sh/chart: filestream-0.12.4
         app.kubernetes.io/name: filestream
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "filestreamtag"
@@ -4791,7 +4797,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: flat-run-fields-updater-0.12.3
+        helm.sh/chart: flat-run-fields-updater-0.12.4
         app.kubernetes.io/name: flat-run-fields-updater
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "flatrunfieldsupdatertag"
@@ -5064,7 +5070,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5485,6 +5491,12 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5580,7 +5592,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5989,7 +6001,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6555,7 +6567,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2570,7 +2570,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3142,7 +3142,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3273,7 +3273,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3684,7 +3684,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4094,7 +4094,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.3
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4238,7 +4238,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2580,7 +2580,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3152,7 +3152,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3283,7 +3283,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3694,7 +3694,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4104,7 +4104,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.3
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4248,7 +4248,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2547,7 +2547,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3119,7 +3119,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3250,7 +3250,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3659,7 +3659,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4069,7 +4069,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.3
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4197,7 +4197,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2549,7 +2549,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3121,7 +3121,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3252,7 +3252,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3661,7 +3661,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4071,7 +4071,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: lumen-agent-0.12.3
+            helm.sh/chart: lumen-agent-0.12.4
             app.kubernetes.io/name: lumen-agent
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "v0.1.5"
@@ -4199,7 +4199,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-migrate-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-migrate-leader-election.snap
@@ -27,6 +27,27 @@ spec:
   - ports:
     - port: 6379
 ---
+# Source: operator-wandb/charts/api/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
 # Source: operator-wandb/charts/app/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -66,6 +87,69 @@ spec:
       operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/frontend/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-frontend
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/glue/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-glue
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: glue
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: glue
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/nginx/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: nginx
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
@@ -111,6 +195,19 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
+# Source: operator-wandb/charts/api/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
 # Source: operator-wandb/charts/app/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -137,16 +234,42 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
-# Source: operator-wandb/charts/lumen-agent/templates/serviceaccount.yaml
+# Source: operator-wandb/charts/frontend/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: lumen
+  name: chartsnap-frontend
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: lumen-agent
+    app.kubernetes.io/name: frontend
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/glue/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-glue
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: glue
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/nginx/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -225,6 +348,8 @@ metadata:
   name: chartsnap-bucket
   labels:
 data:
+  ACCESS_KEY: bWluaW8=
+  SECRET_KEY: dGVzdHBhc3N3b3Jk
 ---
 # Source: operator-wandb/templates/clickhouse.yaml
 apiVersion: v1
@@ -304,7 +429,7 @@ metadata:
   name: "chartsnap-redis-secret"
   labels:
 data:
-  REDIS_PASSWORD:
+  REDIS_PASSWORD: cmVkaXMxMjM=
   REDIS_CA_CERT:
 ---
 # Source: operator-wandb/templates/session-key.yaml
@@ -331,6 +456,32 @@ metadata:
   labels:
 data:
   SMTP_PASSWORD: ""
+---
+# Source: operator-wandb/charts/mysql/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-mysql-initdb
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+data:
+  my.cnf: |
+    [mysqld]
+    binlog_format = 'ROW'
+    innodb_online_alter_log_max_size = 268435456
+    sync_binlog = 1
+    innodb_flush_log_at_trx_commit = 1
+    binlog_row_image = 'MINIMAL'
+    local-infile = 1
+    sort_buffer_size = 33554432
+  # We need RELOAD, SELECT, and LOCK TABLES for making backups
+  initdb.sql: |
+    GRANT SESSION_VARIABLES_ADMIN,RELOAD,SELECT,LOCK TABLES ON *.* TO `wandb`@`%`;
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/configmap.yaml
 apiVersion: v1
@@ -1161,9 +1312,9 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
 data:
-  BUCKET_NAME: ""
+  BUCKET_NAME: "minio:9000/bucket"
   BUCKET_PATH: ""
-  AWS_REGION: ""
+  AWS_REGION: "us-east-1"
   AWS_S3_KMS_ID: ""
   GORILLA_DEFAULT_REGION: "minio-local"
 ---
@@ -1355,7 +1506,7 @@ data:
   GORILLA_STATSD_PORT: "0"
   GORILLA_LICENSE_CERT_PATH: /jwks.json
   # T-shirt size for deployment
-  GORILLA_TSHIRT_SIZE: "small"
+  GORILLA_TSHIRT_SIZE: "testing"
   GORILLA_ONPREM: "true"
   ONPREM: "true"
 ---
@@ -1439,7 +1590,7 @@ metadata:
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  GLUE_ENABLED: "true"
+  GLUE_ENABLED: "false"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
   LOCAL_K8S_SIGNER_SECRET_NAME: "chartsnap-internal-signer"
@@ -1455,7 +1606,7 @@ metadata:
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
-  LUMEN_DATA_ROOT: "gs://wandb-lumen-configs"
+  LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"
 ---
 # Source: operator-wandb/templates/lumen.yaml
@@ -1618,27 +1769,6 @@ data:
           valueHooks:
             - URIPassword
 ---
-# Source: operator-wandb/templates/lumen.yaml
-# WIF only needed for lumen dataRoot, not when using standard wandb-bucket
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-lumen-gcp-wif
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-data:
-  credential-config.json: |
-    {
-      "type": "external_account",
-      "audience": "//iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/aks-default-pool/providers/aks-default-provider",
-      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-      "token_url": "https://sts.googleapis.com/v1/token",
-      "credential_source": {
-        "file": "/var/run/secrets/tokens/gcp-ksa/token",
-        "format": { "type": "text" }
-      }
-    }
----
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -1668,10 +1798,26 @@ data:
         proxy_set_header Host $host:8080;
         client_max_body_size 0;
         location / {
-          proxy_pass http://chartsnap-app:8080;
+          proxy_pass http://chartsnap-frontend:8080;
         }
         location /console {
           proxy_pass http://chartsnap-console:8082;
+        }
+
+        location /api {
+          proxy_pass http://chartsnap-api:8081;
+        }
+
+        location /graphql {
+          proxy_pass http://chartsnap-api:8081;
+        }
+
+        location /graphql2 {
+          proxy_pass http://chartsnap-api:8081;
+        }
+        location /bucket {
+          proxy_set_header Host minio:9000;
+          proxy_pass http://minio:9000;
         }
       }
     }
@@ -1721,7 +1867,7 @@ data:
   PORT: "8080"
   API_PATH_PREFIX: "/traces"
   WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
-  WANDB_BASE_URL: "http://chartsnap-app:8080/"
+  WANDB_BASE_URL: "http://chartsnap-api:8081/"
   WF_TRACE_SERVER_URL: "http://localhost:8080/traces"
   WF_ENFORCE_PASSWORD_LENGTH: "false"
   WEAVE_ENABLE_ONLINE_EVAL: "false"
@@ -1731,7 +1877,7 @@ data:
   WANDB_INTERNAL_SERVICE_TOKEN_SECRET_NAME: "weave-worker-auth"
   KAFKA_BROKER_HOST: "bufstream.bufstream.svc.cluster.local"
   KAFKA_BROKER_PORT: "9092"
-  WEAVE_REDIS_URL: "redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
+  WEAVE_REDIS_URL: "redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
 ---
 # Source: operator-wandb/templates/weave.yaml
 apiVersion: v1
@@ -1742,13 +1888,32 @@ metadata:
 data:
   GORILLA_ONPREM: "true"
   PORT: "9994"
-  WANDB_BASE_URL: "http://chartsnap-app:8080/"
+  WANDB_BASE_URL: "http://chartsnap-api:8081/"
   WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
   WEAVE_LOG_FORMAT: "json"
   WEAVE_SERVER_NUM_WORKERS: "4"
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+---
+# Source: operator-wandb/charts/mysql/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chartsnap-mysql-data
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "20Gi"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1
@@ -2004,6 +2169,57 @@ subjects:
   name: system:unauthenticated
   apiGroup: rbac.authorization.k8s.io
 ---
+# Source: operator-wandb/charts/api/templates/leader-election-rbac.yaml
+# Grants the component's ServiceAccount the Lease permissions used by
+# client-go leader election. `create` cannot be scoped by resourceName,
+# so it is granted in a separate unscoped rule.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-api-leader-election
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: ["gorilla-migrate-leader"]
+  verbs: ["get", "update"]
+---
+# Source: operator-wandb/charts/api/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+---
 # Source: operator-wandb/charts/app/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2032,41 +2248,96 @@ rules:
   verbs:
   - get
 ---
-# Source: operator-wandb/charts/lumen-agent/templates/role.yaml
+# Source: operator-wandb/charts/glue/templates/leader-election-rbac.yaml
+# Grants the component's ServiceAccount the Lease permissions used by
+# client-go leader election. `create` cannot be scoped by resourceName,
+# so it is granted in a separate unscoped rule.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: chartsnap-lumen-agent
+  name: chartsnap-glue-leader-election
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: lumen-agent
+    app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: ["gorilla-migrate-leader"]
+  verbs: ["get", "update"]
+---
+# Source: operator-wandb/charts/glue/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-glue
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: glue
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - configmaps
   - secrets
   verbs:
   - get
-  - list
+  - create
+  - update
+  - delete
 - apiGroups:
-  - apps
+  - ""
   resources:
-  - replicasets
-  - deployments
+  - namespaces
   verbs:
   - get
-- apiGroups:
-  - apps.wandb.com
-  resources:
-  - weightsandbiases
-  verbs:
-  - get
-  - list
+---
+# Source: operator-wandb/charts/api/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-api-leader-election
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-api
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-api-leader-election
+---
+# Source: operator-wandb/charts/api/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-api
+  namespace: default
+roleRef:
+  kind: Role
+  name: chartsnap-api
+  apiGroup: rbac.authorization.k8s.io
 ---
 # Source: operator-wandb/charts/app/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2088,25 +2359,67 @@ roleRef:
   name: chartsnap-app
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: operator-wandb/charts/lumen-agent/templates/rolebinding.yaml
+# Source: operator-wandb/charts/glue/templates/leader-election-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: chartsnap-lumen-agent
+  name: chartsnap-glue-leader-election
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: lumen-agent
+    app.kubernetes.io/name: glue
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
-  name: lumen
+  name: chartsnap-glue
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-glue-leader-election
+---
+# Source: operator-wandb/charts/glue/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-glue
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: glue
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-glue
   namespace: default
 roleRef:
   kind: Role
-  name: chartsnap-lumen-agent
+  name: chartsnap-glue
   apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/api/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8081
+    protocol: TCP
+    targetPort: api
+  selector:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/app/templates/service.yaml
 apiVersion: v1
@@ -2157,6 +2470,75 @@ spec:
     protocol: TCP
   selector:
     app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/frontend/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-frontend
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: frontend
+  selector:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/mysql/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-mysql
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: mysql
+  selector:
+    helm.sh/chart: mysql-0.1.0
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: operator-wandb/charts/nginx/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/service.yaml
@@ -2445,7 +2827,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: daemonset
-        image: "otel/opentelemetry-collector-contrib:0.97.0"
+        image: "us-docker.pkg.dev/wandb-production/public/otel/opentelemetry-collector-contrib:0.97.0"
         securityContext:
           capabilities:
           allowPrivilegeEscalation: false
@@ -2540,6 +2922,572 @@ spec:
         hostPath:
           path: /var/lib/docker/containers
       hostNetwork: false
+---
+# Source: operator-wandb/charts/api/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      annotations:
+        lumen.wandb.ai/agent: "true"
+      labels:
+        helm.sh/chart: api-0.12.4
+        app.kubernetes.io/name: api
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: api
+        args:
+        - gorilla
+        envFrom:
+        - configMapRef:
+            name: chartsnap-api-configmap
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - secretRef:
+            name: chartsnap-gorilla-session-key
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LIMITER
+          value: noop://
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+              name: gorilla-coreweave-observability
+              optional: true
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: api
+          protocol: TCP
+        - containerPort: 16060
+          name: lumen
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: api
+          periodSeconds: 5
+          successThreshold: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      initContainers:
+      - name: migrate-db
+        command:
+        - bash
+        - -c
+        - |
+          LOG_FILE="/tmp/migrate.log"
+          ./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE --usage-db=$GORILLA_USAGE_STORE 2>&1 | tee -a $LOG_FILE
+          EXIT_CODE=${PIPESTATUS[0]}
+          MIGRATION_FILE_MISSING_ERROR_CODE=101
+          if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq $MIGRATION_FILE_MISSING_ERROR_CODE ]]; then
+            exit 0
+          else
+            # missing migration error log from golang-migrate@v4 -- older versions of megabinary
+            if grep -q "no migration found for version" $LOG_FILE; then
+              exit 0
+            fi
+            exit $EXIT_CODE
+          fi
+        envFrom:
+        - configMapRef:
+            name: chartsnap-api-configmap
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - secretRef:
+            name: chartsnap-gorilla-session-key
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LIMITER
+          value: noop://
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+              name: gorilla-coreweave-observability
+              optional: true
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "true"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      serviceAccountName: chartsnap-api
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: api
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: api
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - emptyDir: {}
+        name: temp-dir
 ---
 # Source: operator-wandb/charts/app/templates/deployment.yaml
 apiVersion: apps/v1
@@ -2651,13 +3599,11 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -2688,23 +3634,23 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
         - name: KAFKA_CLIENT_PASSWORD
@@ -2760,20 +3706,34 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_PROXY
+          value: "true"
         - name: BUCKET_QUEUE
           value: "internal://"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_FILEMETA_ENABLED
+          value: "false"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
         - name: GORILLA_GLUE_CONTAINER_PORT
           value: "8083"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
+        - name: GORILLA_STORAGE_BUCKET
+          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -2785,7 +3745,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/local:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -2827,12 +3787,9 @@ spec:
               - sleep
               - "25"
         resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
           requests:
-            cpu: "1"
-            memory: 2Gi
+            cpu: 100m
+            memory: 128Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -2924,13 +3881,11 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -2961,23 +3916,23 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
         - name: KAFKA_CLIENT_PASSWORD
@@ -3033,20 +3988,34 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_PROXY
+          value: "true"
         - name: BUCKET_QUEUE
           value: "internal://"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_FILEMETA_ENABLED
+          value: "false"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
         - name: GORILLA_GLUE_CONTAINER_PORT
           value: "8083"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
+        - name: GORILLA_STORAGE_BUCKET
+          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -3058,7 +4027,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/local:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: wandb-ca-certs-root
@@ -3152,6 +4121,16 @@ spec:
         - configMapRef:
             name: chartsnap-console-configmap
         env:
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3159,7 +4138,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/console:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8082
@@ -3241,6 +4220,807 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
+---
+# Source: operator-wandb/charts/frontend/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-frontend
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: frontend-0.12.4
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: frontend
+        envFrom:
+        - configMapRef:
+            name: chartsnap-frontend-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: frontend
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /docker-entrypoint.d/02_patch_env_js.sh
+          name: wandb-setup-scripts
+          subPath: 02_patch_env_js.sh
+      serviceAccountName: chartsnap-frontend
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: frontend
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - configMap:
+          defaultMode: 493
+          items:
+          - key: 02_patch_env_js.sh
+            path: 02_patch_env_js.sh
+          name: 'chartsnap-frontend-patch-env-js'
+        name: wandb-setup-scripts
+---
+# Source: operator-wandb/charts/glue/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-glue
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: glue
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: glue
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      annotations:
+        lumen.wandb.ai/agent: "true"
+      labels:
+        helm.sh/chart: glue-0.12.4
+        app.kubernetes.io/name: glue
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: glue
+        args:
+        - glue
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-glue-configmap
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 16060
+          name: lumen
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      initContainers:
+      - name: migrate-db
+        command:
+        - bash
+        - -c
+        - |
+          LOG_FILE="/tmp/migrate.log"
+          ./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE --usage-db=$GORILLA_USAGE_STORE 2>&1 | tee -a $LOG_FILE
+          EXIT_CODE=${PIPESTATUS[0]}
+          MIGRATION_FILE_MISSING_ERROR_CODE=101
+          if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq $MIGRATION_FILE_MISSING_ERROR_CODE ]]; then
+            exit 0
+          else
+            # missing migration error log from golang-migrate@v4 -- older versions of megabinary
+            if grep -q "no migration found for version" $LOG_FILE; then
+              exit 0
+            fi
+            exit $EXIT_CODE
+          fi
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-glue-configmap
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "true"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      serviceAccountName: chartsnap-glue
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: glue
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: glue
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - emptyDir: {}
+        name: temp-dir
+---
+# Source: operator-wandb/charts/nginx/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: nginx-0.12.4
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: nginx
+        envFrom:
+        env:
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /etc/nginx/nginx.conf
+          name: nginx-config
+          subPath: nginx.conf
+      serviceAccountName: chartsnap-nginx
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: nginx
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - configMap:
+          name: 'chartsnap-nginx-configmap'
+        name: nginx-config
 ---
 # Source: operator-wandb/charts/parquet/templates/deployment.yaml
 apiVersion: apps/v1
@@ -3346,13 +5126,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_NAME)
+          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3383,23 +5163,23 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
         - name: KAFKA_CLIENT_PASSWORD
@@ -3455,7 +5235,15 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
-        - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
         securityContext:
           allowPrivilegeEscalation: false
@@ -3464,7 +5252,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/megabinary:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8087
@@ -3492,12 +5280,9 @@ spec:
           successThreshold: 1
           timeoutSeconds: 30
         resources:
-          limits:
-            cpu: "4"
-            memory: 16Gi
           requests:
-            cpu: "1"
-            memory: 8Gi
+            cpu: 100m
+            memory: 128Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -3700,6 +5485,16 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3707,7 +5502,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/weave-python:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9994
@@ -3728,12 +5523,9 @@ spec:
             port: http
           periodSeconds: 10
         resources:
-          limits:
-            cpu: "4"
-            memory: 16Gi
           requests:
-            cpu: "1"
-            memory: 8Gi
+            cpu: 100m
+            memory: 128Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -3762,6 +5554,16 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3769,7 +5571,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "wandb/weave-python:latest"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -3841,69 +5643,109 @@ spec:
           sizeLimit: '20Gi'
         name: cache
 ---
-# Source: operator-wandb/charts/parquet/templates/hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
+# Source: operator-wandb/charts/mysql/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
-  name: chartsnap-parquet
+  name: chartsnap-mysql
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: parquet
+    app.kubernetes.io/name: mysql
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
     app.kubernetes.io/managed-by: Helm
 spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: chartsnap-parquet-bc
-  minReplicas: 2
-  maxReplicas: 2
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 80
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
----
-# Source: operator-wandb/charts/weave/templates/hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: chartsnap-weave
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: weave
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: chartsnap-weave-bc
-  minReplicas: 2
-  maxReplicas: 2
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 80
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/instance: chartsnap
+      helm.sh/chart: mysql-0.1.0
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/version: "1.16.0"
+      wandb.com/app-name: mysql-0.1.0
+      app.kubernetes.io/managed-by: Helm
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: mysql-0.1.0
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "1.16.0"
+        wandb.com/app-name: mysql-0.1.0
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 0
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+      containers:
+      - name: mysql
+        image: "us-docker.pkg.dev/wandb-production/public/mysql:latest"
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: mysql
+          containerPort: 3306
+          protocol: TCP
+        env:
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "chartsnap-mysql"
+              key: "MYSQL_PASSWORD"
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: "chartsnap-mysql"
+        - name: MYSQL_DATABASE
+          value: "wandb_local"
+        - name: MYSQL_USER
+          value: "wandb"
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-mysql
+              key: MYSQL_ROOT_PASSWORD
+        livenessProbe:
+          tcpSocket:
+            port: 3306
+        readinessProbe:
+          tcpSocket:
+            port: 3306
+        startupProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          failureThreshold: 60
+          tcpSocket:
+            port: 3306
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        - name: initdb
+          mountPath: /docker-entrypoint-initdb.d/initdb.sql
+          subPath: initdb.sql
+        - name: initdb
+          mountPath: /etc/mysql/my.cnf
+          subPath: my.cnf
+        resources:
+          limits:
+            cpu: 4000m
+            memory: 8Gi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      volumes:
+      - name: initdb
+        configMap:
+          name: chartsnap-mysql-initdb
+      - name: data
+        persistentVolumeClaim:
+          claimName: chartsnap-mysql-data
 ---
 # Source: operator-wandb/charts/redis/templates/master/application.yaml
 apiVersion: apps/v1
@@ -3967,7 +5809,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: redis
-        image: docker.io/bitnamilegacy/redis:7.2.4-debian-12-r9
+        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/redis:7.2.4-debian-12-r9
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -4068,154 +5910,6 @@ spec:
         requests:
           storage: "8Gi"
 ---
-# Source: operator-wandb/charts/lumen-agent/templates/cronjob.yaml
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: chartsnap-lumen-agent
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: lumen-agent
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "v0.1.5"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  concurrencyPolicy: Forbid
-  schedule: "0 * * * *"
-  suspend: false
-  successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 3
-  startingDeadlineSeconds: 300
-  jobTemplate:
-    spec:
-      backoffLimit: 5
-      template:
-        metadata:
-          labels:
-            helm.sh/chart: lumen-agent-0.12.4
-            app.kubernetes.io/name: lumen-agent
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/version: "v0.1.5"
-            app.kubernetes.io/managed-by: Helm
-        spec:
-          containers:
-          - name: collector
-            command:
-            - /app/entrypoint.sh
-            - agent
-            envFrom:
-            - configMapRef:
-                name: chartsnap-bucket-configmap
-            - configMapRef:
-                name: chartsnap-lumen-configmap
-            env:
-            - name: AZURE_STORAGE_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: ACCESS_KEY
-                  name: chartsnap-bucket
-                  optional: true
-            - name: BUCKET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: ACCESS_KEY
-                  name: chartsnap-bucket
-                  optional: true
-            - name: BUCKET_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: SECRET_KEY
-                  name: chartsnap-bucket
-                  optional: true
-            - name: BUCKET
-              value: s3://$(BUCKET_NAME)
-            - name: GORILLA_FILE_STORE
-              value: s3://$(BUCKET_NAME)
-            - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-              value: s3://$(BUCKET_NAME)
-            - name: GORILLA_STORAGE_BUCKET
-              value: s3://$(BUCKET_NAME)
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-            - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: "/var/secrets/gcp/credential-config.json"
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add: []
-                drop: []
-              privileged: false
-              readOnlyRootFilesystem: false
-            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
-            imagePullPolicy: IfNotPresent
-            resources:
-              limits:
-                cpu: 2
-                memory: 4Gi
-              requests:
-                cpu: 1
-                memory: 4Gi
-            volumeMounts:
-            - name: lumen-staging-dir
-              mountPath: /vol/staging
-            - name: gcp-ksa
-              mountPath: /var/run/secrets/tokens/gcp-ksa
-              readOnly: true
-            - name: gcp-wif-config
-              mountPath: /var/secrets/gcp
-              readOnly: true
-            - name: lumen-managed-install
-              mountPath: /app/definitions/collector/managed-install.yaml
-              subPath: managed-install.yaml
-              readOnly: true
-          restartPolicy: OnFailure
-          serviceAccountName: lumen
-          securityContext:
-            fsGroup: 0
-            fsGroupChangePolicy: OnRootMismatch
-            runAsGroup: 0
-            runAsNonRoot: true
-            runAsUser: 999
-            seccompProfile:
-              type: RuntimeDefault
-          topologySpreadConstraints:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: lumen-agent
-            maxSkew: 1
-            topologyKey: topology.kubernetes.io/zone
-            whenUnsatisfiable: ScheduleAnyway
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: lumen-agent
-            maxSkew: 1
-            topologyKey: kubernetes.io/hostname
-            whenUnsatisfiable: ScheduleAnyway
-          volumes:
-          - name: lumen-staging-dir
-            emptyDir: {}
-          - name: gcp-ksa
-            projected:
-              sources:
-              - serviceAccountToken:
-                  path: token
-                  expirationSeconds: 3600
-                  audience: //iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/aks-default-pool/providers/aks-default-provider
-          - name: gcp-wif-config
-            configMap:
-              name: "chartsnap-lumen-gcp-wif"
-          - name: lumen-managed-install
-            configMap:
-              name: "chartsnap-lumen-rules"
----
 # Source: operator-wandb/charts/parquet/templates/cronjob.yaml
 apiVersion: batch/v1
 kind: CronJob
@@ -4313,13 +6007,13 @@ spec:
                   name: chartsnap-bucket
                   optional: true
             - name: BUCKET
-              value: s3://$(BUCKET_NAME)
+              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
             - name: GORILLA_FILE_STORE
-              value: s3://$(BUCKET_NAME)
+              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-              value: s3://$(BUCKET_NAME)
+              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
             - name: GORILLA_STORAGE_BUCKET
-              value: s3://$(BUCKET_NAME)
+              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -4350,23 +6044,23 @@ spec:
                   name: chartsnap-redis-secret
                   optional: true
             - name: REDIS
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_AUDITOR_CACHE
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_CACHE
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_FILE_METADATA_SOURCE
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_LOCKER
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_METADATA_CACHE
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_SETTINGS_CACHE
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_USAGE_METRICS_CACHE
-              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_TASK_QUEUE
               value: noop://
             - name: KAFKA_CLIENT_PASSWORD
@@ -4422,12 +6116,20 @@ spec:
               value: /etc/ssl/certs/ca-certificates.crt
             - name: GORILLA_LUMEN_ADDR
               value: :16060
-            - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
+            - name: BUCKET_PROXY
+              value: "true"
+            - name: GLOBAL_ADMIN_API_KEY
+              value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+            - name: GORILLA_FILE_STORE_IS_PROXIED
               value: "true"
             - name: GORILLA_GLUE_EXECUTE
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+              value: "true"
+            - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+              value: "true"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -4435,7 +6137,7 @@ spec:
                 drop: []
               privileged: false
               readOnlyRootFilesystem: false
-            image: "wandb/megabinary:latest"
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -4496,34 +6198,6 @@ spec:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
               optional: true
----
-# Source: operator-wandb/templates/ingress.yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: chartsnap
-  labels:
-spec:
-  ingressClassName:
-  tls: []
-  rules:
-  - host: localhost:8080
-    http:
-      paths:
-      - pathType: Prefix
-        path: /
-        backend:
-          service:
-            name: chartsnap-app
-            port:
-              number: 8080
-      - pathType: Prefix
-        path: /console
-        backend:
-          service:
-            name: chartsnap-console
-            port:
-              number: 8082
 ---
 # Source: operator-wandb/charts/appRenamePostHook/templates/serviceaccount.yaml
 apiVersion: v1
@@ -4738,7 +6412,7 @@ spec:
     - name: WANDB_BASE_URL
       value: "http://chartsnap-nginx:8080"
     - name: WANDB_API_KEY
-      value: ""
+      value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
     command:
     - sh
     - -c
@@ -4778,6 +6452,16 @@ spec:
         - /cleanup-scripts/post_upgrade.sh
         envFrom:
         env:
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4785,8 +6469,12 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "alpine/k8s:1.31.12"
+        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
         volumeMounts:
         - mountPath: /cleanup-scripts
           name: app-rename-cleanup
@@ -4854,6 +6542,16 @@ spec:
         - /cleanup-scripts/pre_upgrade.sh
         envFrom:
         env:
+        - name: BUCKET_PROXY
+          value: "true"
+        - name: GLOBAL_ADMIN_API_KEY
+          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+        - name: GORILLA_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_GLUE_FILE_STORE_IS_PROXIED
+          value: "true"
+        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4861,8 +6559,12 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "alpine/k8s:1.31.12"
+        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
         volumeMounts:
         - mountPath: /cleanup-scripts
           name: app-rename-cleanup

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2680,7 +2680,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3152,6 +3152,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3254,7 +3260,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3863,7 +3869,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4013,7 +4019,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4440,7 +4446,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4917,7 +4923,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2597,7 +2597,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3045,6 +3045,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3138,7 +3144,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3710,7 +3716,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3841,7 +3847,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4250,7 +4256,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4688,7 +4694,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2612,7 +2612,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3080,6 +3080,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3173,7 +3179,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3765,7 +3771,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3896,7 +3902,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4305,7 +4311,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4743,7 +4749,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2612,7 +2612,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3080,6 +3080,12 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3173,7 +3179,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3765,7 +3771,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3896,7 +3902,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4305,7 +4311,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4743,7 +4749,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2711,7 +2711,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -2854,7 +2854,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3432,7 +3432,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3568,7 +3568,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4068,7 +4068,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4521,7 +4521,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2487,7 +2487,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3069,7 +3069,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3200,7 +3200,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3614,7 +3614,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4020,7 +4020,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2478,7 +2478,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3054,7 +3054,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3185,7 +3185,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3596,7 +3596,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4002,7 +4002,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -2953,7 +2953,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3108,7 +3108,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3561,6 +3561,12 @@ spec:
               optional: true
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3660,7 +3666,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4252,7 +4258,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4398,7 +4404,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4673,7 +4679,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5099,6 +5105,12 @@ spec:
           value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5205,7 +5217,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5715,7 +5727,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6188,7 +6200,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3091,7 +3091,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3241,7 +3241,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3706,6 +3706,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3799,7 +3805,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4392,7 +4398,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4530,7 +4536,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4823,7 +4829,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5094,7 +5100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5232,7 +5238,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5670,6 +5676,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5763,7 +5775,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5891,7 +5903,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6396,7 +6408,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6861,7 +6873,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2532,7 +2532,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3104,7 +3104,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3235,7 +3235,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3644,7 +3644,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.3
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3891,7 +3891,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4329,7 +4329,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3439,7 +3439,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3589,7 +3589,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4110,6 +4110,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4203,7 +4209,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4802,7 +4808,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4940,7 +4946,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5236,7 +5242,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5510,7 +5516,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5648,7 +5654,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6142,6 +6148,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6235,7 +6247,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6363,7 +6375,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6871,7 +6883,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7684,7 +7696,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3840,7 +3840,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3990,7 +3990,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4455,6 +4455,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4548,7 +4554,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5141,7 +5147,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5279,7 +5285,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5572,7 +5578,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5843,7 +5849,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5981,7 +5987,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6419,6 +6425,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6512,7 +6524,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6640,7 +6652,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7145,7 +7157,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-evaluate-model-worker-0.12.3
+        helm.sh/chart: weave-evaluate-model-worker-0.12.4
         app.kubernetes.io/name: weave-evaluate-model-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7296,7 +7308,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-worker-0.12.3
+        helm.sh/chart: weave-trace-worker-0.12.4
         app.kubernetes.io/name: weave-trace-worker
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7456,7 +7468,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.3
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7703,7 +7715,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -8813,7 +8825,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3533,7 +3533,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: anaconda2-0.12.3
+        helm.sh/chart: anaconda2-0.12.4
         app.kubernetes.io/name: anaconda2
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -3683,7 +3683,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: api-0.12.3
+        helm.sh/chart: api-0.12.4
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4148,6 +4148,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4241,7 +4247,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: app-0.12.3
+        helm.sh/chart: app-0.12.4
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4834,7 +4840,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: console-0.12.3
+        helm.sh/chart: console-0.12.4
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -4972,7 +4978,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: executor-0.12.3
+        helm.sh/chart: executor-0.12.4
         app.kubernetes.io/name: executor
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5265,7 +5271,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: filemeta-0.12.3
+        helm.sh/chart: filemeta-0.12.4
         app.kubernetes.io/name: filemeta
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5536,7 +5542,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: frontend-0.12.3
+        helm.sh/chart: frontend-0.12.4
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -5674,7 +5680,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: glue-0.12.3
+        helm.sh/chart: glue-0.12.4
         app.kubernetes.io/name: glue
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6112,6 +6118,12 @@ spec:
           value: "true"
         - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
           value: "true"
+        - name: GORILLA_LEADER_ELECTION_ENABLED
+          value: "false"
+        - name: GORILLA_LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6205,7 +6217,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: nginx-0.12.3
+        helm.sh/chart: nginx-0.12.4
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6333,7 +6345,7 @@ spec:
       annotations:
         lumen.wandb.ai/agent: "true"
       labels:
-        helm.sh/chart: parquet-0.12.3
+        helm.sh/chart: parquet-0.12.4
         app.kubernetes.io/name: parquet
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -6838,7 +6850,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-trace-0.12.3
+        helm.sh/chart: weave-trace-0.12.4
         app.kubernetes.io/name: weave-trace
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7085,7 +7097,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: weave-0.12.3
+        helm.sh/chart: weave-0.12.4
         app.kubernetes.io/name: weave
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -7895,7 +7907,7 @@ spec:
       template:
         metadata:
           labels:
-            helm.sh/chart: parquet-0.12.3
+            helm.sh/chart: parquet-0.12.4
             app.kubernetes.io/name: parquet
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/version: "latest"

--- a/test-configs/operator-wandb/snap-migrate-leader-election.yaml
+++ b/test-configs/operator-wandb/snap-migrate-leader-election.yaml
@@ -1,0 +1,64 @@
+global:
+  repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
+  imageRegistry: "us-docker.pkg.dev/wandb-production/public"
+  bucket:
+    provider: "s3"
+    name: "minio:9000/bucket"
+    region: "us-east-1"
+    accessKey: "minio"
+    secretKey: "testpassword"
+  env:
+    GLOBAL_ADMIN_API_KEY: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+    GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS: "true"
+    BUCKET_PROXY: "true"
+    GORILLA_GLUE_FILE_STORE_IS_PROXIED: "true"
+    GORILLA_FILE_STORE_IS_PROXIED: "true"
+  redis:
+    password: "redis123"
+  glue:
+    enabled: true
+  api:
+    enabled: true
+  size: "testing"
+
+api:
+  leaderElection:
+    enabled: true
+
+glue:
+  leaderElection:
+    enabled: true
+
+app:
+  env:
+    GORILLA_STORAGE_BUCKET: "s3://local-files"
+    GORILLA_FILEMETA_ENABLED: "false"
+
+frontend:
+  install: true
+
+nginx:
+  install: true
+  additionalServices:
+    bucket:
+      host: "http://minio:9000"
+      headers:
+        Host: "minio:9000"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+redis:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -6,7 +6,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.3
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -27,7 +27,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.3
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -48,7 +48,7 @@ kind: PodDisruptionBudget
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.3
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -69,7 +69,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.3
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -95,7 +95,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.3
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -108,7 +108,7 @@ kind: ServiceAccount
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.3
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -121,7 +121,7 @@ kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: orchestrator-1.2.2
+    helm.sh/chart: orchestrator-1.2.3
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -136,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: orchestrator-1.2.2
+    helm.sh/chart: orchestrator-1.2.3
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -311,7 +311,7 @@ kind: Service
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.3
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -369,7 +369,7 @@ kind: Service
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.3
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -391,7 +391,7 @@ kind: Service
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.3
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -495,7 +495,7 @@ kind: Deployment
 metadata:
   name: chartsnap-identity
   labels:
-    helm.sh/chart: identity-0.12.3
+    helm.sh/chart: identity-0.12.4
     app.kubernetes.io/name: identity
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -516,7 +516,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: identity-0.12.3
+        helm.sh/chart: identity-0.12.4
         app.kubernetes.io/name: identity
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -628,7 +628,7 @@ kind: Deployment
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.3
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -649,7 +649,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: web-0.12.3
+        helm.sh/chart: web-0.12.4
         app.kubernetes.io/name: web
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -714,7 +714,7 @@ kind: Deployment
 metadata:
   name: chartsnap-workspace-engine
   labels:
-    helm.sh/chart: workspace-engine-0.12.3
+    helm.sh/chart: workspace-engine-0.12.4
     app.kubernetes.io/name: workspace-engine
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -735,7 +735,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: workspace-engine-0.12.3
+        helm.sh/chart: workspace-engine-0.12.4
         app.kubernetes.io/name: workspace-engine
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/version: "latest"
@@ -865,7 +865,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: chartsnap-web
   labels:
-    helm.sh/chart: web-0.12.3
+    helm.sh/chart: web-0.12.4
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
@@ -897,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: orchestrator-1.2.2
+    helm.sh/chart: orchestrator-1.2.3
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"

--- a/test-configs/wandb-base/__snapshots__/leader-election.snap
+++ b/test-configs/wandb-base/__snapshots__/leader-election.snap
@@ -1,0 +1,149 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/leader-election-rbac.yaml
+# Grants the component's ServiceAccount the Lease permissions used by
+# client-go leader election. `create` cannot be scoped by resourceName,
+# so it is granted in a separate unscoped rule.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-wandb-base-leader-election
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: ["gorilla-migrate-leader"]
+  verbs: ["get", "update"]
+---
+# Source: wandb-base/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-wandb-base-leader-election
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-wandb-base
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-wandb-base-leader-election
+---
+# Source: wandb-base/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: app
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - sleep infinity
+        envFrom:
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "debian:12-slim"
+        imagePullPolicy:
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/leader-election.yaml
+++ b/test-configs/wandb-base/leader-election.yaml
@@ -1,0 +1,14 @@
+leaderElection:
+  enabled: true
+  leaseName: gorilla-migrate-leader
+
+containers:
+  app:
+    image:
+      repository: debian
+      tag: 12-slim
+    command:
+      - /bin/bash
+    args:
+      - -c
+      - sleep infinity


### PR DESCRIPTION
## What

Adds opt-in leader election so concurrent `migrate-db` initContainers (api, glue)
serialize DB migrations via a Kubernetes Lease instead of racing.

## How

- New `leader-election-rbac.yaml` template in `wandb-base` — any component can set
  `leaderElection.enabled: true` to grant its ServiceAccount the lease permissions
  (scoped to `leaseName` where possible)
- `api` / `glue` wire `GORILLA_LEADER_ELECTION_*` env into `migrate-db`, driven by
  the same flag — one switch enables both RBAC and behavior
- Operator role gains `coordination.k8s.io/leases` so it can delegate the grant
  (RBAC escalation prevention)

Off by default; no behavior change unless enabled. Requires megabinary with
leader-election support in `migrate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added leader election support for select services, including configurable lease settings and related permissions.
  * Introduced updated chart versions and dependency refreshes across multiple components.

* **Bug Fixes**
  * Improved deployment reliability by ensuring required lease access is available when leader election is enabled.

* **Tests**
  * Added new test configurations covering leader election and operator deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->