### PR TITLE
chore: add default env vars for service sizing blocks

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.7
+version: 0.43.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -697,6 +697,8 @@ api:
   size: ""
   sizing:
     small:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
       resources:
         limits:
           cpu: "4"
@@ -710,6 +712,8 @@ api:
           maxReplicas: 2
           minReplicas: 2
     medium:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "150"
       resources:
         limits:
           cpu: "6"
@@ -723,6 +727,8 @@ api:
           maxReplicas: 2
           minReplicas: 2
     large:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "240"
       resources:
         limits:
           cpu: "6"
@@ -736,6 +742,8 @@ api:
           maxReplicas: 2
           minReplicas: 2
     xlarge:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "240"
       resources:
         limits:
           cpu: "6"
@@ -749,6 +757,8 @@ api:
           maxReplicas: 2
           minReplicas: 2
     xxlarge:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "240"
       resources:
         limits:
           cpu: "6"
@@ -1137,6 +1147,8 @@ executor:
   size: ""
   sizing:
     small:
+      env:
+        GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS: 4
       resources:
         limits:
           cpu: "4"
@@ -1150,6 +1162,8 @@ executor:
           maxReplicas: 2
           minReplicas: 1
     medium:
+      env:
+        GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS: 6
       resources:
         limits:
           cpu: "6"
@@ -1163,6 +1177,8 @@ executor:
           maxReplicas: 3
           minReplicas: 1
     large:
+      env:
+        GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS: 6
       resources:
         limits:
           cpu: "6"
@@ -1176,6 +1192,8 @@ executor:
           maxReplicas: 4
           minReplicas: 2
     xlarge:
+      env:
+        GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS: 10
       resources:
         limits:
           cpu: "10"
@@ -1189,6 +1207,8 @@ executor:
           maxReplicas: 5
           minReplicas: 2
     xxlarge:
+      env:
+        GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS: 10
       resources:
         limits:
           cpu: "10"
@@ -1517,6 +1537,8 @@ flat-run-fields-updater:
   size: ""
   sizing:
     small:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
       resources:
         limits:
           cpu: "2"
@@ -1563,6 +1585,8 @@ flat-run-fields-updater:
                   selectPolicy: Max
           # triggers must be provided by user when enabling KEDA
     medium:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
       resources:
         limits:
           cpu: "2"
@@ -1609,6 +1633,8 @@ flat-run-fields-updater:
                   selectPolicy: Max
           # triggers must be provided by user when enabling KEDA
     large:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
       resources:
         limits:
           cpu: "2"
@@ -1655,6 +1681,8 @@ flat-run-fields-updater:
                   selectPolicy: Max
           # triggers must be provided by user when enabling KEDA
     xlarge:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
       resources:
         limits:
           cpu: "2"
@@ -1701,6 +1729,8 @@ flat-run-fields-updater:
                   selectPolicy: Max
           # triggers must be provided by user when enabling KEDA
     xxlarge:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
       resources:
         limits:
           cpu: "2"
@@ -2709,6 +2739,11 @@ parquet:
   size: ""
   sizing:
     small:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "100"
+        GORILLA_PARQUET_READER_METADATA_CACHE_SIZE: "25"
+        GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB: "1500"
+        GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS: "1000000"
       resources:
         limits:
           cpu: "4"
@@ -2722,6 +2757,11 @@ parquet:
           maxReplicas: 2
           minReplicas: 2
     medium:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "250"
+        GORILLA_PARQUET_READER_METADATA_CACHE_SIZE: "50"
+        GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB: "2500"
+        GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS: "2000000"
       resources:
         limits:
           cpu: "15"
@@ -2735,6 +2775,11 @@ parquet:
           maxReplicas: 2
           minReplicas: 2
     large:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "420"
+        GORILLA_PARQUET_READER_METADATA_CACHE_SIZE: "50"
+        GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB: "2500"
+        GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS: "2000000"
       resources:
         limits:
           cpu: "15"
@@ -2749,6 +2794,11 @@ parquet:
           minReplicas: 2
     # At larger t-shirt sizes, reserve an entire node for parquet.
     xlarge:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "420"
+        GORILLA_PARQUET_READER_METADATA_CACHE_SIZE: "50"
+        GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB: "2500"
+        GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS: "2000000"
       resources:
         limits:
           cpu: "15"
@@ -2762,6 +2812,11 @@ parquet:
           maxReplicas: 3
           minReplicas: 2
     xxlarge:
+      env:
+        GORILLA_MYSQL_MAX_OPEN_CONNS: "430"
+        GORILLA_PARQUET_READER_METADATA_CACHE_SIZE: "50"
+        GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB: "2500"
+        GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS: "2000000"
       resources:
         limits:
           cpu: "15"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -3364,6 +3364,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4185,6 +4193,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -3368,6 +3368,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4189,6 +4197,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -3368,6 +3368,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4189,6 +4197,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -3685,6 +3685,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4506,6 +4514,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -3390,6 +3390,8 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_FLAT_RUN_FIELDS_UPDATER
           value: 'kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)'
         securityContext:
@@ -3678,6 +3680,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4499,6 +4509,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -3608,6 +3608,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4429,6 +4437,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -3608,6 +3608,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4429,6 +4437,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -3606,6 +3606,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4427,6 +4435,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2793,6 +2793,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4027,6 +4029,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4880,6 +4890,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2793,6 +2793,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4029,6 +4031,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4882,6 +4892,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2793,6 +2793,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4029,6 +4031,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4882,6 +4892,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -3192,6 +3192,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4421,6 +4423,8 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS
+          value: "4"
         - name: GORILLA_TASK_QUEUE
           value: 'redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)&concurrency=10'
         securityContext:
@@ -4985,6 +4989,8 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_FLAT_RUN_FIELDS_UPDATER
           value: 'pubsub:/playground-111/run-updates-shadow/flat-run-fields-updater'
         securityContext:
@@ -5573,6 +5579,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6554,6 +6568,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -3192,6 +3192,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4421,6 +4423,8 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_PARQUET_POLICY_EXPORT_NUM_WORKERS
+          value: "4"
         - name: GORILLA_TASK_QUEUE
           value: 'redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)&concurrency=10'
         securityContext:
@@ -4985,6 +4989,8 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_FLAT_RUN_FIELDS_UPDATER
           value: 'pubsub:/playground-111/run-updates-shadow/flat-run-fields-updater'
         securityContext:
@@ -5573,6 +5579,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6554,6 +6568,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -3462,6 +3462,14 @@ spec:
           value: :16060
         - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
           value: "true"
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4433,6 +4441,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -3460,6 +3460,14 @@ spec:
           value: :16060
         - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
           value: "true"
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4431,6 +4439,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -3472,6 +3472,14 @@ spec:
           value: :16060
         - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
           value: "true"
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4443,6 +4451,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -3437,6 +3437,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4390,6 +4398,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -3439,6 +3439,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4392,6 +4400,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2794,6 +2794,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4028,6 +4030,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4881,6 +4891,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2819,6 +2819,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4083,6 +4085,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4936,6 +4946,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2819,6 +2819,8 @@ spec:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4083,6 +4085,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4936,6 +4946,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -3392,6 +3392,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4218,6 +4226,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -3374,6 +3374,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4197,6 +4205,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -3422,6 +3422,14 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4522,6 +4530,14 @@ spec:
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:


### PR DESCRIPTION
Moves the Dedicated Cloud sizing environment variables into the operator-wandb chart’s existing sizing profiles. This establishes the chart as the source of truth for API, Parquet, Executor, and Flat Run Fields Updater sizing defaults.

The values exactly match the current Deployer configuration, so upgrading the chart while retaining the Deployer overrides is a no-op. After rollout, the redundant sizing blocks can be safely removed from Deployer. Explicit Helm overrides continue to take precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Tuned database connection limits and parquet processing settings across deployment sizing tiers.
  * Improved parquet reader cache configuration and export worker scaling for larger workloads.

* **Release**
  * Updated the Helm chart version to 0.43.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->