### PR TITLE
fix: update weave-cache-clear mode

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.3
+version: 0.43.4
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/weave.yaml
+++ b/charts/operator-wandb/templates/weave.yaml
@@ -18,3 +18,6 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "{{ .Values.weave.cache.intervalInHours }}"
+  WEAVE_CACHE_CHECK_INTERVAL: "{{ .Values.weave.cache.checkIntervalInSeconds }}"
+  WEAVE_CACHE_SIZE_LIMIT: "{{ .Values.weave.cache.size }}"
+  WEAVE_CACHE_CLEAR_PERCENT: "{{ .Values.weave.cache.clearPercent }}"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -3036,7 +3036,16 @@ weave:
   install: true
   deploymentPostfix: "bc"
   cache:
+    # Keep WEAVE_CACHE_DURATION_DAYS unset or 0 for size-triggered cleanup.
+    # Positive values only remove expired buckets and may not reclaim the active bucket.
+    # Clear expired cache entries on this interval, in hours.
     intervalInHours: 24
+    # Check cache usage on this interval, in seconds.
+    checkIntervalInSeconds: 60
+    # Trigger cleanup when cache usage reaches this percentage of size (1-99).
+    clearPercent: 80
+    # Also used as WEAVE_CACHE_SIZE_LIMIT so cleanup and emptyDir share one limit.
+    # Supports bytes and K/M/G/Ki/Mi/Gi suffixes.
     size: 20Gi
     medium: ""
   image:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -3885,7 +3885,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -1711,6 +1711,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -3885,6 +3885,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -3889,6 +3889,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -3889,7 +3889,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -1715,6 +1715,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -1885,6 +1885,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -2120,6 +2120,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -2036,6 +2036,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -2014,6 +2014,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -2014,6 +2014,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -3889,6 +3889,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -3889,7 +3889,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -1715,6 +1715,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -4206,7 +4206,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -4206,6 +4206,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -1749,6 +1749,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -4199,7 +4199,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -4199,6 +4199,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -1749,6 +1749,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -1715,6 +1715,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -3857,6 +3857,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -3857,7 +3857,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -1982,6 +1982,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -2014,6 +2014,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -4129,7 +4129,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -1758,6 +1758,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -4129,6 +4129,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -4129,7 +4129,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -1758,6 +1758,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -4129,6 +4129,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -1758,6 +1758,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -4127,6 +4127,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -4127,7 +4127,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -2180,6 +2180,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -2014,6 +2014,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -2024,6 +2024,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -2315,6 +2315,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -1940,6 +1940,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -2193,6 +2193,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -2014,6 +2014,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -1861,6 +1861,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -2158,6 +2158,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -4580,7 +4580,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -1761,6 +1761,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -4580,6 +4580,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -1761,6 +1761,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -4582,6 +4582,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -4582,7 +4582,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -1761,6 +1761,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -4582,6 +4582,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -4582,7 +4582,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -1794,6 +1794,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -1933,6 +1933,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -6448,7 +6448,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -6448,6 +6448,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -1933,6 +1933,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -6448,7 +6448,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -6448,6 +6448,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -3983,7 +3983,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -3983,6 +3983,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -1749,6 +1749,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -3981,6 +3981,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -3981,7 +3981,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -1749,6 +1749,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -3993,7 +3993,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -3993,6 +3993,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -1749,6 +1749,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -1728,6 +1728,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -3958,7 +3958,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -3958,6 +3958,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -3960,7 +3960,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -3960,6 +3960,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -1730,6 +1730,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -1798,6 +1798,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -4810,7 +4810,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -4810,6 +4810,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -1762,6 +1762,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -4581,7 +4581,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -4581,6 +4581,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -1777,6 +1777,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -4636,6 +4636,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -4636,7 +4636,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -1777,6 +1777,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -4636,6 +4636,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -4636,7 +4636,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -1794,6 +1794,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -1724,6 +1724,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -3913,6 +3913,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -3913,7 +3913,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -3895,7 +3895,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -3895,6 +3895,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -1715,6 +1715,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -1908,6 +1908,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -2014,6 +2014,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -4222,6 +4222,7 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
+          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -4222,7 +4222,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: null
           seccompProfile:
             type: RuntimeDefault
         command:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -1747,6 +1747,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -2198,6 +2198,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -2486,6 +2486,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -2273,6 +2273,9 @@ data:
   WEAVE_SERVER_URL: "http://127.0.0.1:9994"
   WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
   WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
 ---
 # Source: operator-wandb/charts/mysql/templates/pvc.yaml
 apiVersion: v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded Weave cache configuration options for check intervals, size limits, and cleanup percentages.
  * Cache settings are now applied automatically from the chart’s configured values.

* **Documentation**
  * Improved inline guidance for cache cleanup behavior, timing, thresholds, disabling cleanup, and supported size units.

* **Chores**
  * Updated the Helm chart release version to 0.43.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->