### PR TITLE
chore(mcp-server): right-size CPU/memory requests (idle at ~1% of reservation)

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.1
+version: 0.43.2
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -3114,8 +3114,8 @@ mcp-server:
         periodSeconds: 10
       resources:
         requests:
-          cpu: 500m
-          memory: 1Gi
+          cpu: 50m
+          memory: 512Mi
         limits:
           cpu: 2
           memory: 4Gi

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -3333,8 +3333,8 @@ spec:
             cpu: 2
             memory: 4Gi
           requests:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 50m
+            memory: 512Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -3333,8 +3333,8 @@ spec:
             cpu: 2
             memory: 4Gi
           requests:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 50m
+            memory: 512Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -3331,8 +3331,8 @@ spec:
             cpu: 2
             memory: 4Gi
           requests:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 50m
+            memory: 512Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -5365,8 +5365,8 @@ spec:
             cpu: 2
             memory: 4Gi
           requests:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 50m
+            memory: 512Mi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/


### PR DESCRIPTION
## What
Lower the default `mcp-server` resource **requests** from `500m / 1Gi` → `50m / 512Mi`. Limits unchanged (`cpu: 2 / memory: 4Gi`), so burst headroom is preserved.

## Why
On managed-install (dedicated), mcp-server runs one pod per cluster and sits idle. Datadog (us5, 30-day avg):
- **CPU:** ~199 cores requested fleet-wide vs **~2.8 used** → ~70× over. Per-pod: 500m requested vs **~5 millicores** peak.
- **Memory:** ~427 GB requested vs ~78 GB used → ~5× over. Per-pod: 1Gi requested vs **~192 MiB** working set.

The oversized **requests** (not usage) reserved node capacity and contributed to the 2026-07-06/07 "pods pending" node-ceiling incident. `50m` still leaves ~10× headroom over the ~5m peak; `512Mi` is ~2.5× the ~192 MiB working set. Reclaims ~180 cores fleet-wide (≈$50–76k/yr).

Full write-up + Datadog evidence: DD notebook 300930. This is the capacity-planning follow-up to wandb/core#47476 (which raised the node ceiling 6→20).

## Safety
Requests-only change; limits unchanged. No behavior change, no customer impact, fully reversible. `mcp-server.install: false` default is untouched — this only right-sizes clusters where MCP is already enabled.

## Reviewers, please confirm
Whether any Dedicated **release-channel sizing profile** overrides these requests above the chart default. If so, apply the same trim there too, or this chart change won't take effect on those clusters.

cc @ash0ts (mcp-server owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the Helm chart version to `0.43.2`.
  * Reduced default CPU and memory requests for the `mcp-server` container, which may help lower baseline resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->