### PR TITLE
feat: support splitting connect and controller into separate deployments

### DIFF
--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -1,15 +1,18 @@
 dependencies:
-- name: otel
-  repository: file://charts/otel
-  version: 0.2.4
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.4
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.4
-- name: wandb-base
-  repository: file://../wandb-base
-  version: 0.12.4
-digest: sha256:cacd0c5539600e06bf59055669952dc9d78390387470ff8414dee8ebc49db6b4
-generated: "2026-07-08T16:53:14.367535-07:00"
+  - name: otel
+    repository: file://charts/otel
+    version: 0.2.4
+  - name: wandb-base
+    repository: file://../wandb-base
+    version: 0.12.4
+  - name: wandb-base
+    repository: file://../wandb-base
+    version: 0.12.4
+  - name: wandb-base
+    repository: file://../wandb-base
+    version: 0.12.4
+  - name: wandb-base
+    repository: file://../wandb-base
+    version: 0.12.4
+digest: sha256:f1f5cd700ef656b95d51ec8366e9fe53dfdb7166e9adb5856a0b49af8bf3593f
+generated: "2026-07-10T10:37:21.2476-04:00"

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
-  - name: otel
-    repository: file://charts/otel
-    version: 0.2.4
-  - name: wandb-base
-    repository: file://../wandb-base
-    version: 0.12.4
-  - name: wandb-base
-    repository: file://../wandb-base
-    version: 0.12.4
-  - name: wandb-base
-    repository: file://../wandb-base
-    version: 0.12.4
-  - name: wandb-base
-    repository: file://../wandb-base
-    version: 0.12.4
-digest: sha256:f1f5cd700ef656b95d51ec8366e9fe53dfdb7166e9adb5856a0b49af8bf3593f
-generated: "2026-07-10T10:37:21.2476-04:00"
+- name: otel
+  repository: file://charts/otel
+  version: 0.2.4
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.4
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.4
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.4
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.4
+digest: sha256:8010266cd7e906d26d0e4b920fb3a01165223c7119e0e17460f6c18fe8b55b7e
+generated: "2026-07-10T11:04:10.417419-04:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.3.2
+version: 1.4.0
 appVersion: 1.0.0
 
 maintainers:
@@ -24,6 +24,11 @@ dependencies:
     name: wandb-base
     condition: workspace-engine.install
     version: "0.12.4"
+    repository: "file://../wandb-base"
+  - alias: workspace-engine-controllers
+    name: wandb-base
+    condition: workspace-engine-controllers.install
+    version: "0.12.3"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.3"
+    version: "0.12.4"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -10,3 +10,36 @@ Features:
 - **Active Development**: Continuously updated to keep up with the latest best practices and features in the orchestrator ecosystem.
 
 Get started with orchestratordev/orchestrator-charts today and supercharge your Kubernetes deployments!
+
+## Workspace-engine topology
+
+By default the chart runs a single `workspace-engine` Deployment in which every pod serves the Connect API **and** runs all reconcile controllers (`SERVICES` is empty, which the engine treats as "run everything").
+
+For independent scaling, the chart can split the engine into two Deployments:
+
+```yaml
+workspace-engine:
+  replicaCount: 2
+  env:
+    SERVICES: connect
+
+workspace-engine-controllers:
+  install: true # off by default
+  replicaCount: 4
+```
+
+- `workspace-engine` keeps the Kubernetes Service (`<release>-workspace-engine:8086`), so the web app, identity service, and inbound webhooks continue to route to it unchanged. Set `SERVICES: connect` so it serves only the API.
+- `workspace-engine-controllers` runs `SERVICES: controllers` (the default for this block): every background worker and no API server. It exposes no Service.
+
+This is the standard web + worker pattern: one image, two Deployments. The API deployment deliberately keeps the plain `workspace-engine` name rather than something like `workspace-engine-api`, because it owns the engine's network identity — the Service name `<release>-workspace-engine` is what identity's `CONNECT_URL`, the web app, and the ingress `/engine` route all resolve to. Whatever answers the API *is* the workspace-engine to the rest of the system; the controllers are a headless worker fleet that nothing addresses. Keeping the name also means enabling or disabling the split never renames the Service, so routing is identical in both topologies and existing values files keep working.
+
+### Version requirements and rollback
+
+The `controllers` and `connect` values for `SERVICES` require a workspace-engine image containing the service group aliases (ctrlplane `c48ced3` / PR #79 or later).
+
+On older images, `SERVICES: controllers` matches nothing: the pods pass health checks but process **no work**, silently stalling all deployments. Therefore:
+
+- Enable the split and bump the image tag in the **same** change.
+- Never roll the image back past `c48ced3` while the split is enabled — roll back by reverting the entire change (topology values + tag together).
+
+Disabling the split (`install: false` on `workspace-engine-controllers`, remove the `SERVICES` override) is always safe: the single Deployment reverts to running everything, on any image version.

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -402,3 +402,62 @@ workspace-engine:
         httpGet:
           path: /readyz
           port: health
+
+# Optional second engine Deployment running only the reconcile controllers,
+# for scaling them independently of the Connect API. See "Workspace-engine
+# topology" in the README — requires an engine image >= ctrlplane c48ced3,
+# and the workspace-engine block above should set SERVICES: connect when
+# this is enabled.
+workspace-engine-controllers:
+  install: false
+
+  image:
+    repository: orchestrator/workspace-engine
+    tag: latest
+
+  env:
+    BASE_URL: "{{ .Values.global.fqdn }}"
+    GITHUB_URL: "{{ .Values.global.integrations.github.url }}"
+    DD_SERVICE: "ctrlplane/workspace-engine"
+    DD_ENV: "local"
+    TRACE_SAMPLE_RATE: "0.1"
+
+    AUTH_ALLOW_UNVERIFIED_JWT_CLAIMS: "false"
+    AUTHZ_ALLOW_DISABLED: "false"
+
+    SERVICES: "controllers"
+
+  envTpls:
+    - '{{ include "orchestrator.githubBotEnvVars" . }}'
+    - '{{ include "orchestrator.postgresqlEnvVars" . }}'
+    - '{{ include "orchestrator.encryptionKeyEnvVars" . }}'
+    - '{{ include "orchestrator.spicedbEnvVars" . }}'
+    - '{{ include "orchestrator.authJwtEnvVars" . }}'
+    - '{{ include "orchestrator.redisEnvVars" . }}'
+    - '{{ include "orchestrator.authSyncSecretEnvVars" . }}'
+    - '{{ include "orchestrator.workspaceEngineTelemetryEnvVars" . }}'
+
+  containers:
+    workspace-engine:
+      ports:
+        - name: health
+          containerPort: 8089
+      resources:
+        requests:
+          cpu: 8
+          memory: 16Gi
+        limits:
+          cpu: 32
+          memory: 64Gi
+      livenessProbe:
+        httpGet:
+          path: /livez
+          port: health
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: health
+      startupProbe:
+        httpGet:
+          path: /readyz
+          port: health

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -121,7 +121,7 @@ kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: orchestrator-1.3.2
+    helm.sh/chart: orchestrator-1.4.0
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -136,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: orchestrator-1.3.2
+    helm.sh/chart: orchestrator-1.4.0
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -897,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: orchestrator-1.3.2
+    helm.sh/chart: orchestrator-1.4.0
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for deploying dedicated workspace-engine controller workers alongside the workspace-engine API.
  * Added configuration for controller-specific service selection, environment settings, health checks, and readiness probes.
  * Added a chart dependency for the controller deployment.

* **Documentation**
  * Documented single- and split-deployment topologies, version requirements, and safe rollback guidance.

* **Chores**
  * Bumped the orchestrator Helm chart version to 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->