### PR TITLE
refactor: extract OCI release scripts

### DIFF
--- a/.github/scripts/push-and-sign-oci-charts.sh
+++ b/.github/scripts/push-and-sign-oci-charts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: > pushed-refs.txt
+pushed_count=0
+for tarball in .cr-release-packages/*.tgz; do
+  [ -e "$tarball" ] || continue
+  echo "Pushing $tarball to $OCI_REPO"
+  push_output=$(helm push \
+    "$tarball" \
+    "$OCI_REPO" \
+    --registry-config "$HOME/.docker/config.json" 2>&1)
+  echo "$push_output"
+  pushed=$(awk '/^Pushed: /{print $2}' <<< "$push_output")
+  digest=$(awk '/^Digest: /{print $2}' <<< "$push_output")
+  if [ -z "$pushed" ] || [ -z "$digest" ]; then
+    echo "::error::failed to parse push output for $tarball"
+    exit 1
+  fi
+  ref="${pushed}@${digest}"
+  echo "Signing $ref"
+  cosign sign --yes "$ref"
+  echo "$ref" >> pushed-refs.txt
+  pushed_count=$((pushed_count + 1))
+done
+if [ "$pushed_count" -eq 0 ]; then
+  echo "::error::chart-releaser reported changed charts, but no OCI artifacts were found in .cr-release-packages/"
+  exit 1
+fi
+echo "--- pushed and signed refs ---"
+cat pushed-refs.txt

--- a/.github/scripts/verify-oci-signatures.sh
+++ b/.github/scripts/verify-oci-signatures.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+while IFS= read -r ref; do
+  [ -z "$ref" ] && continue
+  echo "Verifying $ref"
+  cosign verify \
+    --certificate-identity-regexp "$CERT_IDENTITY_REGEXP" \
+    --certificate-oidc-issuer "$CERT_OIDC_ISSUER" \
+    "$ref" >/dev/null
+done < pushed-refs.txt
+echo "All published charts verified."

--- a/.github/scripts/verify-public-oci-access.sh
+++ b/.github/scripts/verify-public-oci-access.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+anonymous_config="$RUNNER_TEMP/helm-anonymous/config.json"
+download_dir="$RUNNER_TEMP/helm-anonymous/downloads"
+mkdir -p "$download_dir"
+while IFS= read -r ref; do
+  [ -z "$ref" ] && continue
+  tagged_ref=${ref%@*}
+  chart_ref=${tagged_ref%:*}
+  chart_version=${tagged_ref##*:}
+  echo "Pulling $chart_ref:$chart_version without credentials"
+  helm pull \
+    "oci://${chart_ref}" \
+    --version "$chart_version" \
+    --destination "$download_dir" \
+    --registry-config "$anonymous_config"
+done < pushed-refs.txt
+echo "All published charts are publicly accessible."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,36 +67,7 @@ jobs:
         shell: bash
         env:
           OCI_REPO: oci://ghcr.io/${{ github.repository_owner }}/helm-charts
-        run: |
-          set -euo pipefail
-          : > pushed-refs.txt
-          pushed_count=0
-          for tarball in .cr-release-packages/*.tgz; do
-            [ -e "$tarball" ] || continue
-            echo "Pushing $tarball to $OCI_REPO"
-            push_output=$(helm push \
-              "$tarball" \
-              "$OCI_REPO" \
-              --registry-config "$HOME/.docker/config.json" 2>&1)
-            echo "$push_output"
-            pushed=$(awk '/^Pushed: /{print $2}' <<< "$push_output")
-            digest=$(awk '/^Digest: /{print $2}' <<< "$push_output")
-            if [ -z "$pushed" ] || [ -z "$digest" ]; then
-              echo "::error::failed to parse push output for $tarball"
-              exit 1
-            fi
-            ref="${pushed}@${digest}"
-            echo "Signing $ref"
-            cosign sign --yes "$ref"
-            echo "$ref" >> pushed-refs.txt
-            pushed_count=$((pushed_count + 1))
-          done
-          if [ "$pushed_count" -eq 0 ]; then
-            echo "::error::chart-releaser reported changed charts, but no OCI artifacts were found in .cr-release-packages/"
-            exit 1
-          fi
-          echo "--- pushed and signed refs ---"
-          cat pushed-refs.txt
+        run: ./.github/scripts/push-and-sign-oci-charts.sh
 
       - name: Verify OCI chart signatures
         if: steps.releaser.outputs.changed_charts != ''
@@ -104,36 +75,9 @@ jobs:
         env:
           CERT_IDENTITY_REGEXP: ^https://github\.com/${{ github.repository }}/\.github/workflows/release\.yaml@refs/heads/main$
           CERT_OIDC_ISSUER: https://token.actions.githubusercontent.com
-        run: |
-          set -euo pipefail
-          while IFS= read -r ref; do
-            [ -z "$ref" ] && continue
-            echo "Verifying $ref"
-            cosign verify \
-              --certificate-identity-regexp "$CERT_IDENTITY_REGEXP" \
-              --certificate-oidc-issuer "$CERT_OIDC_ISSUER" \
-              "$ref" >/dev/null
-          done < pushed-refs.txt
-          echo "All published charts verified."
+        run: ./.github/scripts/verify-oci-signatures.sh
 
       - name: Verify public OCI chart access
         if: steps.releaser.outputs.changed_charts != ''
         shell: bash
-        run: |
-          set -euo pipefail
-          anonymous_config="$RUNNER_TEMP/helm-anonymous/config.json"
-          download_dir="$RUNNER_TEMP/helm-anonymous/downloads"
-          mkdir -p "$download_dir"
-          while IFS= read -r ref; do
-            [ -z "$ref" ] && continue
-            tagged_ref=${ref%@*}
-            chart_ref=${tagged_ref%:*}
-            chart_version=${tagged_ref##*:}
-            echo "Pulling $chart_ref:$chart_version without credentials"
-            helm pull \
-              "oci://${chart_ref}" \
-              --version "$chart_version" \
-              --destination "$download_dir" \
-              --registry-config "$anonymous_config"
-          done < pushed-refs.txt
-          echo "All published charts are publicly accessible."
+        run: ./.github/scripts/verify-public-oci-access.sh


### PR DESCRIPTION
## Summary

- move OCI chart push-and-sign logic into an executable shell script
- move signature verification and anonymous pull checks into dedicated shell scripts
- keep the existing release workflow steps, conditions, environment variables, and `pushed-refs.txt` handoff unchanged

## Why

Follow-up to Jonathan's maintainability feedback on #597. Keeping the operational Bash in standalone files makes it easier to review and test while preserving step-level visibility in GitHub Actions.

## Impact

No intended behavior change. The release workflow still publishes each changed chart to GHCR, signs it immediately, verifies the signature, and confirms anonymous Helm access.

## Validation

- `shellcheck .github/scripts/*.sh`
- `actionlint .github/workflows/release.yaml .github/workflows/pr-release.yaml`
- `bash -n` for all extracted scripts
- mocked push/sign/verify/pull execution, including the no-artifact failure path
- anonymous `helm pull oci://ghcr.io/wandb/helm-charts/operator-wandb --version 0.43.7`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Helm charts are now published to OCI registries with cryptographic signatures.
  - Published chart references and digests are recorded for traceability.
- **Verification**
  - Release automation verifies chart signatures after publishing.
  - It also confirms charts can be downloaded without authentication, helping ensure public availability.
- **Reliability**
  - Releases now report an error when no charts are published, improving detection of incomplete releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->