### PR TITLE
chore: run authz schema migration as preinstall hook

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -11,6 +11,26 @@ Features:
 
 Get started with orchestratordev/orchestrator-charts today and supercharge your Kubernetes deployments!
 
+## SpiceDB (authorization)
+
+The chart does not install SpiceDB — like PostgreSQL and Redis, it is an external dependency. Deploy it separately (Authzed's [spicedb-operator](https://github.com/authzed/spicedb-operator) is the recommended way to run it, with a PostgreSQL datastore) and wire the connection via `global.spicedb`:
+
+```yaml
+global:
+  spicedb:
+    addr: "spicedb.spicedb:50051"
+    insecure: "true"
+    token:
+      valueFrom:
+        secretKeyRef:
+          name: spicedb-config # e.g. materialized by an ExternalSecret
+          key: preshared_key
+```
+
+Both the identity service (writes membership grants) and the workspace-engine (enforces them) connect to it. The workspace-engine additionally **fails closed at boot** when `global.spicedb.addr` is unset, so SpiceDB must be up before the app pods start.
+
+The authorization schema is applied by the `authz-apply-schema` pre-install/pre-upgrade hook job, which runs `engine authz apply-schema` — the SpiceDB analog of the `migrate` job. The write is idempotent (an unchanged schema is a no-op) and keeps the schema in lockstep with the engine image on upgrades. SpiceDB must be reachable at install/upgrade time, same as PostgreSQL for the migration jobs. A schema change that would orphan existing relationship data is rejected by SpiceDB, failing the hook and stopping the upgrade before the app rolls out.
+
 ## Workspace-engine topology
 
 By default the chart runs a single `workspace-engine` Deployment in which every pod serves the Connect API **and** runs all reconcile controllers (`SERVICES` is empty, which the engine treats as "run everything").

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -331,6 +331,23 @@ workspace-engine:
             limits:
               cpu: "1"
               memory: 1Gi
+    authz-apply-schema:
+      annotations:
+        "helm.sh/hook": "pre-install,pre-upgrade"
+        "helm.sh/hook-weight": "-4"
+        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+      backoffLimit: 3
+      ttlSecondsAfterFinished: 300
+      containers:
+        authz-apply-schema:
+          command: ["./engine", "authz", "apply-schema"]
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
 
   service:
     enabled: true

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -121,7 +121,7 @@ kind: Secret
 metadata:
   name: chartsnap-encryption-key
   labels:
-    helm.sh/chart: orchestrator-1.4.0
+    helm.sh/chart: orchestrator-1.4.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -136,7 +136,7 @@ kind: Secret
 metadata:
   name: chartsnap-auth-secret
   labels:
-    helm.sh/chart: orchestrator-1.4.0
+    helm.sh/chart: orchestrator-1.4.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -897,7 +897,7 @@ kind: Ingress
 metadata:
   name: chartsnap-orchestrator
   labels:
-    helm.sh/chart: orchestrator-1.4.0
+    helm.sh/chart: orchestrator-1.4.1
     app.kubernetes.io/name: orchestrator
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "1.0.0"
@@ -1051,6 +1051,138 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/name: identity
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+---
+# Source: orchestrator/charts/workspace-engine/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-authz-apply-schema
+  labels:
+    helm.sh/chart: workspace-engine-0.12.4
+    app.kubernetes.io/name: workspace-engine
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-4"
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: workspace-engine-0.12.4
+        app.kubernetes.io/name: workspace-engine
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: authz-apply-schema
+        command:
+        - ./engine
+        - authz
+        - apply-schema
+        envFrom:
+        env:
+        - name: POSTGRES_USER
+          value: orchestrator
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DATABASE
+          value: orchestrator
+        - name: POSTGRES_PASSWORD
+          value: orchestrator
+        - name: POSTGRES_URL
+          value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DATABASE)
+        - name: VARIABLES_AES_256_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AES_256_KEY
+              name: chartsnap-encryption-key
+        - name: SPICEDB_INSECURE
+          value: "true"
+        - name: AUTH_JWKS_URL
+          value: http://chartsnap-identity:8081/api/auth/jwks
+        - name: AUTH_VALID_ISSUERS
+          value: https://orchestrator.example.test
+        - name: AUTH_AUDIENCE
+          value: workspace-engine
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_URL
+          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)
+        - name: OTEL_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: TRACE_ADDRESS
+          value: $(OTEL_HOST_IP):4317
+        - name: METRICS_ADDRESS
+          value: $(OTEL_HOST_IP):4317
+        - name: AUTHZ_ALLOW_DISABLED
+          value: "false"
+        - name: AUTH_ALLOW_UNVERIFIED_JWT_CLAIMS
+          value: "false"
+        - name: BASE_URL
+          value: "https://orchestrator.example.test"
+        - name: DD_ENV
+          value: "local"
+        - name: DD_SERVICE
+          value: "ctrlplane/workspace-engine"
+        - name: GITHUB_URL
+          value: "https://github.com"
+        - name: GRPC_PORT
+          value: "8086"
+        - name: HTTP_PREFIX_PATH
+          value: "/engine"
+        - name: SERVICES
+          value: ""
+        - name: TRACE_SAMPLE_RATE
+          value: "0.1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "orchestrator/workspace-engine:latest"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+      restartPolicy: Never
+      serviceAccountName: chartsnap-workspace-engine
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: workspace-engine
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: workspace-engine
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic authorization schema application during chart installation and upgrades.
  * Added configuration guidance for connecting to an external SpiceDB service, including address and token settings.
  * Documented authorization behavior, including safe startup handling and upgrade compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->