### PR TITLE
fix: grant operator ClusterRole coordination.k8s.io/leases

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 1.4.7
+version: 1.4.8
 appVersion: "1.0.0"
 maintainers:
   - name: wandb

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -225,6 +225,18 @@ role:
         - update
         - patch
         - delete
+    - apiGroups:
+        - coordination.k8s.io
+      resources:
+        - leases
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
 resources:
   limits:
     cpu: 1000m


### PR DESCRIPTION
* Operator couldn't patch workload Roles requesting Lease permissions (e.g. glue leader election) since it can't grant a permission it doesn't hold itself — Kubernetes blocks the self-escalation and reconcile fails, leaving the CR stuck in Invalid Config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes operator reliability by enabling required access to coordination leases.
  * Added permissions to create, update, patch, delete, get, list, and watch lease resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->