### PR TITLE
chore: Add Helm template maintainability guardrails

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,9 +34,6 @@ jobs:
       - name: Test template maintainability checker
         run: python3 -m unittest discover -s scripts/tests
 
-      - name: Check template maintainability
-        run: python3 scripts/check_template_maintainability.py
-
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,6 +31,12 @@ jobs:
         with:
           version: v3.11.0
 
+      - name: Test template maintainability checker
+        run: python3 -m unittest discover -s scripts/tests
+
+      - name: Check template maintainability
+        run: python3 scripts/check_template_maintainability.py
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tilt-settings.json
 
 .pi/
 .claude/
+__pycache__/
+*.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Working agreements
+
+Run `python3 -m unittest discover -s scripts/tests` and
+`python3 scripts/check_template_maintainability.py` before considering template
+changes complete. Also run the relevant chart lint and snapshot tests. Treat
+these checks as a minimum: render the affected paths and understand the values,
+helpers, and Kubernetes objects involved.
+
+Keep template decisions easy to follow in source:
+
+- Use `if`/`else` for complementary conditions instead of two adjacent `if`
+  blocks.
+- Indent nested template control flow to expose its structure, even when
+  whitespace trimming means indentation does not affect rendered YAML.
+- Prefer declarative values and focused helpers over repeated branch logic.
+- Give compound conditions a name when that name communicates intent better
+  than the inline expression.
+- Exercise every meaningful branch with render or snapshot tests.
+
+When an exception is necessary, keep it narrow and make the reason durable with
+a focused behavior test or a concise comment next to the exception.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/scripts/check_template_maintainability.py
+++ b/scripts/check_template_maintainability.py
@@ -12,12 +12,21 @@ from typing import Iterable, Sequence
 
 
 TEMPLATE_ACTION = re.compile(r"{{-?\s*(.*?)\s*-?}}", re.DOTALL)
+TEMPLATE_COMMENT = re.compile(r"{{-?\s*/\*.*?\*/\s*-?}}", re.DOTALL)
 STABLE_SELECTOR = re.compile(
     r"(?:\$[A-Za-z_][A-Za-z0-9_]*|\.[A-Za-z_][A-Za-z0-9_]*)"
     r"(?:\.[A-Za-z_][A-Za-z0-9_]*)*\Z"
 )
 BLOCK_OPENERS = {"block", "define", "if", "range", "with"}
+CONTROL_OPENERS = {"if", "range", "with"}
 TEMPLATE_SUFFIXES = {".tpl", ".txt", ".yaml", ".yml"}
+MAINTAINED_CHARTS = (
+    "operator",
+    "operator-wandb",
+    "orchestrator",
+    "wandb-base",
+    "lumen",
+)
 
 
 @dataclass(frozen=True)
@@ -34,17 +43,23 @@ class Action:
 @dataclass(frozen=True)
 class Finding:
     line: int
-    condition: str
+    message: str
 
 
 def parse_actions(source: str) -> list[Action]:
+    source_without_comments = TEMPLATE_COMMENT.sub(
+        lambda match: "".join(
+            "\n" if character == "\n" else " " for character in match.group(0)
+        ),
+        source,
+    )
     return [
         Action(
             command=" ".join(match.group(1).split()),
             start=match.start(),
             end=match.end(),
         )
-        for match in TEMPLATE_ACTION.finditer(source)
+        for match in TEMPLATE_ACTION.finditer(source_without_comments)
     ]
 
 
@@ -110,9 +125,92 @@ def find_complementary_blocks(source: str) -> list[Finding]:
             findings.append(
                 Finding(
                     line=source.count("\n", 0, action.start) + 1,
-                    condition=expression,
+                    message=(
+                        "combine complementary conditions with if/else "
+                        f"(condition: {expression})"
+                    ),
                 )
             )
+
+    return findings
+
+
+def standalone_indentation(source: str, action: Action) -> int | None:
+    line_start = source.rfind("\n", 0, action.start) + 1
+    line_end = source.find("\n", action.end)
+    if line_end == -1:
+        line_end = len(source)
+    before = source[line_start : action.start]
+    after = source[action.end : line_end]
+    if before.strip() or after.strip():
+        return None
+    return len(before.expandtabs(2))
+
+
+def find_control_indentation(source: str) -> list[Finding]:
+    stack: list[tuple[str, int | None]] = []
+    findings: list[Finding] = []
+
+    for action in parse_actions(source):
+        keyword = action.keyword
+        indentation = standalone_indentation(source, action)
+        line = source.count("\n", 0, action.start) + 1
+
+        if keyword == "end":
+            if not stack:
+                continue
+            opener, opener_indentation = stack.pop()
+            if (
+                indentation is not None
+                and opener_indentation is not None
+                and indentation != opener_indentation
+            ):
+                findings.append(
+                    Finding(
+                        line=line,
+                        message=f"align end with its {opener}",
+                    )
+                )
+            continue
+
+        if keyword == "else":
+            if stack:
+                opener, opener_indentation = stack[-1]
+                if (
+                    indentation is not None
+                    and opener_indentation is not None
+                    and indentation != opener_indentation
+                ):
+                    findings.append(
+                        Finding(
+                            line=line,
+                            message=f"align else with its {opener}",
+                        )
+                    )
+            continue
+
+        if keyword not in BLOCK_OPENERS:
+            continue
+
+        if keyword in CONTROL_OPENERS and indentation is not None:
+            parent = next(
+                (
+                    (parent_keyword, parent_indentation)
+                    for parent_keyword, parent_indentation in reversed(stack)
+                    if parent_keyword in CONTROL_OPENERS
+                    and parent_indentation is not None
+                ),
+                None,
+            )
+            if parent is not None and indentation <= parent[1]:
+                findings.append(
+                    Finding(
+                        line=line,
+                        message=f"indent nested {keyword} deeper than its parent",
+                    )
+                )
+
+        stack.append((keyword, indentation))
 
     return findings
 
@@ -132,11 +230,8 @@ def template_files(paths: Iterable[Path]) -> list[Path]:
 
 
 def default_paths() -> list[Path]:
-    return [
-        path
-        for path in Path("charts").glob("*/templates")
-        if path.is_dir()
-    ]
+    paths = [Path("charts") / chart / "templates" for chart in MAINTAINED_CHARTS]
+    return [path for path in paths if path.is_dir()]
 
 
 def display_path(path: Path) -> str:
@@ -155,13 +250,12 @@ def check(paths: Sequence[Path]) -> int:
             print(f"{display_path(path)}: unable to read template: {error}", file=sys.stderr)
             return 2
 
-        for finding in find_complementary_blocks(source):
+        for finding in [
+            *find_complementary_blocks(source),
+            *find_control_indentation(source),
+        ]:
             had_finding = True
-            print(
-                f"{display_path(path)}:{finding.line}: "
-                "combine complementary conditions with if/else "
-                f"(condition: {finding.condition})"
-            )
+            print(f"{display_path(path)}:{finding.line}: {finding.message}")
     return 1 if had_finding else 0
 
 
@@ -171,7 +265,10 @@ def main() -> int:
         "paths",
         nargs="*",
         type=Path,
-        help="template files or directories (defaults to every chart templates directory)",
+        help=(
+            "template files or directories "
+            "(defaults to maintained chart templates)"
+        ),
     )
     arguments = parser.parse_args()
     return check(arguments.paths or default_paths())

--- a/scripts/check_template_maintainability.py
+++ b/scripts/check_template_maintainability.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Check Helm template source for maintainability problems."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+TEMPLATE_ACTION = re.compile(r"{{-?\s*(.*?)\s*-?}}", re.DOTALL)
+BLOCK_OPENERS = {"block", "define", "if", "range", "with"}
+TEMPLATE_SUFFIXES = {".tpl", ".txt", ".yaml", ".yml"}
+
+
+@dataclass(frozen=True)
+class Action:
+    command: str
+    start: int
+    end: int
+
+    @property
+    def keyword(self) -> str:
+        return self.command.split(maxsplit=1)[0] if self.command else ""
+
+
+@dataclass(frozen=True)
+class Finding:
+    line: int
+    condition: str
+
+
+def parse_actions(source: str) -> list[Action]:
+    return [
+        Action(
+            command=" ".join(match.group(1).split()),
+            start=match.start(),
+            end=match.end(),
+        )
+        for match in TEMPLATE_ACTION.finditer(source)
+    ]
+
+
+def matching_end(actions: Sequence[Action], opening_index: int) -> tuple[int, bool] | None:
+    depth = 1
+    has_top_level_else = False
+    for index in range(opening_index + 1, len(actions)):
+        keyword = actions[index].keyword
+        if keyword in BLOCK_OPENERS:
+            depth += 1
+        elif keyword == "end":
+            depth -= 1
+            if depth == 0:
+                return index, has_top_level_else
+        elif keyword == "else" and depth == 1:
+            has_top_level_else = True
+    return None
+
+
+def if_condition(action: Action) -> str | None:
+    if action.keyword != "if":
+        return None
+    _, separator, condition = action.command.partition(" ")
+    return condition if separator and condition else None
+
+
+def condition_polarity(condition: str) -> tuple[bool, str]:
+    if condition.startswith("not "):
+        return True, condition.removeprefix("not ").strip()
+    return False, condition
+
+
+def find_complementary_blocks(source: str) -> list[Finding]:
+    actions = parse_actions(source)
+    findings: list[Finding] = []
+
+    for index, action in enumerate(actions):
+        condition = if_condition(action)
+        if condition is None:
+            continue
+
+        block_end = matching_end(actions, index)
+        if block_end is None:
+            continue
+        end_index, has_else = block_end
+        if has_else or end_index + 1 >= len(actions):
+            continue
+
+        next_action = actions[end_index + 1]
+        if source[actions[end_index].end : next_action.start].strip():
+            continue
+        next_condition = if_condition(next_action)
+        if next_condition is None:
+            continue
+
+        negated, expression = condition_polarity(condition)
+        next_negated, next_expression = condition_polarity(next_condition)
+        if expression and expression == next_expression and negated != next_negated:
+            findings.append(
+                Finding(
+                    line=source.count("\n", 0, action.start) + 1,
+                    condition=expression,
+                )
+            )
+
+    return findings
+
+
+def template_files(paths: Iterable[Path]) -> list[Path]:
+    files: set[Path] = set()
+    for path in paths:
+        if path.is_dir():
+            files.update(
+                candidate
+                for candidate in path.rglob("*")
+                if candidate.is_file() and candidate.suffix in TEMPLATE_SUFFIXES
+            )
+        elif path.is_file():
+            files.add(path)
+    return sorted(files)
+
+
+def default_paths() -> list[Path]:
+    return [
+        path
+        for path in Path("charts").glob("*/templates")
+        if path.is_dir()
+    ]
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return path.name
+
+
+def check(paths: Sequence[Path]) -> int:
+    had_finding = False
+    for path in template_files(paths):
+        try:
+            source = path.read_text()
+        except (OSError, UnicodeError) as error:
+            print(f"{display_path(path)}: unable to read template: {error}", file=sys.stderr)
+            return 2
+
+        for finding in find_complementary_blocks(source):
+            had_finding = True
+            print(
+                f"{display_path(path)}:{finding.line}: "
+                "combine complementary conditions with if/else "
+                f"(condition: {finding.condition})"
+            )
+    return 1 if had_finding else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="template files or directories (defaults to every chart templates directory)",
+    )
+    arguments = parser.parse_args()
+    return check(arguments.paths or default_paths())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_template_maintainability.py
+++ b/scripts/check_template_maintainability.py
@@ -12,6 +12,10 @@ from typing import Iterable, Sequence
 
 
 TEMPLATE_ACTION = re.compile(r"{{-?\s*(.*?)\s*-?}}", re.DOTALL)
+STABLE_SELECTOR = re.compile(
+    r"(?:\$[A-Za-z_][A-Za-z0-9_]*|\.[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:\.[A-Za-z_][A-Za-z0-9_]*)*\Z"
+)
 BLOCK_OPENERS = {"block", "define", "if", "range", "with"}
 TEMPLATE_SUFFIXES = {".tpl", ".txt", ".yaml", ".yml"}
 
@@ -98,7 +102,11 @@ def find_complementary_blocks(source: str) -> list[Finding]:
 
         negated, expression = condition_polarity(condition)
         next_negated, next_expression = condition_polarity(next_condition)
-        if expression and expression == next_expression and negated != next_negated:
+        if (
+            STABLE_SELECTOR.fullmatch(expression)
+            and expression == next_expression
+            and negated != next_negated
+        ):
             findings.append(
                 Finding(
                     line=source.count("\n", 0, action.start) + 1,

--- a/scripts/tests/test_check_template_maintainability.py
+++ b/scripts/tests/test_check_template_maintainability.py
@@ -1,0 +1,99 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts" / "check_template_maintainability.py"
+
+
+class TemplateMaintainabilityCheckerTest(unittest.TestCase):
+    def run_checker(self, source: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture.tpl"
+            fixture.write_text(source)
+            return subprocess.run(
+                [sys.executable, str(CHECKER), str(fixture)],
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_rejects_adjacent_complementary_if_blocks(self) -> None:
+        result = self.run_checker(
+            """{{- if not $identity.enabled }}
+- name: ACCESS_KEY
+{{- end }}
+{{- if $identity.enabled }}
+- name: CLIENT_ID
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("fixture.tpl:1:", result.stdout)
+        self.assertIn("combine complementary conditions with if/else", result.stdout)
+        self.assertEqual(result.stdout.count("combine complementary conditions"), 1)
+
+    def test_accepts_if_else(self) -> None:
+        result = self.run_checker(
+            """{{- if $identity.enabled }}
+- name: CLIENT_ID
+{{- else }}
+- name: ACCESS_KEY
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_accepts_adjacent_blocks_with_different_conditions(self) -> None:
+        result = self.run_checker(
+            """{{- if not $identity.enabled }}
+- name: ACCESS_KEY
+{{- end }}
+{{- if $identity.clientId }}
+- name: CLIENT_ID
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_matches_across_nested_control_blocks(self) -> None:
+        result = self.run_checker(
+            """{{- if $identity.enabled }}
+{{- if $identity.clientId }}
+- name: CLIENT_ID
+{{- end }}
+{{- end }}
+{{- if not $identity.enabled }}
+- name: ACCESS_KEY
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout.count("combine complementary conditions"), 1)
+
+    def test_does_not_combine_independent_blocks_separated_by_output(self) -> None:
+        result = self.run_checker(
+            """{{- if $identity.enabled }}
+- name: CLIENT_ID
+{{- end }}
+- name: ALWAYS_PRESENT
+{{- if not $identity.enabled }}
+- name: ACCESS_KEY
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_template_maintainability.py
+++ b/scripts/tests/test_check_template_maintainability.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.check_template_maintainability import MAINTAINED_CHARTS
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKER = REPO_ROOT / "scripts" / "check_template_maintainability.py"
@@ -21,6 +23,52 @@ class TemplateMaintainabilityCheckerTest(unittest.TestCase):
                 capture_output=True,
                 text=True,
             )
+
+    def run_default_checker(
+        self, fixtures: dict[str, str]
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative_path, source in fixtures.items():
+                fixture = root / relative_path
+                fixture.parent.mkdir(parents=True, exist_ok=True)
+                fixture.write_text(source)
+            return subprocess.run(
+                [sys.executable, str(CHECKER)],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_default_scan_covers_only_maintained_chart_templates(self) -> None:
+        complementary_blocks = """{{- if not $identity.enabled }}
+disabled
+{{- end }}
+{{- if $identity.enabled }}
+enabled
+{{- end }}
+"""
+        fixtures = {
+            f"charts/{chart}/templates/fixture.tpl": complementary_blocks
+            for chart in MAINTAINED_CHARTS
+        }
+        fixtures["charts/wandb/templates/fixture.tpl"] = complementary_blocks
+        fixtures[
+            "charts/operator-wandb/charts/dependency/templates/fixture.tpl"
+        ] = complementary_blocks
+
+        result = self.run_default_checker(fixtures)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(
+            result.stdout.count("combine complementary conditions with if/else"),
+            len(MAINTAINED_CHARTS),
+        )
+        for chart in MAINTAINED_CHARTS:
+            self.assertIn(f"charts/{chart}/templates/fixture.tpl:1:", result.stdout)
+        self.assertNotIn("charts/wandb/templates", result.stdout)
+        self.assertNotIn("charts/operator-wandb/charts", result.stdout)
 
     def test_rejects_adjacent_complementary_if_blocks(self) -> None:
         result = self.run_checker(
@@ -101,6 +149,64 @@ class TemplateMaintainabilityCheckerTest(unittest.TestCase):
 - name: ALWAYS_PRESENT
 {{- if not $identity.enabled }}
 - name: ACCESS_KEY
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_rejects_nested_control_blocks_at_the_parent_indentation(self) -> None:
+        result = self.run_checker(
+            """{{- if $identity.enabled }}
+{{- if $identity.clientId }}
+- name: CLIENT_ID
+{{- end }}
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("indent nested if deeper than its parent", result.stdout)
+
+    def test_rejects_control_boundaries_not_aligned_with_their_block(self) -> None:
+        result = self.run_checker(
+            """{{- if $identity.enabled }}
+  {{- if $identity.clientId }}
+- name: CLIENT_ID
+{{- else }}
+- name: DEFAULT_CLIENT_ID
+{{- end }}
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("align else with its if", result.stdout)
+        self.assertIn("align end with its if", result.stdout)
+
+    def test_accepts_indented_nested_control_flow(self) -> None:
+        result = self.run_checker(
+            """{{- if $identity.enabled }}
+  {{- if $identity.clientId }}
+- name: CLIENT_ID
+  {{- else }}
+- name: DEFAULT_CLIENT_ID
+  {{- end }}
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_ignores_template_actions_inside_comments(self) -> None:
+        result = self.run_checker(
+            """{{- define "example" -}}
+{{- if $identity.enabled }}
+  {{- /*
+    {{- if $commented.example }}
+    {{- end }}
+  */}}
+{{- end }}
 {{- end }}
 """
         )

--- a/scripts/tests/test_check_template_maintainability.py
+++ b/scripts/tests/test_check_template_maintainability.py
@@ -64,6 +64,19 @@ class TemplateMaintainabilityCheckerTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
+    def test_ignores_complementary_dynamic_expressions(self) -> None:
+        result = self.run_checker(
+            """{{- if not (include "identity.enabled" .) }}
+- name: ACCESS_KEY
+{{- end }}
+{{- if (include "identity.enabled" .) }}
+- name: CLIENT_ID
+{{- end }}
+"""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_matches_across_nested_control_blocks(self) -> None:
         result = self.run_checker(
             """{{- if $identity.enabled }}


### PR DESCRIPTION
## Summary

- define the maintained chart scope once as `MAINTAINED_CHARTS`: `operator`, `operator-wandb`, `orchestrator`, `wandb-base`, and `lumen`
- add compact, tool-neutral working agreements for readable Helm control flow
- add a standard-library Python checker for adjacent complementary `if` blocks and structurally misleading control-flow indentation
- cover each executable rule with passing and failing fixtures, including scope and template-comment regressions
- run both the checker tests and repository scan in the existing chart lint workflow

## Validation

- `python3 -m unittest discover -s scripts/tests -v` — 11 tests pass
- `helm lint` for all five maintained charts — all pass (existing dependency and icon warnings remain)
- `git diff --check` — passes
- `python3 scripts/check_template_maintainability.py` — intentionally reports the current 77-finding repository backlog and exits 1
- running the same checker against PR #662 reports 78 findings, adding `charts/operator-wandb/templates/_env.tpl:149: indent nested if deeper than its parent`

## Rollout

This is the red phase of a red/green/greener rollout. This PR establishes the tested gate and is expected to fail only at the repository scan. After it merges, a follow-up will clean the 77 baseline findings to make the gate green; PR #662 can then be updated to remove its one additional finding.

Embedded dependency charts under `charts/*/charts` and charts outside `MAINTAINED_CHARTS` are intentionally excluded from the default scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader template maintainability checks for complementary conditions, control-structure indentation, and block alignment.
  * Template comments and unsupported cases are handled more safely during validation.

* **Tests**
  * Expanded automated coverage for template structure, default chart scanning, nested blocks, alignment, and comment handling.
  * Maintainability tests now run as part of the lint workflow.

* **Documentation**
  * Added working agreements covering template readability, testing, indentation, and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->