### PR TITLE
chore: raise & align frfu/history-updater memory at large/xlarge/xxlarge

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.8
+version: 0.43.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1638,10 +1638,10 @@ flat-run-fields-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 4Gi
+          memory: 6Gi
         requests:
-          cpu: 250m
-          memory: 2Gi
+          cpu: "1"
+          memory: 4Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1686,10 +1686,10 @@ flat-run-fields-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 8Gi
+          memory: 12Gi
         requests:
-          cpu: 350m
-          memory: 4Gi
+          cpu: "1"
+          memory: 6Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1734,10 +1734,10 @@ flat-run-fields-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 8Gi
+          memory: 16Gi
         requests:
-          cpu: 500m
-          memory: 4Gi
+          cpu: "1"
+          memory: 8Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1819,11 +1819,11 @@ history-updater:
     repository: wandb/megabinary
     tag: latest
   size: ""
-  # Replica counts kept identical to flat-run-fields-updater (same queue,
-  # scales together). Resources are lighter: 2-week prod observation shows
-  # per-pod memory averaging ~0.4 GiB with a real-traffic peak of ~1.9 GiB
-  # (largest dedicated deployment) and CPU averaging ~70m/pod. Limits keep
-  # headroom above the peak; requests track the observed working set.
+  # CPU and replica counts kept identical to flat-run-fields-updater (same
+  # queue, scales together). Memory is lighter: 2-week prod observation shows
+  # ~0.4 GiB/pod average and a ~1.9 GiB real-traffic peak (largest dedicated
+  # deployment), with ~4.3 GiB seen under synthetic xxl load. Limits give
+  # headroom above the peak, growing at the upper tiers.
   sizing:
     small:
       resources:
@@ -1921,10 +1921,10 @@ history-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          cpu: 250m
-          memory: 1Gi
+          cpu: "1"
+          memory: 2Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1967,10 +1967,10 @@ history-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 4Gi
+          memory: 6Gi
         requests:
-          cpu: 350m
-          memory: 1536Mi
+          cpu: "1"
+          memory: 3Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -2013,10 +2013,10 @@ history-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 4Gi
+          memory: 8Gi
         requests:
-          cpu: 500m
-          memory: 1536Mi
+          cpu: "1"
+          memory: 4Gi
       autoscaling:
         horizontal:
           enabled: true

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1640,8 +1640,8 @@ flat-run-fields-updater:
           cpu: "2"
           memory: 4Gi
         requests:
-          cpu: "1"
-          memory: 3Gi
+          cpu: 250m
+          memory: 2Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1688,8 +1688,8 @@ flat-run-fields-updater:
           cpu: "2"
           memory: 8Gi
         requests:
-          cpu: "1"
-          memory: 6Gi
+          cpu: 350m
+          memory: 4Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1736,8 +1736,8 @@ flat-run-fields-updater:
           cpu: "2"
           memory: 8Gi
         requests:
-          cpu: "1"
-          memory: 6Gi
+          cpu: 500m
+          memory: 4Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1819,11 +1819,11 @@ history-updater:
     repository: wandb/megabinary
     tag: latest
   size: ""
-  # CPU and replicas kept identical to flat-run-fields-updater (similar usage
-  # under load, same queue). Memory set to half of flat-run-fields-updater
-  # based on xxl-perf-testing load test (2026-03-17~20): history-updater
-  # peaked at ~0.5 GiB total across 9 pods (~57 MiB/pod), ~10-13x less
-  # than flat-run-fields-updater (~6.5 GiB peak).
+  # Replica counts kept identical to flat-run-fields-updater (same queue,
+  # scales together). Resources are lighter: 2-week prod observation shows
+  # per-pod memory averaging ~0.4 GiB with a real-traffic peak of ~1.9 GiB
+  # (largest dedicated deployment) and CPU averaging ~70m/pod. Limits keep
+  # headroom above the peak; requests track the observed working set.
   sizing:
     small:
       resources:
@@ -1923,8 +1923,8 @@ history-updater:
           cpu: "2"
           memory: 2Gi
         requests:
-          cpu: "1"
-          memory: 1536Mi
+          cpu: 250m
+          memory: 1Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1969,8 +1969,8 @@ history-updater:
           cpu: "2"
           memory: 4Gi
         requests:
-          cpu: "1"
-          memory: 3Gi
+          cpu: 350m
+          memory: 1536Mi
       autoscaling:
         horizontal:
           enabled: true
@@ -2015,8 +2015,8 @@ history-updater:
           cpu: "2"
           memory: 4Gi
         requests:
-          cpu: "1"
-          memory: 3Gi
+          cpu: 500m
+          memory: 1536Mi
       autoscaling:
         horizontal:
           enabled: true

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1819,11 +1819,12 @@ history-updater:
     repository: wandb/megabinary
     tag: latest
   size: ""
-  # CPU and replica counts kept identical to flat-run-fields-updater (same
-  # queue, scales together). Memory is lighter: 2-week prod observation shows
+  # Resources kept identical to flat-run-fields-updater at every tier (same
+  # queue, scales together) so the two share one sizing envelope.
+  # history-updater uses less in practice - 2-week prod observation shows
   # ~0.4 GiB/pod average and a ~1.9 GiB real-traffic peak (largest dedicated
-  # deployment), with ~4.3 GiB seen under synthetic xxl load. Limits give
-  # headroom above the peak, growing at the upper tiers.
+  # deployment), ~4.3 GiB under synthetic xxl load - so the upper-tier limits
+  # are effectively headroom.
   sizing:
     small:
       resources:
@@ -1921,10 +1922,10 @@ history-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 3Gi
+          memory: 6Gi
         requests:
           cpu: "1"
-          memory: 2Gi
+          memory: 4Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -1967,10 +1968,10 @@ history-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 6Gi
+          memory: 12Gi
         requests:
           cpu: "1"
-          memory: 3Gi
+          memory: 6Gi
       autoscaling:
         horizontal:
           enabled: true
@@ -2013,10 +2014,10 @@ history-updater:
       resources:
         limits:
           cpu: "2"
-          memory: 8Gi
+          memory: 16Gi
         requests:
           cpu: "1"
-          memory: 4Gi
+          memory: 8Gi
       autoscaling:
         horizontal:
           enabled: true

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -3410,10 +3410,10 @@ spec:
         resources:
           limits:
             cpu: "2"
-            memory: 4Gi
+            memory: 6Gi
           requests:
-            cpu: 250m
-            memory: 2Gi
+            cpu: "1"
+            memory: 4Gi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -3412,8 +3412,8 @@ spec:
             cpu: "2"
             memory: 4Gi
           requests:
-            cpu: "1"
-            memory: 3Gi
+            cpu: 250m
+            memory: 2Gi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/


### PR DESCRIPTION
## Summary

Raises **memory** requests/limits for `flat-run-fields-updater` (frfu) and `history-updater` at the **large / xlarge / xxlarge** tiers, and **aligns the two services to a single sizing envelope** at each tier (skewing to the larger of the two, so nothing shrinks). **CPU is unchanged** (`1` request / `2` limit at every tier).

## New shared envelope (both services identical per tier)

| tier | mem request | mem limit | cpu req/limit |
|---|---|---|---|
| large | 4Gi | 6Gi | 1 / 2 |
| xlarge | 6Gi | 12Gi | 1 / 2 |
| xxlarge | 8Gi | 16Gi | 1 / 2 |

Previous values → new:
- **frfu**: large 3Gi/4Gi→4Gi/6Gi, xlarge 6Gi/8Gi→6Gi/12Gi, xxlarge 6Gi/8Gi→8Gi/16Gi
- **history-updater**: large 1536Mi/2Gi→4Gi/6Gi, xlarge 3Gi/4Gi→6Gi/12Gi, xxlarge 3Gi/4Gi→8Gi/16Gi

## Why

2 weeks of production `kubernetes.memory.working_set` (per pod, wandb-operated deployments):
- **frfu** reaches **~8.6 GiB/pod** under synthetic xxl load — the prior 8Gi limit left essentially no headroom, risking OOMKills at the top tier. Upper tiers now go to 12–16Gi.
- **history-updater** peaks **~1.9 GiB/pod** in real traffic (~4.3 GiB synthetic), averaging ~0.4 GiB — it uses less than frfu, so the aligned limits are largely headroom. Sharing one envelope keeps the two queue-coupled services simple to reason about and operate.
- Enterprise clusters that override these presets are unaffected.

## Notes
- Snapshot: only `keda-frfu.snap` renders a touched tier (frfu `large`) and is updated here; history-updater isn't rendered at these tiers by any test-config. Full `chartsnap`/`ct` couldn't run locally (blocked from fetching the `prometheus-community` subchart) — please let CI verify.
- Chart version bumped `0.43.8 → 0.43.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)