### PR TITLE
feat: add gorilla weave trace server url

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.4
+version: 0.43.5
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/api.yaml
+++ b/charts/operator-wandb/templates/api.yaml
@@ -46,6 +46,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   {{- if index .Values.global "weave-trace" "enabled" }}
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: {{ tpl (include "wandb.internalJWTMap" .) . }}
+  GORILLA_WEAVE_TRACE_SERVER_URL: "{{ .Values.global.host }}/traces"
   {{- end }}
   {{- if not .Values.app.install }}
   INTERNAL_SIGNER_KEY_PATH: '{{ .Values.global.signerKeyPath }}'

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -1554,6 +1554,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_WEAVE_TRACE_SERVER_URL: "https://wandb.example.com/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'
 ---

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -1698,6 +1698,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'
 ---

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -1869,6 +1869,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'
 ---

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -1656,6 +1656,7 @@ data:
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
   GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'
 ---


### PR DESCRIPTION
For the **Weave Assets in Registry** feature - [Design Doc](https://app.notion.com/p/wandbai/Weave-Assets-in-Registry-2e7e2f5c7ef3805d919fc085876492d3?source=copy_link)

Gorilla's `createAndLinkWeaveAsset` mutation calls weave-trace's `/obj/read` endpoint. This is possible in MT SaaS but not yet in single-tenant instances. This PR is in conjunction with https://github.com/wandb/core/pull/47777 which enables internal client jwts for single-tenant.

All existing weave-trace traffic on single-tenant is unaffected - browser/SDK traffic reaches weave-trace via the ingress at `/traces`, and weave-trace→gorilla auth callbacks use `WANDB_BASE_URL`. This adds only the missing gorilla→weave-trace direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for the Weave trace server URL, enabling trace-related functionality to connect through the configured host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->