### PR TITLE
Add Lumen UI deployment chart

### DIFF
--- a/.github/workflows/test-lumen.yaml
+++ b/.github/workflows/test-lumen.yaml
@@ -6,6 +6,7 @@ on:
       - charts/lumen/**
       - charts/wandb-base/**
       - test-configs/lumen/**
+      - test-configs/lumen-kind/**
       - .github/workflows/test-lumen.yaml
 
 jobs:
@@ -69,7 +70,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create kind cluster
@@ -88,3 +89,67 @@ jobs:
           --config ct.yaml \
           --helm-extra-args '--kube-context kind-chart-testing-${{ matrix.k8s-version }}-${{ matrix.configuration }} --timeout 600s' \
           --helm-extra-set-args '--values test-configs/lumen/${{ matrix.configuration }}.yaml'
+
+  ui-smoke:
+    name: UI init and rollout smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.20.1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          version: v0.32.0
+          cluster_name: lumen-ui-smoke
+          node_image: kindest/node:v1.36.1
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/lumen
+
+      - name: Install UI smoke fixture
+        run: |
+          helm install lumen charts/lumen \
+            --namespace lumen \
+            --create-namespace \
+            --values test-configs/lumen-kind/ui-smoke.yaml \
+            --wait \
+            --timeout 5m
+
+      - name: Verify init permissions and readiness
+        run: |
+          kubectl --namespace lumen exec deployment/lumen-ui --container ui -- \
+            test -r /var/lib/lumen/ducklake-reader/latest.json
+          kubectl --namespace lumen exec deployment/lumen-ui --container ui -- \
+            sh -c "test \"\$(id -u)\" = \"999\""
+          kubectl --namespace lumen exec deployment/lumen-ui --container ui -- \
+            sh -c "test \"\$(stat -c %a /var/lib/lumen/ducklake-reader/latest.json)\" = \"600\""
+          if kubectl --namespace lumen exec deployment/lumen-ui --container ui -- \
+            touch /var/lib/lumen/ducklake-reader/must-stay-read-only; then
+            echo "reader-state application mount unexpectedly accepted a write" >&2
+            exit 1
+          fi
+          kubectl --namespace lumen get --raw \
+            /api/v1/namespaces/lumen/services/http:lumen-ui:3000/proxy/api/v1/ready
+
+      - name: Verify rollout RBAC scope
+        run: |
+          test "$(kubectl auth can-i get deployment/lumen-ui \
+            --namespace lumen \
+            --as system:serviceaccount:lumen:lumen-processor)" = "yes"
+          test "$(kubectl auth can-i patch deployment/lumen-ui \
+            --namespace lumen \
+            --as system:serviceaccount:lumen:lumen-processor)" = "yes"
+          test "$(kubectl auth can-i patch deployment/not-lumen-ui \
+            --namespace lumen \
+            --as system:serviceaccount:lumen:lumen-processor)" = "no"
+
+      - name: Verify rolling replacement
+        run: |
+          kubectl --namespace lumen rollout restart deployment/lumen-ui
+          kubectl --namespace lumen rollout status deployment/lumen-ui --timeout=5m

--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: wandb-base
   repository: file://../wandb-base
   version: 0.12.4
-digest: sha256:6c378616605bdde9cb62aa59528ac25bbb43f26b7e08610e58316d4be125561c
-generated: "2026-07-08T16:53:12.842245-07:00"
+- name: wandb-base
+  repository: file://../wandb-base
+  version: 0.12.4
+digest: sha256:70ee84eadc58e48ab0a7278b203389a098f86ce67307624133bc194c59f5a4f0
+generated: "2026-07-20T16:48:04.039475-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: lumen
-description: A Helm chart for deploying the W&B Lumen processor and notebook
+description: A Helm chart for deploying the W&B Lumen processor, notebook, and UI
 type: application
-version: 0.2.3
+version: 0.3.0
 appVersion: 1.0.0
 
 maintainers:
@@ -19,3 +19,8 @@ dependencies:
     alias: notebook
     version: "0.12.4"
     repository: file://../wandb-base
+  - name: wandb-base
+    alias: ui
+    version: "0.12.4"
+    repository: file://../wandb-base
+    condition: ui.enabled

--- a/charts/lumen/templates/_lumen.tpl
+++ b/charts/lumen/templates/_lumen.tpl
@@ -9,3 +9,55 @@
 {{- define "wandb.lumen.stagingPath" -}}
 /vol/staging
 {{- end -}}
+
+{{- define "wandb.lumen.ducklakeRoot" -}}
+{{- $configured := dig "config" "ducklakeRoot" "" .Values.ui -}}
+{{- if $configured -}}
+{{- $configured -}}
+{{- else -}}
+{{- $dataRoot := include "wandb.lumen.dataRoot" . -}}
+{{- if $dataRoot -}}
+{{- printf "%s/ducklake" (trimSuffix "/" $dataRoot) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wandb.lumen.uiFullname" -}}
+{{- if .Values.ui.fullnameOverride -}}
+{{- .Values.ui.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "ui" .Values.ui.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wandb.lumen.processorServiceAccountName" -}}
+{{- if .Values.processor.serviceAccount.name -}}
+{{- .Values.processor.serviceAccount.name -}}
+{{- else if .Values.processor.fullnameOverride -}}
+{{- .Values.processor.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "processor" .Values.processor.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wandb.lumen.validateUI" -}}
+{{- if .Values.ui.enabled -}}
+{{- if and (not .Values.ui.image.digest) (or (not .Values.ui.image.tag) (eq .Values.ui.image.tag "latest")) -}}
+{{- fail "ui.image.tag must be an immutable tag, or ui.image.digest must be set, when ui.enabled=true" -}}
+{{- end -}}
+{{- $fetchImage := index .Values.ui.initContainers "fetch-reader" "image" -}}
+{{- if and (not $fetchImage.digest) (or (not $fetchImage.tag) (eq $fetchImage.tag "latest")) -}}
+{{- fail "ui.initContainers.fetch-reader.image.tag must be an immutable tag, or its digest must be set, when ui.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lumen/templates/_lumen.tpl
+++ b/charts/lumen/templates/_lumen.tpl
@@ -51,6 +51,9 @@
 {{- end -}}
 
 {{- define "wandb.lumen.validateUI" -}}
+{{- if and .Values.ui.exposure.enabled (not .Values.ui.enabled) -}}
+{{- fail "ui.exposure.enabled requires ui.enabled=true" -}}
+{{- end -}}
 {{- if .Values.ui.enabled -}}
 {{- if and (not .Values.ui.image.digest) (or (not .Values.ui.image.tag) (eq .Values.ui.image.tag "latest")) -}}
 {{- fail "ui.image.tag must be an immutable tag, or ui.image.digest must be set, when ui.enabled=true" -}}
@@ -58,6 +61,11 @@
 {{- $fetchImage := index .Values.ui.initContainers "fetch-reader" "image" -}}
 {{- if and (not $fetchImage.digest) (or (not $fetchImage.tag) (eq $fetchImage.tag "latest")) -}}
 {{- fail "ui.initContainers.fetch-reader.image.tag must be an immutable tag, or its digest must be set, when ui.enabled=true" -}}
+{{- end -}}
+{{- if .Values.ui.exposure.enabled -}}
+{{- $serviceAnnotations := default (dict) .Values.ui.service.annotations -}}
+{{- $_ := required "ui.service.annotations[cloud.google.com/neg] is required when ui.exposure.enabled=true" (get $serviceAnnotations "cloud.google.com/neg") -}}
+{{- $_ := required "ui.service.annotations[cloud.google.com/backend-config] is required when ui.exposure.enabled=true" (get $serviceAnnotations "cloud.google.com/backend-config") -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/lumen/templates/_volumes.tpl
+++ b/charts/lumen/templates/_volumes.tpl
@@ -7,3 +7,22 @@
 - name: lumen-staging-dir
   emptyDir: { }
 {{- end }}
+
+{{- define "wandb.lumenUISecretVolume" }}
+{{- if .Values.secretProviderClass.enabled }}
+- name: lumen-ui-secrets
+  csi:
+    driver: secrets-store-gke.csi.k8s.io
+    readOnly: true
+    volumeAttributes:
+      secretProviderClass: {{ printf "%s-ui" .Release.Name | quote }}
+{{- end }}
+{{- end }}
+
+{{- define "wandb.lumenUISecretVolumeMount" }}
+{{- if .Values.secretProviderClass.enabled }}
+- name: lumen-ui-secrets
+  mountPath: /var/run/secrets/lumen-ui
+  readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/lumen/templates/configmap.yaml
+++ b/charts/lumen/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "wandb.lumen.validateUI" . -}}
 {{- $bucket := include "wandb.lumen.dataRoot" . -}}
 apiVersion: v1
 kind: ConfigMap
@@ -6,6 +7,10 @@ metadata:
 data:
   LUMEN_DATA_ROOT: {{ $bucket | quote }}
   LUMEN_STAGING_ROOT: "file://{{ include "wandb.lumen.stagingPath" . }}"
+  {{- if .Values.ui.enabled }}
+  LUMEN_UI_ROLLOUT_DEPLOYMENT: {{ include "wandb.lumen.uiFullname" . | quote }}
+  LUMEN_UI_ROLLOUT_NAMESPACE: {{ .Release.Namespace | quote }}
+  {{- end }}
 
 ---
 
@@ -17,3 +22,29 @@ data:
   XDG_CONFIG_HOME: "{{ include "wandb.lumen.stagingPath" . }}/.config"
   XDG_STATE_HOME: "{{ include "wandb.lumen.stagingPath" . }}/.local/state"
   XDG_CACHE_HOME: "{{ include "wandb.lumen.stagingPath" . }}/.cache"
+
+{{- if .Values.ui.enabled }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ui-configmap
+data:
+  NODE_ENV: "production"
+  PORT: "3000"
+  LUMEN_DUCKLAKE_ROOT: {{ required "ui.config.ducklakeRoot or global.lumen.dataRoot is required when ui.enabled=true" (include "wandb.lumen.ducklakeRoot" .) | quote }}
+  LUMEN_DUCKLAKE_STATE_DIR: "/var/lib/lumen/ducklake-reader"
+  LUMEN_UI_SOURCE_MODE: "ducklake"
+  LUMEN_UI_INSTALL_DUCKDB_EXTENSIONS: "false"
+  LUMEN_UI_SESSION_SECRET_FILE: "/var/run/secrets/lumen-ui/session-secret"
+  GITHUB_APP_CLIENT_SECRET_FILE: "/var/run/secrets/lumen-ui/github-client-secret"
+  LUMEN_UI_HOSTNAME: {{ .Values.ui.config.hostname | quote }}
+  GITHUB_APP_CLIENT_ID: {{ .Values.ui.config.github.clientId | quote }}
+  {{- if .Values.ui.config.github.redirectUri }}
+  GITHUB_APP_REDIRECT_URI: {{ .Values.ui.config.github.redirectUri | quote }}
+  {{- end }}
+  GITHUB_ALLOWED_ORG: {{ .Values.ui.config.github.allowedOrg | quote }}
+  GITHUB_ALLOWED_TEAM_SLUG: {{ .Values.ui.config.github.allowedTeamSlug | quote }}
+  AUTH_ALLOWED_EMAIL_DOMAINS: {{ join "," .Values.ui.config.allowedEmailDomains | quote }}
+{{- end }}

--- a/charts/lumen/templates/ui-ingress.yaml
+++ b/charts/lumen/templates/ui-ingress.yaml
@@ -1,0 +1,71 @@
+{{- if and .Values.ui.enabled .Values.ui.exposure.enabled }}
+{{- $name := printf "%s-ui" .Release.Name }}
+{{- $hostname := required "ui.config.hostname is required when ui.exposure.enabled=true" .Values.ui.config.hostname }}
+{{- $staticIpName := required "ui.exposure.globalStaticIpName is required when ui.exposure.enabled=true" .Values.ui.exposure.globalStaticIpName }}
+{{- $iapSecretName := required "ui.exposure.iap.oauthSecretName is required when ui.exposure.enabled=true" .Values.ui.exposure.iap.oauthSecretName }}
+{{- $iapCredentialRevision := required "ui.exposure.iap.credentialRevision is required when ui.exposure.enabled=true" .Values.ui.exposure.iap.credentialRevision }}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ $name }}
+  annotations:
+    lumen.wandb.com/iap-credential-revision: {{ $iapCredentialRevision | quote }}
+spec:
+  timeoutSec: 180
+  connectionDraining:
+    drainingTimeoutSec: 150
+  healthCheck:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 3
+    type: HTTP
+    requestPath: /api/v1/health
+    port: 3000
+  iap:
+    enabled: true
+    oauthclientCredentials:
+      secretName: {{ $iapSecretName }}
+  logging:
+    enable: true
+    sampleRate: 1.0
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ $name }}
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ $name }}
+spec:
+  domains:
+    - {{ $hostname | quote }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.global-static-ip-name: {{ $staticIpName | quote }}
+    networking.gke.io/managed-certificates: {{ $name | quote }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ $name | quote }}
+spec:
+  rules:
+    - host: {{ $hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $name }}
+                port:
+                  number: 3000
+{{- end }}

--- a/charts/lumen/templates/ui-rollout-rbac.yaml
+++ b/charts/lumen/templates/ui-rollout-rbac.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ui.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-processor-ui-rollout
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: [{{ include "wandb.lumen.uiFullname" . | quote }}]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-processor-ui-rollout
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "wandb.lumen.processorServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-processor-ui-rollout
+{{- end }}

--- a/charts/lumen/templates/ui-secret-provider-class.yaml
+++ b/charts/lumen/templates/ui-secret-provider-class.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.ui.enabled .Values.ui.secretProviderClass.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Release.Name }}-ui
+spec:
+  provider: gke
+  parameters:
+    secrets: |
+      - resourceName: {{ required "ui.secretProviderClass.sessionSecretResourceName is required" .Values.ui.secretProviderClass.sessionSecretResourceName | quote }}
+        path: "session-secret"
+      - resourceName: {{ required "ui.secretProviderClass.githubClientSecretResourceName is required" .Values.ui.secretProviderClass.githubClientSecretResourceName | quote }}
+        path: "github-client-secret"
+{{- end }}

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -112,7 +112,7 @@ notebook:
 # UI: read-only configuration explorer. Disabled until its identity, Secret
 # Manager resources, hostname, and immutable image tags are configured.
 ui:
-  enabled: false
+  enabled: true
   kind: Deployment
   replicaCount: 2
   image:

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -159,6 +159,17 @@ ui:
     enabled: true
     sessionSecretResourceName: ""
     githubClientSecretResourceName: ""
+  exposure:
+    # Creates a GKE external Ingress with a managed certificate, HTTPS redirect,
+    # and IAP-protected BackendConfig. The Service remains ClusterIP-only and
+    # reaches pods through an ingress NEG, leaving no direct public bypass.
+    enabled: false
+    globalStaticIpName: ""
+    iap:
+      oauthSecretName: ""
+      # A non-secret digest of the OAuth client secret. Updating it causes the
+      # BackendConfig to reconcile when the referenced Secret is rotated.
+      credentialRevision: ""
   volumes:
     - name: ducklake-reader
       emptyDir:

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -112,7 +112,7 @@ notebook:
 # UI: read-only configuration explorer. Disabled until its identity, Secret
 # Manager resources, hostname, and immutable image tags are configured.
 ui:
-  enabled: true
+  enabled: false
   kind: Deployment
   replicaCount: 2
   image:

--- a/charts/lumen/values.yaml
+++ b/charts/lumen/values.yaml
@@ -108,3 +108,124 @@ notebook:
         limits:
           cpu: 8
           memory: 24Gi
+
+# UI: read-only configuration explorer. Disabled until its identity, Secret
+# Manager resources, hostname, and immutable image tags are configured.
+ui:
+  enabled: false
+  kind: Deployment
+  replicaCount: 2
+  image:
+    repository: us-docker.pkg.dev/wandb-production/public/wandb/lumen-ui
+    # Required when enabled. Use the immutable Git SHA published by wandb/lumen.
+    tag: ""
+  serviceAccount:
+    create: true
+    automount: true
+    annotations: {}
+  globalOptOut:
+    volumes: true
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  terminationGracePeriodSeconds: 150
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+    maxUnavailable: 0
+  service:
+    enabled: true
+    ports:
+      - port: 3000
+        targetPort: http
+        protocol: TCP
+        name: http
+  config:
+    # Defaults to <global.lumen.dataRoot>/ducklake when empty.
+    ducklakeRoot: ""
+    hostname: ""
+    allowedEmailDomains:
+      - wandb.com
+      - coreweave.com
+    github:
+      clientId: ""
+      redirectUri: ""
+      allowedOrg: wandb
+      allowedTeamSlug: engineering
+  secretProviderClass:
+    # The GKE managed Secret Manager add-on. Disable only in local chart tests.
+    enabled: true
+    sessionSecretResourceName: ""
+    githubClientSecretResourceName: ""
+  volumes:
+    - name: ducklake-reader
+      emptyDir:
+        sizeLimit: 1Gi
+  volumesTpls:
+    - '{{ include "wandb.lumenUISecretVolume" . }}'
+  initContainers:
+    fetch-reader:
+      image:
+        repository: us-docker.pkg.dev/wandb-production/public/wandb/lumen
+        # Required when enabled and initially expected to match ui.image.tag.
+        tag: ""
+        pullPolicy: IfNotPresent
+      command: ["/app/bin/processor"]
+      args: ["ducklake", "fetch", "--state-dir", "/var/lib/lumen/ducklake-reader"]
+      envFrom:
+        "{{ .Release.Name }}-ui-configmap": configMapRef
+      volumeMounts:
+        - name: ducklake-reader
+          mountPath: /var/lib/lumen/ducklake-reader
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 1
+          memory: 1Gi
+  containers:
+    ui:
+      envFrom:
+        "{{ .Release.Name }}-ui-configmap": configMapRef
+      ports:
+        - containerPort: 3000
+          name: http
+      livenessProbe:
+        httpGet:
+          path: /api/v1/health
+          port: http
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /api/v1/ready
+          port: http
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      startupProbe:
+        httpGet:
+          path: /api/v1/ready
+          port: http
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
+      volumeMounts:
+        - name: ducklake-reader
+          mountPath: /var/lib/lumen/ducklake-reader
+          readOnly: true
+      volumeMountsTpls:
+        - '{{ include "wandb.lumenUISecretVolumeMount" . }}'
+      resources:
+        requests:
+          cpu: 1
+          memory: 4Gi
+          ephemeral-storage: 1Gi
+        limits:
+          cpu: 4
+          memory: 12Gi
+          ephemeral-storage: 10Gi

--- a/test-configs/lumen-kind/ui-smoke.yaml
+++ b/test-configs/lumen-kind/ui-smoke.yaml
@@ -1,0 +1,64 @@
+# Lightweight images exercise the chart's init/application separation, shared
+# UID file ownership, readiness, and rolling replacement without cloud access.
+global:
+  repositoryPrefix: ""
+  lumen:
+    dataRoot: file:///tmp/lumen
+
+notebook:
+  replicaCount: 0
+
+processor:
+  cronJobs:
+    processor:
+      suspend: true
+
+ui:
+  enabled: true
+  image:
+    repository: busybox
+    tag: 1.37.0
+    pullPolicy: IfNotPresent
+  secretProviderClass:
+    enabled: false
+  initContainers:
+    fetch-reader:
+      image:
+        repository: alpine
+        tag: 3.23.3
+        pullPolicy: IfNotPresent
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -eu
+          mkdir -p /var/lib/lumen/ducklake-reader
+          printf '{"snapshot_id":1}\n' > /var/lib/lumen/ducklake-reader/latest.json
+          chmod 0600 /var/lib/lumen/ducklake-reader/latest.json
+      envFrom: {}
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+  containers:
+    ui:
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -eu
+          test -r /var/lib/lumen/ducklake-reader/latest.json
+          mkdir -p /tmp/www/api/v1
+          printf '{"status":"healthy"}\n' > /tmp/www/api/v1/health
+          printf '{"status":"ready","snapshotId":1}\n' > /tmp/www/api/v1/ready
+          exec httpd -f -p 3000 -h /tmp/www
+      envFrom: {}
+      volumeMountsTpls: []
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi

--- a/test-configs/lumen/__snapshots__/ui-enabled.snap
+++ b/test-configs/lumen/__snapshots__/ui-enabled.snap
@@ -1,0 +1,551 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: lumen/charts/ui/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0123456789abcdef0123456789abcdef01234567"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: ui
+      app.kubernetes.io/instance: chartsnap
+  minAvailable: 1
+---
+# Source: lumen/charts/notebook/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/charts/processor/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/charts/ui/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0123456789abcdef0123456789abcdef01234567"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  LUMEN_DATA_ROOT: "gs://wandb-lumen-example/sandbox"
+  LUMEN_STAGING_ROOT: "file:///vol/staging"
+  LUMEN_UI_ROLLOUT_DEPLOYMENT: "chartsnap-ui"
+  LUMEN_UI_ROLLOUT_NAMESPACE: "default"
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-marimo-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  XDG_CONFIG_HOME: "/vol/staging/.config"
+  XDG_STATE_HOME: "/vol/staging/.local/state"
+  XDG_CACHE_HOME: "/vol/staging/.cache"
+---
+# Source: lumen/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-ui-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  NODE_ENV: "production"
+  PORT: "3000"
+  LUMEN_DUCKLAKE_ROOT: "gs://wandb-lumen-example/sandbox/ducklake"
+  LUMEN_DUCKLAKE_STATE_DIR: "/var/lib/lumen/ducklake-reader"
+  LUMEN_UI_SOURCE_MODE: "ducklake"
+  LUMEN_UI_INSTALL_DUCKDB_EXTENSIONS: "false"
+  LUMEN_UI_SESSION_SECRET_FILE: "/var/run/secrets/lumen-ui/session-secret"
+  GITHUB_APP_CLIENT_SECRET_FILE: "/var/run/secrets/lumen-ui/github-client-secret"
+  LUMEN_UI_HOSTNAME: "lumen-sandbox.wandb.dev"
+  GITHUB_APP_CLIENT_ID: "example-client-id"
+  GITHUB_APP_REDIRECT_URI: "https://lumen-sandbox.wandb.dev/auth/github/callback"
+  GITHUB_ALLOWED_ORG: "wandb"
+  GITHUB_ALLOWED_TEAM_SLUG: "engineering"
+  AUTH_ALLOWED_EMAIL_DOMAINS: "wandb.com,coreweave.com"
+---
+# Source: lumen/templates/ui-rollout-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-processor-ui-rollout
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  resourceNames: ["chartsnap-ui"]
+  verbs: ["get", "patch"]
+---
+# Source: lumen/templates/ui-rollout-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-processor-ui-rollout
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-processor
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-processor-ui-rollout
+---
+# Source: lumen/charts/notebook/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: marimo
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: lumen/charts/ui/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0123456789abcdef0123456789abcdef01234567"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: lumen/charts/notebook/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-notebook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: notebook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notebook
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: notebook
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "v0.1.5"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: notebook
+        command:
+        - /app/entrypoint.sh
+        - marimo
+        envFrom:
+        - configMapRef:
+            name: chartsnap-configmap
+        - configMapRef:
+            name: chartsnap-marimo-configmap
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: marimo
+        resources:
+          limits:
+            cpu: 8
+            memory: 24Gi
+          requests:
+            cpu: 2
+            memory: 12Gi
+        volumeMounts:
+        - name: lumen-staging-dir
+          mountPath: /vol/staging
+      serviceAccountName: chartsnap-notebook
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: notebook
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: lumen-staging-dir
+        emptyDir: {}
+---
+# Source: lumen/charts/ui/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: ui
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0123456789abcdef0123456789abcdef01234567"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ui
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: ui
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "0123456789abcdef0123456789abcdef01234567"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: ui
+        envFrom:
+        - configMapRef:
+            name: chartsnap-ui-configmap
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen-ui:0123456789abcdef0123456789abcdef01234567"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+          name: http
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /api/v1/health
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /api/v1/ready
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 5
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /api/v1/ready
+            port: http
+          periodSeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 4
+            ephemeral-storage: 10Gi
+            memory: 12Gi
+          requests:
+            cpu: 1
+            ephemeral-storage: 1Gi
+            memory: 4Gi
+        volumeMounts:
+        - name: lumen-ui-secrets
+          mountPath: /var/run/secrets/lumen-ui
+          readOnly: true
+        - mountPath: /var/lib/lumen/ducklake-reader
+          name: ducklake-reader
+          readOnly: true
+      initContainers:
+      - name: fetch-reader
+        command:
+        - /app/bin/processor
+        args:
+        - ducklake
+        - fetch
+        - --state-dir
+        - /var/lib/lumen/ducklake-reader
+        envFrom:
+        - configMapRef:
+            name: chartsnap-ui-configmap
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:0123456789abcdef0123456789abcdef01234567"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/lib/lumen/ducklake-reader
+          name: ducklake-reader
+      serviceAccountName: chartsnap-ui
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 150
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: ui
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: ui
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: lumen-ui-secrets
+        csi:
+          driver: secrets-store-gke.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: "chartsnap-ui"
+      - emptyDir:
+          sizeLimit: 1Gi
+        name: ducklake-reader
+---
+# Source: lumen/charts/processor/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-processor
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: processor
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "15 * * * *"
+  suspend: false
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 5
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: processor
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/version: "v0.1.5"
+            app.kubernetes.io/managed-by: Helm
+        spec:
+          containers:
+          - name: collector
+            command:
+            - /app/entrypoint.sh
+            - processor
+            envFrom:
+            - configMapRef:
+                name: chartsnap-configmap
+            env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 12
+                memory: 24Gi
+              requests:
+                cpu: 8
+                memory: 12Gi
+            volumeMounts:
+            - name: lumen-staging-dir
+              mountPath: /vol/staging
+          restartPolicy: OnFailure
+          serviceAccountName: chartsnap-processor
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: processor
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          volumes:
+          - name: lumen-staging-dir
+            emptyDir: {}
+---
+# Source: lumen/templates/ui-secret-provider-class.yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  provider: gke
+  parameters:
+    secrets: |
+      - resourceName: "projects/wandb-lumen/secrets/lumen-ui-session-sandbox/versions/latest"
+        path: "session-secret"
+      - resourceName: "projects/wandb-lumen/secrets/lumen-ui-github-client-sandbox/versions/latest"
+        path: "github-client-secret"

--- a/test-configs/lumen/__snapshots__/ui-enabled.snap
+++ b/test-configs/lumen/__snapshots__/ui-enabled.snap
@@ -169,6 +169,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "0123456789abcdef0123456789abcdef01234567"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/backend-config: '{"default": "lumen-ui"}'
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: ClusterIP
   ports:
@@ -533,6 +536,83 @@ spec:
           volumes:
           - name: lumen-staging-dir
             emptyDir: {}
+---
+# Source: lumen/templates/ui-ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chartsnap-ui
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.global-static-ip-name: "lumen-ui-sandbox"
+    networking.gke.io/managed-certificates: "chartsnap-ui"
+    networking.gke.io/v1beta1.FrontendConfig: "chartsnap-ui"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  rules:
+  - host: "lumen-sandbox.wandb.dev"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: chartsnap-ui
+            port:
+              number: 3000
+---
+# Source: lumen/templates/ui-ingress.yaml
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: chartsnap-ui
+  annotations:
+    lumen.wandb.com/iap-credential-revision: "8c32f1e10f9528909d32ec11dd37d618908673e22790ac7273d21c5f3f6c827f"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  timeoutSec: 180
+  connectionDraining:
+    drainingTimeoutSec: 150
+  healthCheck:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 3
+    type: HTTP
+    requestPath: /api/v1/health
+    port: 3000
+  iap:
+    enabled: true
+    oauthclientCredentials:
+      secretName: lumen-ui-iap-oauth
+  logging:
+    enable: true
+    sampleRate: 1.0
+---
+# Source: lumen/templates/ui-ingress.yaml
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT
+---
+# Source: lumen/templates/ui-ingress.yaml
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: chartsnap-ui
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  domains:
+  - "lumen-sandbox.wandb.dev"
 ---
 # Source: lumen/templates/ui-secret-provider-class.yaml
 apiVersion: secrets-store.csi.x-k8s.io/v1

--- a/test-configs/lumen/ui-enabled.yaml
+++ b/test-configs/lumen/ui-enabled.yaml
@@ -1,0 +1,24 @@
+# Production-shaped UI rendering with immutable but illustrative image SHAs and
+# Secret Manager resources. This is a render-only fixture; no secret values are
+# stored in the repository.
+global:
+  repositoryPrefix: ""
+  lumen:
+    dataRoot: gs://wandb-lumen-example/sandbox
+
+ui:
+  enabled: true
+  image:
+    tag: 0123456789abcdef0123456789abcdef01234567
+  initContainers:
+    fetch-reader:
+      image:
+        tag: 0123456789abcdef0123456789abcdef01234567
+  config:
+    hostname: lumen-sandbox.wandb.dev
+    github:
+      clientId: example-client-id
+      redirectUri: https://lumen-sandbox.wandb.dev/auth/github/callback
+  secretProviderClass:
+    sessionSecretResourceName: projects/wandb-lumen/secrets/lumen-ui-session-sandbox/versions/latest
+    githubClientSecretResourceName: projects/wandb-lumen/secrets/lumen-ui-github-client-sandbox/versions/latest

--- a/test-configs/lumen/ui-enabled.yaml
+++ b/test-configs/lumen/ui-enabled.yaml
@@ -22,3 +22,13 @@ ui:
   secretProviderClass:
     sessionSecretResourceName: projects/wandb-lumen/secrets/lumen-ui-session-sandbox/versions/latest
     githubClientSecretResourceName: projects/wandb-lumen/secrets/lumen-ui-github-client-sandbox/versions/latest
+  exposure:
+    enabled: true
+    globalStaticIpName: lumen-ui-sandbox
+    iap:
+      oauthSecretName: lumen-ui-iap-oauth
+      credentialRevision: 8c32f1e10f9528909d32ec11dd37d618908673e22790ac7273d21c5f3f6c827f
+  service:
+    annotations:
+      cloud.google.com/neg: '{"ingress": true}'
+      cloud.google.com/backend-config: '{"default": "lumen-ui"}'


### PR DESCRIPTION
## What changed

- add a disabled-by-default Lumen UI Deployment with two rolling replicas, Service, probes, PDB, resource defaults, and topology spreading
- fetch DuckLake reader state in an init container and mount it read-only in the UI container
- add a dedicated UI service account and GKE Secret Manager CSI-backed session/GitHub secret files
- pass non-sensitive hostname and GitHub authorization settings through the ConfigMap
- grant the processor narrowly scoped `get`/`patch` access to the named UI Deployment
- require immutable processor and UI image references whenever the UI is enabled
- add a separately gated GKE Ingress, managed certificate, HTTPS redirect, IAP `BackendConfig`, NEG wiring, and full backend logging
- require the stable address, IAP Secret reference, non-secret rotation revision, and Service annotations whenever external exposure is enabled
- add enabled rendering snapshots and a Kind smoke test for permissions, readiness, RBAC, and rolling replacement
- bump the chart to `0.3.0`

## Why

This provides the complete Kubernetes deployment contract for the read-only Lumen UI. Both the workload and public exposure remain independently disabled until Terraform, identity, DNS, secrets, and immutable images are ready.

## Impact

Existing installs are unchanged because `ui.enabled` and `ui.exposure.enabled` default to `false`. Exposure uses a `ClusterIP` Service and container-native NEG, leaving no direct public Service bypass around IAP.

## Validation

- `./snapshots.sh update lumen`
- `./snapshots.sh run lumen`
- `./snapshots.sh lint lumen`
- `helm lint charts/lumen -f test-configs/lumen/ui-enabled.yaml`
- enabled render checks for Ingress, `BackendConfig`, managed certificate, hostname, IAP Secret, and rotation annotation
- disabled and invalid-input checks, including exposure without UI, missing IAP revision, and missing NEG annotations
- isolated Kubernetes 1.36 Kind smoke test for the non-exposure UI resources
- `git diff --check`

Companion PRs: [wandb/lumen#31](https://github.com/wandb/lumen/pull/31), [wandb/core#48540](https://github.com/wandb/core/pull/48540).
