### PR TITLE
chore: add identity db migration prehook

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -191,21 +191,12 @@ identity:
     repository: orchestrator/identity
     tag: latest
 
-  # Run the auth DB (Drizzle better-auth) migrations before the identity
-  # Deployment rolls. helmHook only annotates jobs, so the Deployment/Service
-  # render normally.
-  helmHook:
-    enabled: true
-    hook: "pre-install,pre-upgrade"
-    hookWeight: "-5"
-    hookDeletePolicy: "before-hook-creation,hook-succeeded"
-
-  # The job container inherits the identity image (same tag as the deployment) and
-  # AUTH_DATABASE_URL from envTpls below via wandb-base. It runs the same compiled
-  # migrate the old dedicated migrations image ran. SKIP_AUTH_DB_CREATE assumes the
-  # auth DB is pre-provisioned (like the engine assumes its DB exists).
   jobs:
     auth-migrate:
+      annotations:
+        "helm.sh/hook": "pre-install,pre-upgrade"
+        "helm.sh/hook-weight": "-5"
+        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
       backoffLimit: 3
       ttlSecondsAfterFinished: 300
       containers:
@@ -322,14 +313,12 @@ workspace-engine:
     repository: orchestrator/workspace-engine
     tag: latest
 
-  helmHook:
-    enabled: true
-    hook: "pre-install,pre-upgrade"
-    hookWeight: "-5"
-    hookDeletePolicy: "before-hook-creation,hook-succeeded"
-
   jobs:
     migrate:
+      annotations:
+        "helm.sh/hook": "pre-install,pre-upgrade"
+        "helm.sh/hook-weight": "-5"
+        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
       backoffLimit: 3
       ttlSecondsAfterFinished: 300
       containers:

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -191,6 +191,36 @@ identity:
     repository: orchestrator/identity
     tag: latest
 
+  # Run the auth DB (Drizzle better-auth) migrations before the identity
+  # Deployment rolls. helmHook only annotates jobs, so the Deployment/Service
+  # render normally.
+  helmHook:
+    enabled: true
+    hook: "pre-install,pre-upgrade"
+    hookWeight: "-5"
+    hookDeletePolicy: "before-hook-creation,hook-succeeded"
+
+  # The job container inherits the identity image (same tag as the deployment) and
+  # AUTH_DATABASE_URL from envTpls below via wandb-base. It runs the same compiled
+  # migrate the old dedicated migrations image ran. SKIP_AUTH_DB_CREATE assumes the
+  # auth DB is pre-provisioned (like the engine assumes its DB exists).
+  jobs:
+    auth-migrate:
+      backoffLimit: 3
+      ttlSecondsAfterFinished: 300
+      containers:
+        auth-migrate:
+          command: ["node", "/app/packages/db/dist/migrate.js"]
+          env:
+            SKIP_AUTH_DB_CREATE: "true"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+
   env:
     BASE_URL: "{{ .Values.global.fqdn }}"
     AUTH_URL: "{{ .Values.global.fqdn }}"

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -63,19 +63,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: orchestrator/charts/identity/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-identity
-  labels:
-    helm.sh/chart: identity-0.12.3
-    app.kubernetes.io/name: identity
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: orchestrator/charts/otel/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -925,6 +912,23 @@ spec:
             port:
               number: 8086
 ---
+# Source: orchestrator/charts/identity/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-identity
+  labels:
+    helm.sh/chart: identity-0.12.3
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+automountServiceAccountToken: true
+---
 # Source: orchestrator/charts/workspace-engine/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -941,6 +945,123 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 automountServiceAccountToken: true
+---
+# Source: orchestrator/charts/identity/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-auth-migrate
+  labels:
+    helm.sh/chart: identity-0.12.3
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: identity-0.12.3
+        app.kubernetes.io/name: identity
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: auth-migrate
+        command:
+        - node
+        - /app/packages/db/dist/migrate.js
+        envFrom:
+        env:
+        - name: AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: AUTH_SECRET
+              name: chartsnap-auth-secret
+        - name: AUTH_DB_USER
+          value: auth
+        - name: AUTH_DB_PORT
+          value: "5432"
+        - name: AUTH_DB_NAME
+          value: ctrlplane_auth
+        - name: AUTH_DATABASE_URL
+          value: postgresql://$(AUTH_DB_USER):$(AUTH_DB_PASSWORD)@$(AUTH_DB_HOST):$(AUTH_DB_PORT)/$(AUTH_DB_NAME)
+        - name: SPICEDB_INSECURE
+          value: "true"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_URL
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)
+        - name: OTEL_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_HOST_IP):4318
+        - name: AUTH_JWT_AUDIENCE
+          value: "workspace-engine"
+        - name: AUTH_URL
+          value: "https://orchestrator.example.test"
+        - name: BASE_URL
+          value: "https://orchestrator.example.test"
+        - name: CONNECT_URL
+          value: "http://chartsnap-workspace-engine:8086"
+        - name: OTEL_SAMPLER_RATIO
+          value: "0.1"
+        - name: OTEL_SERVICE_NAME
+          value: "ctrlplane/identity"
+        - name: PORT
+          value: "8081"
+        - name: SKIP_AUTH_DB_CREATE
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "orchestrator/identity:latest"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+      restartPolicy: Never
+      serviceAccountName: chartsnap-identity
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: identity
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: identity
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
 ---
 # Source: orchestrator/charts/workspace-engine/templates/job.yaml
 apiVersion: batch/v1

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -63,6 +63,19 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
+# Source: orchestrator/charts/identity/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-identity
+  labels:
+    helm.sh/chart: identity-0.12.3
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
 # Source: orchestrator/charts/otel/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -89,13 +102,26 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
+# Source: orchestrator/charts/workspace-engine/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-workspace-engine
+  labels:
+    helm.sh/chart: workspace-engine-0.12.3
+    app.kubernetes.io/name: workspace-engine
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
 # Source: orchestrator/templates/secrets.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: orchestrator-1.3.0
+    helm.sh/chart: orchestrator-1.3.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -110,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: orchestrator-1.3.0
+    helm.sh/chart: orchestrator-1.3.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -871,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: orchestrator-1.3.0
+    helm.sh/chart: orchestrator-1.3.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -912,40 +938,6 @@ spec:
             port:
               number: 8086
 ---
-# Source: orchestrator/charts/identity/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-identity
-  labels:
-    helm.sh/chart: identity-0.12.3
-    app.kubernetes.io/name: identity
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
-automountServiceAccountToken: true
----
-# Source: orchestrator/charts/workspace-engine/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-workspace-engine
-  labels:
-    helm.sh/chart: workspace-engine-0.12.3
-    app.kubernetes.io/name: workspace-engine
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
-automountServiceAccountToken: true
----
 # Source: orchestrator/charts/identity/templates/job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -958,9 +950,9 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 3
@@ -1075,9 +1067,9 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the orchestrator Helm chart version to **1.3.1**.
  * Improved database migration job handling during installs and upgrades, including updated hook behavior and cleanup settings.
  * Added a new identity migration job with resource settings and safer startup behavior.
  * Adjusted the workspace migration job configuration to use the updated hook setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->