### PR TITLE
fix(operator-wandb): correct LDAP template rendering bugs

### DIFF
--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -640,19 +640,19 @@ Global values will override any chart-specific values.
 {{- end -}}
 
 {{- define "wandb.ldapEnvs" -}}
-  {{- if .Values.global.auth.ldap.enabled}}
-  {{- if kindIs "map" .Values.global.auth.ldap.bindPW }}
-  - name: LDAP_BIND_PW
-  {{- toYaml .Values.global.auth.ldap.bindPW | nindent 2 }}
-  {{- else if .Values.global.auth.ldap.bindPW }}
-  - name: LDAP_BIND_PW
-    valueFrom:
-      secretKeyRef:
-        name: {{ .Release.Name }}-ldap-secret
-        key: LDAP_BIND_PW
-  {{- end }}
-  - name: GORILLA_LDAP_CONNECTION_STRING
-    value: {{ include "wandb.ldapConnectionString" . | quote }}
-  {{- end }}
-  {{- end }}
+{{- if .Values.global.auth.ldap.enabled }}
+{{- if kindIs "map" .Values.global.auth.ldap.bindPW }}
+- name: LDAP_BIND_PW
+{{- toYaml .Values.global.auth.ldap.bindPW | nindent 2 }}
+{{- else if .Values.global.auth.ldap.bindPW }}
+- name: LDAP_BIND_PW
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-ldap-secret
+      key: LDAP_BIND_PW
+{{- end }}
+- name: GORILLA_LDAP_CONNECTION_STRING
+  value: {{ include "wandb.ldapConnectionString" . | quote }}
+{{- end }}
+{{- end -}}
 

--- a/charts/operator-wandb/templates/_ldap.tpl
+++ b/charts/operator-wandb/templates/_ldap.tpl
@@ -4,10 +4,14 @@
 {{- $scheme := ternary "ldaps" "ldap" $ldap.tls -}}
 {{- $tls := ternary "true" "false" $ldap.tls -}}
 {{- $queryParams := printf "attributes=%s&userBaseDN=%s&groupBaseDN=%s&userObjectClass=%s&groupObjectClass=%s&groupAllowList=%s&tls=%s" $ldap.attributes $ldap.userBaseDN $ldap.groupBaseDN $ldap.userObjectClass $ldap.groupObjectClass $ldap.groupAllowList $tls -}}
-{{- if $ldap.bindDN -}}
-{{ $scheme }}://{{ $ldap.bindDN }}:$(LDAP_BIND_PW)@{{ $ldap.host }}:{{ $ldap.port }}/{{ $ldap.baseDN }}?{{ $queryParams }}
+{{- $hostPort := $ldap.host -}}
+{{- if $ldap.port -}}
+{{- $hostPort = printf "%s:%v" $ldap.host $ldap.port -}}
+{{- end -}}
+{{- if and $ldap.bindDN $ldap.bindPW -}}
+{{ $scheme }}://{{ $ldap.bindDN }}:$(LDAP_BIND_PW)@{{ $hostPort }}/{{ $ldap.baseDN }}?{{ $queryParams }}
 {{- else -}}
-{{ $scheme }}://{{ $ldap.host }}:{{ $ldap.port }}/{{ $ldap.baseDN }}?{{ $queryParams }}
+{{ $scheme }}://{{ $hostPort }}/{{ $ldap.baseDN }}?{{ $queryParams }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/operator-wandb/templates/_volumes.tpl
+++ b/charts/operator-wandb/templates/_volumes.tpl
@@ -74,21 +74,21 @@
 {{- end }}
 
 {{- define "wandb.ldapVolumeMounts" -}}
-  {{- if and .Values.global.auth.ldap.enabled .Values.global.auth.ldap.tls .Values.global.auth.ldap.tlsCert.configMap.name }}
-  - name: ldap-tls-cert
-    mountPath: /var/run/secrets/wandb.ai/ldap/ca.crt
-    subPath: ca.crt
-    readOnly: true
-  {{- end }}
-  {{- end -}}
+{{- if and .Values.global.auth.ldap.enabled .Values.global.auth.ldap.tls .Values.global.auth.ldap.tlsCert.configMap.name .Values.global.auth.ldap.tlsCert.configMap.key }}
+- name: ldap-tls-cert
+  mountPath: /var/run/secrets/wandb.ai/ldap/ca.crt
+  subPath: ca.crt
+  readOnly: true
+{{- end }}
+{{- end -}}
 
 {{- define "wandb.ldapVolumes" -}}
-  {{- if and .Values.global.auth.ldap.enabled .Values.global.auth.ldap.tls .Values.global.auth.ldap.tlsCert.configMap.name .Values.global.auth.ldap.tlsCert.configMap.key}}
-  - name: ldap-tls-cert
-    configMap:
-      name: "{{ .Values.global.auth.ldap.tlsCert.configMap.name }}"
-      items:
-        - key: "{{ .Values.global.auth.ldap.tlsCert.configMap.key }}"
-          path: ca.crt
-  {{- end }}
-  {{- end -}}
+{{- if and .Values.global.auth.ldap.enabled .Values.global.auth.ldap.tls .Values.global.auth.ldap.tlsCert.configMap.name .Values.global.auth.ldap.tlsCert.configMap.key }}
+- name: ldap-tls-cert
+  configMap:
+    name: "{{ .Values.global.auth.ldap.tlsCert.configMap.name }}"
+    items:
+      - key: "{{ .Values.global.auth.ldap.tlsCert.configMap.key }}"
+        path: ca.crt
+{{- end }}
+{{- end -}}

--- a/test-configs/operator-wandb/__snapshots__/ldap-tls-external-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/ldap-tls-external-secret.snap
@@ -1,5 +1,14 @@
 # chartsnap: snapshot_version=v3
 ---
+apiVersion: helm-chartsnap.jlandowner.dev/v1alpha1
+kind: Unknown
+metadata:
+  name: helm-output
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+raw: |-
+  ###DYNAMIC_FIELD###
+---
 # Source: operator-wandb/charts/redis/templates/networkpolicy.yaml
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -425,17 +434,6 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
----
-# Source: operator-wandb/templates/auth.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: chartsnap-ldap-secret
-  labels:
-  annotations:
-    "helm.sh/resource-policy": "keep"
-data:
-  LDAP_BIND_PW: dGVzdHBhc3N3b3Jk
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1
@@ -1378,11 +1376,12 @@ data:
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'true'
   LDAP_LOGIN: "true"
-  LDAP_ADDRESS: "example.com"
+  LDAP_ADDRESS: "ldap.example.com"
   LDAP_BASE_DN: "dc=example,dc=com"
   LDAP_BIND_DN: "cn=admin,dc=example,dc=com"
   LDAP_ATTRIBUTES: "email,group"
-  LDAP_GROUP_ALLOW_LIST: ""
+  LDAP_GROUP_ALLOW_LIST: "cn=wandb,ou=groups,dc=example,dc=com"
+  LDAP_TLS_ENABLE: "true"
 ---
 # Source: operator-wandb/templates/app.yaml
 apiVersion: v1
@@ -3105,10 +3104,10 @@ spec:
         - name: LDAP_BIND_PW
           valueFrom:
             secretKeyRef:
-              key: LDAP_BIND_PW
-              name: chartsnap-ldap-secret
+              key: bindpw
+              name: my-ldap-secret
         - name: GORILLA_LDAP_CONNECTION_STRING
-          value: ldap://cn=admin,dc=example,dc=com:$(LDAP_BIND_PW)@example.com/dc=example,dc=com?attributes=email,group&userBaseDN=&groupBaseDN=&userObjectClass=&groupObjectClass=&groupAllowList=&tls=false
+          value: ldaps://cn=admin,dc=example,dc=com:$(LDAP_BIND_PW)@ldap.example.com:636/dc=example,dc=com?attributes=email,group&userBaseDN=ou=users,dc=example,dc=com&groupBaseDN=ou=groups,dc=example,dc=com&userObjectClass=inetOrgPerson&groupObjectClass=groupOfNames&groupAllowList=cn=wandb,ou=groups,dc=example,dc=com&tls=true
         - name: SMTP_HOST
           value: smtp.example.com
         - name: SMTP_PORT
@@ -3192,6 +3191,10 @@ spec:
         volumeMounts:
         - name: wandb-internal-signer-root
           mountPath: /vol/env
+        - name: ldap-tls-cert
+          mountPath: /var/run/secrets/wandb.ai/ldap/ca.crt
+          subPath: ca.crt
+          readOnly: true
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
         - name: wandb-ca-certs
@@ -3370,10 +3373,10 @@ spec:
         - name: LDAP_BIND_PW
           valueFrom:
             secretKeyRef:
-              key: LDAP_BIND_PW
-              name: chartsnap-ldap-secret
+              key: bindpw
+              name: my-ldap-secret
         - name: GORILLA_LDAP_CONNECTION_STRING
-          value: ldap://cn=admin,dc=example,dc=com:$(LDAP_BIND_PW)@example.com/dc=example,dc=com?attributes=email,group&userBaseDN=&groupBaseDN=&userObjectClass=&groupObjectClass=&groupAllowList=&tls=false
+          value: ldaps://cn=admin,dc=example,dc=com:$(LDAP_BIND_PW)@ldap.example.com:636/dc=example,dc=com?attributes=email,group&userBaseDN=ou=users,dc=example,dc=com&groupBaseDN=ou=groups,dc=example,dc=com&userObjectClass=inetOrgPerson&groupObjectClass=groupOfNames&groupAllowList=cn=wandb,ou=groups,dc=example,dc=com&tls=true
         - name: SMTP_HOST
           value: smtp.example.com
         - name: SMTP_PORT
@@ -3471,6 +3474,12 @@ spec:
       - name: wandb-internal-signer-root
         secret:
           secretName: "chartsnap-internal-signer"
+      - name: ldap-tls-cert
+        configMap:
+          name: "ldap-ca"
+          items:
+          - key: "ca.crt"
+            path: ca.crt
       - name: wandb-ca-certs-root
         emptyDir: {}
       - name: wandb-ca-certs
@@ -6268,7 +6277,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: internalSignerPreHook
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "0.78.0-rc.1771864722"
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": "pre-upgrade,pre-install"
@@ -6395,7 +6404,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: internalSignerPreHook
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "0.78.0-rc.1771864722"
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": "pre-upgrade,pre-install"
@@ -6469,7 +6478,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: internalSignerPreHook
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "0.78.0-rc.1771864722"
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": "pre-upgrade,pre-install"
@@ -6701,7 +6710,7 @@ metadata:
     helm.sh/chart: '###CHART_VERSION###'
     app.kubernetes.io/name: internalSignerPreHook
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "0.78.0-rc.1771864722"
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": "pre-upgrade,pre-install"
@@ -6714,7 +6723,7 @@ spec:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: internalSignerPreHook
         app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "0.78.0-rc.1771864722"
+        app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
@@ -6744,7 +6753,7 @@ spec:
             drop: []
           privileged: false
           readOnlyRootFilesystem: false
-        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:0.78.0-rc.1771864722"
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/test-configs/operator-wandb/ldap-tls-external-secret.yaml
+++ b/test-configs/operator-wandb/ldap-tls-external-secret.yaml
@@ -1,0 +1,105 @@
+global:
+  repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
+  imageRegistry: "us-docker.pkg.dev/wandb-production/public"
+  bucket:
+    provider: "s3"
+    name: "minio:9000/bucket"
+    region: "us-east-1"
+    accessKey: "minio"
+    secretKey: "testpassword"
+  env:
+    GLOBAL_ADMIN_API_KEY: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+    GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS: "true"
+    BUCKET_PROXY: "true"
+    GORILLA_GLUE_FILE_STORE_IS_PROXIED: "true"
+    GORILLA_FILE_STORE_IS_PROXIED: "true"
+  redis:
+    password: "redis123"
+  glue:
+    enabled: true
+  localService:
+    bypass: true
+  api:
+    enabled: true
+  executor:
+    enabled: true
+  size: "testing"
+  email:
+    smtp:
+      host: "smtp.example.com"
+      port: 587
+      user: "noreply@example.com"
+      password: "" # intentionally empty
+  auth:
+    ldap:
+      enabled: true
+      host: "ldap.example.com"
+      port: 636
+      baseDN: "dc=example,dc=com"
+      userBaseDN: "ou=users,dc=example,dc=com"
+      groupBaseDN: "ou=groups,dc=example,dc=com"
+      bindDN: "cn=admin,dc=example,dc=com"
+      # bindPW provided as a K8s secret reference (bring-your-own-secret / map form).
+      # The chart must NOT create its own ldap-secret in this case.
+      bindPW:
+        valueFrom:
+          secretKeyRef:
+            name: "my-ldap-secret"
+            key: "bindpw"
+      attributes: "email,group"
+      userObjectClass: "inetOrgPerson"
+      groupObjectClass: "groupOfNames"
+      groupAllowList: "cn=wandb,ou=groups,dc=example,dc=com"
+      tls: true
+      tlsCert:
+        configMap:
+          name: "ldap-ca"
+          key: "ca.crt"
+
+app:
+  install: false
+
+executor:
+  install: true
+
+filemeta:
+  install: true
+
+frontend:
+  install: true
+
+nginx:
+  install: true
+  additionalServices:
+    bucket:
+      host: "http://minio:9000"
+      headers:
+        Host: "minio:9000"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+redis:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+reloader:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+anaconda2:
+  install: true


### PR DESCRIPTION
Follow-up to #577 (LDAP auth). This PR targets `ONPREM-125-LDAP-Config` so it can merge directly into that branch.

I reproduced each issue with `helm template` using Helm v3.20.1, the version used by CI, and checked the behavior against `wandb/core/services/connectors/ldap.go`.

## Rendering fixes

### `_env.tpl`

When `bindPW` was a `secretKeyRef` map, the `kindIs "map"` branch used `nindent 2` below a list item that was already indented two spaces. This put `valueFrom` in the same column as the `-` in `- name:`. The result was invalid YAML when `envTpls` passed through `fromYamlArray` in `charts/wandb-base/templates/_containers.tpl`.

`wandb.ldapEnvs` now starts at column 0, matching `mysqlConfigEnvs` and `smtpEnvs`. The map branch still uses `nindent 2` to match its siblings.

### `_volumes.tpl`

`volumeMountsTpls` and `volumesTpls` are inserted with `tpl | indent 4`, without `fromYamlArray` normalization. The LDAP templates had two leading spaces, so their list items appeared two columns below the sibling `internalSigner` items. That produced invalid YAML whenever TLS was enabled. Both definitions now start at column 0.

`wandb.ldapVolumeMounts` now also checks `tlsCert.configMap.key`, matching the existing guard in `wandb.ldapVolumes`. Previously, a `configMap.name` without a `key` rendered a `volumeMount` without a matching `volume`. The Kubernetes API server then rejected the API Deployment.

### `_ldap.tpl`

- When the default port is empty, omit `:port` instead of emitting `host:`.
- Include the `:$(LDAP_BIND_PW)` userinfo only when `bindPW` is set. Without this guard, setting `bindDN` without `bindPW` left the literal `$(LDAP_BIND_PW)` in the URL because the environment variable was undefined.

## Test coverage

- Added `test-configs/operator-wandb/ldap-tls-external-secret.yaml` for snapshot coverage of `bindPW` through `secretKeyRef` and the TLS CA certificate volume. It is intentionally excluded from the kind-install matrix because it references an external secret and ConfigMap, and the test cluster has no LDAP server.
- Refreshed `local-bypass-no-app.snap` to remove the dangling colon from `example.com:`.

## Verification

- `./snapshots.sh run operator-wandb`: all snapshots matched with Helm v3.20.1.
- `ct lint --config ct.yaml --charts ./charts/operator-wandb`: lint passed.

## Notes

- No chart version bump is needed. `ct.yaml` sets `target-branch: main`, and the existing `0.42.2` already satisfies the version check against main's `0.42.1`. Keeping it avoids another snapshot refresh.
- The CA mount path does not need environment variable wiring. Gorilla sets `CustomRootFile = "/var/run/secrets/wandb.ai/ldap/ca.crt"`, which matches the mount path.
- Out of scope: trailing blank lines in `global.yaml`, the missing trailing newline in `auth.yaml`, and a `global.auth.ldap` row in the chart README.
