### PR TITLE
chore: Bump k8s kind cluster versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,8 +1,11 @@
 name: Lint Charts
 
 on:
+  # No paths filter: lint-test is a required status check, so it must always run
+  # and report. `ct lint` reads ct.yaml (target-branch: main) and no-ops quickly
+  # when no chart changed, so unrelated PRs still get a green required status
+  # instead of hanging on "Waiting for status to be reported".
   pull_request:
-    paths: charts/**
 
 jobs:
   lint-test:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,7 @@
 name: Lint Charts
 
 on:
-  # No paths filter: lint-test is a required status check, so it must always run
-  # and report. `ct lint` reads ct.yaml (target-branch: main) and no-ops quickly
-  # when no chart changed, so unrelated PRs still get a green required status
-  # instead of hanging on "Waiting for status to be reported".
+  # No paths filter: run on every PR and let ct + ct.yaml gate what's linted.
   pull_request:
 
 jobs:

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -50,7 +50,17 @@ jobs:
           ./helm-dep-build.sh
         shell: bash
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
       - name: Package charts
+        if: steps.list-changed.outputs.changed == 'true'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
@@ -61,6 +71,7 @@ jobs:
         shell: bash
 
       - name: Run chart-releaser
+        if: steps.list-changed.outputs.changed == 'true'
         uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         with:
           skip_packaging: true

--- a/.github/workflows/test-lumen.yaml
+++ b/.github/workflows/test-lumen.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       max-parallel: 9
       matrix:
-        k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
+        k8s-version: ["v1.36.1", "v1.35.5", "v1.34.8"]
         configuration:
           [
             "default",
@@ -72,9 +72,9 @@ jobs:
           fi
 
       - name: Create kind cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
-          version: v0.27.0
+          version: v0.32.0
           cluster_name: chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }}
           node_image: kindest/node:${{ matrix.k8s-version }}
         if: env.ACT || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test-lumen.yaml
+++ b/.github/workflows/test-lumen.yaml
@@ -6,6 +6,7 @@ on:
       - charts/lumen/**
       - charts/wandb-base/**
       - test-configs/lumen/**
+      - .github/workflows/test-lumen.yaml
 
 jobs:
   snapshots:

--- a/.github/workflows/test-operator-wandb.yaml
+++ b/.github/workflows/test-operator-wandb.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - charts/operator-wandb/**
       - test-configs/operator-wandb/**
+      - .github/workflows/test-operator-wandb.yaml
 
 jobs:
   snapshots:

--- a/.github/workflows/test-operator-wandb.yaml
+++ b/.github/workflows/test-operator-wandb.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       max-parallel: 39
       matrix:
-        k8s-version: ["v1.32.2", "v1.31.6", "v1.30.10"]
+        k8s-version: ["v1.36.1", "v1.35.5", "v1.34.8"]
         configuration:
           [
             "default",
@@ -94,9 +94,9 @@ jobs:
           fi
 
       - name: Create kind cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
-          version: v0.27.0
+          version: v0.32.0
           cluster_name: chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }}
           node_image: kindest/node:${{ matrix.k8s-version }}
         if: env.ACT || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test-orchestrator.yaml
+++ b/.github/workflows/test-orchestrator.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - charts/orchestrator/**
       - test-configs/orchestrator/**
+      - .github/workflows/test-orchestrator.yaml
 
 jobs:
   snapshots:

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - charts/wandb-base/**
       - test-configs/wandb-base/**
+      - .github/workflows/test-wandb-base.yaml
 
 jobs:
   snapshots:

--- a/.github/workflows/test-wandb.yaml
+++ b/.github/workflows/test-wandb.yaml
@@ -2,7 +2,9 @@ name: Test wandb Chart
 
 on:
   pull_request:
-    paths: charts/wandb/**
+    paths:
+      - charts/wandb/**
+      - .github/workflows/test-wandb.yaml
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ tilt-settings.json
 ``
 *secret.ini
 
+.pi/
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ _tmp_*
 tilt-settings.json
 ``
 *secret.ini
+
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ tilt-settings.json
 
 .pi/
 .claude/
-.codex/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tilt-settings.json
 
 .pi/
 .claude/
+.codex/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the CI chart/operator Kubernetes test matrix to newer versions.
  * Upgraded the Kind-based test setup action to a newer release for better compatibility.

* **Release Automation**
  * Chart packaging and releaser steps now execute only when chart changes are detected, reducing unnecessary release runs.

* **Chores**
  * Updated `.gitignore` to exclude additional local working directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->