### PR TITLE
chore(dev): run bundled clickhouse on official 26.4 images, re-enable runStoreAccelerator in CI

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.2
+version: 0.44.3
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/charts/clickhouse/values.yaml
+++ b/charts/operator-wandb/charts/clickhouse/values.yaml
@@ -965,8 +965,9 @@ keeper:
   ##
   replicaCount: 3
   ## @param keeper.configuration Specify content for ClickHouse Keeper configuration (basic one auto-generated based on other values otherwise)
-  ##
-  configuration: {}
+  ## Default changed from {} to "" so parent charts can override it with an XML
+  ## string without a Helm coalesce type-mismatch warning.
+  configuration: ""
   ## @param keeper.existingConfigmap The name of an existing ConfigMap with your custom configuration for ClickHouse Keeper
   ##
   existingConfigmap: ""

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -4634,17 +4634,56 @@ reloader:
 
 clickhouse:
   install: false
+  # The bundled ClickHouse is for CI/dev only; production platforms use
+  # ClickHouse Cloud or customer-provided instances. Official images replace
+  # the frozen bitnamilegacy archive (stuck at 25.7; core's migrations need
+  # 26.x). The overrides below do what the Bitnami entrypoint did: admin user,
+  # logging, config/data paths, keeper server id.
   image:
-    repository: bitnamilegacy/clickhouse
+    repository: clickhouse/clickhouse-server
+    tag: "26.4"
   global:
     security:
       allowInsecureImages: true
   auth:
     existingSecret: '{{ include "wandb.clickhouse.passwordSecret" . }}'
     existingSecretKey: "{{- .Values.global.clickhouse.passwordSecret.passwordKey -}}"
+  # Keep the admin password as an env var so from_env works in usersdFiles below.
+  usePasswordFiles: false
 
   shards: 1
   replicaCount: 1
+
+  # /var/log/clickhouse-server is not writable as the chart's non-root uid;
+  # log to console like the Bitnami build did.
+  configdFiles:
+    00-logger-console.xml: |
+      <clickhouse>
+          <logger>
+              <console>1</console>
+              <log remove="remove"></log>
+              <errorlog remove="remove"></errorlog>
+          </logger>
+      </clickhouse>
+  # The Bitnami entrypoint provisioned the admin user; with the official image
+  # declare it via users.d, fed by the env var the chart already sets.
+  usersdFiles:
+    zz-admin-user.xml: |
+      <clickhouse>
+          <users>
+              <{{ .Values.auth.username }}>
+                  <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                  <access_management>1</access_management>
+              </{{ .Values.auth.username }}>
+          </users>
+      </clickhouse>
+  # Re-mount the chart's config/users fragments where the official image reads
+  # them (the chart itself mounts them at Bitnami's /bitnami/clickhouse/etc).
+  extraVolumeMounts:
+    - name: configd-configuration
+      mountPath: /etc/clickhouse-server/config.d
+    - name: usersd-configuration-configuration
+      mountPath: /etc/clickhouse-server/users.d
 
   # Apply global nodeSelector and tolerations to ClickHouse
   nodeSelector: {}
@@ -4658,8 +4697,40 @@ clickhouse:
     enabled: true
     size: 30Gi
     storageClass: ""
+    # The official image's config keeps data under /var/lib/clickhouse.
+    mountPath: /var/lib/clickhouse
 
   keeper:
+    image:
+      repository: clickhouse/clickhouse-keeper
+      tag: "26.4"
+    # Full keeper config replacing the Bitnami entrypoint-generated one. Raft
+    # membership still comes from the chart's keeper_config.d fragment, which
+    # ClickHouse merges from the directory next to the main config file.
+    configuration: |
+      <clickhouse>
+          <listen_host>0.0.0.0</listen_host>
+          <logger>
+              <console>1</console>
+              <log remove="remove"></log>
+              <errorlog remove="remove"></errorlog>
+          </logger>
+          <path>/var/lib/clickhouse-keeper</path>
+          <keeper_server>
+              <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+              <server_id from_env="KEEPER_SERVER_ID"></server_id>
+              <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+              <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+          </keeper_server>
+      </clickhouse>
+    # The Bitnami entrypoint derived the numeric keeper server id from the pod
+    # ordinal; from_env needs an integer, so do the same here.
+    command:
+      - sh
+      - -ec
+      - |
+        export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+        exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
     # Apply global nodeSelector and tolerations to ClickHouse Keeper
     nodeSelector: {}
     tolerations: []
@@ -4671,3 +4742,4 @@ clickhouse:
       enabled: true
       size: 8Gi
       storageClass: ""
+      mountPath: /var/lib/clickhouse-keeper

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -650,6 +650,14 @@ metadata:
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
+  00-logger-console.xml: |
+    <clickhouse>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+    </clickhouse>
   01-listen.xml: |
     <yandex>
         <listen_host>::</listen_host>
@@ -726,6 +734,63 @@ data:
                 </server>
             </raft_configuration>
         </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/keeper/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-keeper
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: keeper
+    app.kubernetes.io/part-of: clickhouse
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+        <path>/var/lib/clickhouse-keeper</path>
+        <keeper_server>
+            <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"></server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/usersd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-usersd
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: clickhouse
+    app.kubernetes.io/part-of: clickhouse
+data:
+  zz-admin-user.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                <access_management>1</access_management>
+            </default>
+        </users>
     </clickhouse>
 ---
 # Source: operator-wandb/charts/mysql/templates/configmap.yaml
@@ -6347,6 +6412,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/configuration: 28e8b3cc3e08583128d3083fc8d3547900b45b5c2eb0c22dda06c7d62fa35c4e
         checksum/configd-configuration: bfdea18bbc1786d95702e6f773f35a312de0f1cd6f51dc27fdf091b40320afdd
       labels:
         app.kubernetes.io/instance: chartsnap
@@ -6380,7 +6446,7 @@ spec:
       initContainers:
       containers:
       - name: keeper
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-keeper:26.4
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -6395,6 +6461,12 @@ spec:
           seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
+        command:
+        - sh
+        - -ec
+        - |
+          export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+          exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
         env:
         - name: BITNAMI_DEBUG
           value: "false"
@@ -6438,7 +6510,10 @@ spec:
             memory: 64Mi
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse-keeper
+          mountPath: /var/lib/clickhouse-keeper
+        - name: configuration
+          mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.xml
+          subPath: keeper_config.xml
         - name: configd-configuration
           mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.d
         - name: empty-dir
@@ -6456,6 +6531,9 @@ spec:
       volumes:
       - name: empty-dir
         emptyDir: {}
+      - name: configuration
+        configMap:
+          name: chartsnap-clickhouse-keeper
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-keeper-configd
@@ -6511,7 +6589,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configd-configuration: dc3b278f99d27bba9daa9c189b7500c5cf80a73866e54f4e92475777381f9c59
+        checksum/configd-configuration: 8c243af91e23c69d4ed85ebb3e0cce24367419fb43919bd4db0b432991ddc1f4
+        checksum/usersd-configuration: c5ab1093996fc7b5fa2ffe1abae40154115d076f3592fa2bfc6de8efd7147bca
       labels:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
@@ -6545,7 +6624,7 @@ spec:
       initContainers:
       containers:
       - name: clickhouse
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-server:26.4
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -6581,8 +6660,11 @@ spec:
               fieldPath: metadata.name
         - name: CLICKHOUSE_ADMIN_USER
           value: "default"
-        - name: CLICKHOUSE_ADMIN_PASSWORD_FILE
-          value: /opt/bitnami/clickhouse/secrets/CLICKHOUSE_PASSWORD
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-clickhouse
+              key: CLICKHOUSE_PASSWORD
         resources:
           requests:
             cpu: 40m
@@ -6617,12 +6699,11 @@ spec:
             port: http
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse
+          mountPath: /var/lib/clickhouse
         - name: configd-configuration
           mountPath: /bitnami/clickhouse/etc/config.d
-        - name: secrets
-          mountPath: /opt/bitnami/clickhouse/secrets
-          readOnly: true
+        - name: usersd-configuration-configuration
+          mountPath: /bitnami/clickhouse/etc/users.d
         - name: empty-dir
           mountPath: /opt/bitnami/clickhouse/etc
           subPath: app-conf-dir
@@ -6635,16 +6716,21 @@ spec:
         - name: empty-dir
           mountPath: /tmp
           subPath: tmp-dir
+        - mountPath: /etc/clickhouse-server/config.d
+          name: configd-configuration
+        - mountPath: /etc/clickhouse-server/users.d
+          name: usersd-configuration-configuration
       volumes:
       - name: empty-dir
         emptyDir: {}
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-configd
-      - name: secrets
-        secret:
-          secretName: chartsnap-clickhouse
-          defaultMode: 256
+      - name: usersd-configuration-configuration
+        projected:
+          sources:
+          - configMap:
+              name: chartsnap-clickhouse-usersd
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -722,6 +722,20 @@ metadata:
 data:
   REGISTRY_SEARCH_PASSWORD: '###DYNAMIC_FIELD###'
 ---
+# Source: operator-wandb/templates/olap.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "chartsnap-olap-run-store-accelerator"
+  annotations:
+    "helm.sh/resource-policy": "keep"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "chartsnap-.*"
+  labels:
+data:
+  RUN_STORE_ACCELERATOR_PASSWORD: '###DYNAMIC_FIELD###'
+---
 # Source: operator-wandb/templates/parquet.yaml
 apiVersion: v1
 kind: Secret
@@ -780,6 +794,14 @@ metadata:
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
+  00-logger-console.xml: |
+    <clickhouse>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+    </clickhouse>
   01-listen.xml: |
     <yandex>
         <listen_host>::</listen_host>
@@ -856,6 +878,63 @@ data:
                 </server>
             </raft_configuration>
         </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/keeper/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-keeper
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: keeper
+    app.kubernetes.io/part-of: clickhouse
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+        <path>/var/lib/clickhouse-keeper</path>
+        <keeper_server>
+            <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"></server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/usersd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-usersd
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: clickhouse
+    app.kubernetes.io/part-of: clickhouse
+data:
+  zz-admin-user.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                <access_management>1</access_management>
+            </default>
+        </users>
     </clickhouse>
 ---
 # Source: operator-wandb/charts/mysql/templates/configmap.yaml
@@ -3943,6 +4022,23 @@ spec:
           value: ?tls=false
         - name: GORILLA_REGISTRY_SEARCH_ADDRESS
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
+        - name: RUN_STORE_ACCELERATOR_HOST
+          value: chartsnap-clickhouse-headless
+        - name: RUN_STORE_ACCELERATOR_PORT
+          value: "9000"
+        - name: RUN_STORE_ACCELERATOR_DATABASE
+          value: runs
+        - name: RUN_STORE_ACCELERATOR_USER
+          value: default
+        - name: RUN_STORE_ACCELERATOR_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: RUN_STORE_ACCELERATOR_PASSWORD
+              name: chartsnap-olap-run-store-accelerator
+        - name: RUN_STORE_ACCELERATOR_PARAMS
+          value: ?tls=false
+        - name: GORILLA_RUN_STORE_ACCELERATOR_ADDRESS
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
         - name: GORILLA_LUMEN_ADDR
           value: :16060
         - name: BUCKET_PROXY
@@ -4221,6 +4317,23 @@ spec:
           value: ?tls=false
         - name: GORILLA_REGISTRY_SEARCH_ADDRESS
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
+        - name: RUN_STORE_ACCELERATOR_HOST
+          value: chartsnap-clickhouse-headless
+        - name: RUN_STORE_ACCELERATOR_PORT
+          value: "9000"
+        - name: RUN_STORE_ACCELERATOR_DATABASE
+          value: runs
+        - name: RUN_STORE_ACCELERATOR_USER
+          value: default
+        - name: RUN_STORE_ACCELERATOR_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: RUN_STORE_ACCELERATOR_PASSWORD
+              name: chartsnap-olap-run-store-accelerator
+        - name: RUN_STORE_ACCELERATOR_PARAMS
+          value: ?tls=false
+        - name: GORILLA_RUN_STORE_ACCELERATOR_ADDRESS
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
         - name: GORILLA_LUMEN_ADDR
           value: :16060
         - name: BUCKET_PROXY
@@ -5969,6 +6082,23 @@ spec:
           value: ?tls=false
         - name: GORILLA_REGISTRY_SEARCH_ADDRESS
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
+        - name: RUN_STORE_ACCELERATOR_HOST
+          value: chartsnap-clickhouse-headless
+        - name: RUN_STORE_ACCELERATOR_PORT
+          value: "9000"
+        - name: RUN_STORE_ACCELERATOR_DATABASE
+          value: runs
+        - name: RUN_STORE_ACCELERATOR_USER
+          value: default
+        - name: RUN_STORE_ACCELERATOR_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: RUN_STORE_ACCELERATOR_PASSWORD
+              name: chartsnap-olap-run-store-accelerator
+        - name: RUN_STORE_ACCELERATOR_PARAMS
+          value: ?tls=false
+        - name: GORILLA_RUN_STORE_ACCELERATOR_ADDRESS
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
         - name: GORILLA_LUMEN_ADDR
           value: :16060
         - name: BUCKET_PROXY
@@ -7199,6 +7329,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/configuration: 28e8b3cc3e08583128d3083fc8d3547900b45b5c2eb0c22dda06c7d62fa35c4e
         checksum/configd-configuration: bfdea18bbc1786d95702e6f773f35a312de0f1cd6f51dc27fdf091b40320afdd
       labels:
         app.kubernetes.io/instance: chartsnap
@@ -7232,7 +7363,7 @@ spec:
       initContainers:
       containers:
       - name: keeper
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-keeper:26.4
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -7247,6 +7378,12 @@ spec:
           seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
+        command:
+        - sh
+        - -ec
+        - |
+          export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+          exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
         env:
         - name: BITNAMI_DEBUG
           value: "false"
@@ -7290,7 +7427,10 @@ spec:
             memory: 64Mi
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse-keeper
+          mountPath: /var/lib/clickhouse-keeper
+        - name: configuration
+          mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.xml
+          subPath: keeper_config.xml
         - name: configd-configuration
           mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.d
         - name: empty-dir
@@ -7308,6 +7448,9 @@ spec:
       volumes:
       - name: empty-dir
         emptyDir: {}
+      - name: configuration
+        configMap:
+          name: chartsnap-clickhouse-keeper
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-keeper-configd
@@ -7363,7 +7506,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configd-configuration: dc3b278f99d27bba9daa9c189b7500c5cf80a73866e54f4e92475777381f9c59
+        checksum/configd-configuration: 8c243af91e23c69d4ed85ebb3e0cce24367419fb43919bd4db0b432991ddc1f4
+        checksum/usersd-configuration: c5ab1093996fc7b5fa2ffe1abae40154115d076f3592fa2bfc6de8efd7147bca
       labels:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
@@ -7397,7 +7541,7 @@ spec:
       initContainers:
       containers:
       - name: clickhouse
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-server:26.4
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -7433,8 +7577,11 @@ spec:
               fieldPath: metadata.name
         - name: CLICKHOUSE_ADMIN_USER
           value: "default"
-        - name: CLICKHOUSE_ADMIN_PASSWORD_FILE
-          value: /opt/bitnami/clickhouse/secrets/CLICKHOUSE_PASSWORD
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-clickhouse
+              key: CLICKHOUSE_PASSWORD
         resources:
           requests:
             cpu: 40m
@@ -7469,12 +7616,11 @@ spec:
             port: http
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse
+          mountPath: /var/lib/clickhouse
         - name: configd-configuration
           mountPath: /bitnami/clickhouse/etc/config.d
-        - name: secrets
-          mountPath: /opt/bitnami/clickhouse/secrets
-          readOnly: true
+        - name: usersd-configuration-configuration
+          mountPath: /bitnami/clickhouse/etc/users.d
         - name: empty-dir
           mountPath: /opt/bitnami/clickhouse/etc
           subPath: app-conf-dir
@@ -7487,16 +7633,21 @@ spec:
         - name: empty-dir
           mountPath: /tmp
           subPath: tmp-dir
+        - mountPath: /etc/clickhouse-server/config.d
+          name: configd-configuration
+        - mountPath: /etc/clickhouse-server/users.d
+          name: usersd-configuration-configuration
       volumes:
       - name: empty-dir
         emptyDir: {}
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-configd
-      - name: secrets
-        secret:
-          secretName: chartsnap-clickhouse
-          defaultMode: 256
+      - name: usersd-configuration-configuration
+        projected:
+          sources:
+          - configMap:
+              name: chartsnap-clickhouse-usersd
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
@@ -8492,6 +8643,63 @@ spec:
       exit $fail
   restartPolicy: Never
 ---
+# Source: operator-wandb/templates/tests/test-olap.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-operator-wandb-test-olap-run-store-accelerator"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: test-olap-envs
+    image: us-docker.pkg.dev/wandb-production/public/python:3.12
+    env:
+    - name: RUN_STORE_ACCELERATOR_HOST
+      value: "chartsnap-clickhouse-headless"
+    - name: RUN_STORE_ACCELERATOR_PORT
+      value: "9000"
+    - name: RUN_STORE_ACCELERATOR_DATABASE
+      value: "runs"
+    - name: RUN_STORE_ACCELERATOR_USER
+      value: "default"
+    - name: RUN_STORE_ACCELERATOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: "chartsnap-olap-run-store-accelerator"
+          key: "RUN_STORE_ACCELERATOR_PASSWORD"
+    - name: RUN_STORE_ACCELERATOR_PARAMS
+      value: "?tls=false"
+    - name: GORILLA_RUN_STORE_ACCELERATOR_ADDRESS
+      value: "clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)"
+    - name: "MIGRATE_RUN_STORE_ACCELERATOR_DB"
+      value: "clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)"
+    - name: MIGRATE_RUNS_ACCELERATOR_DB
+      value: "$(MIGRATE_RUN_STORE_ACCELERATOR_DB)"
+    command:
+    - sh
+    - -c
+    - |
+      echo "Testing OLAP env vars for runStoreAccelerator..."
+      fail=0
+      for var in RUN_STORE_ACCELERATOR_HOST RUN_STORE_ACCELERATOR_PORT RUN_STORE_ACCELERATOR_DATABASE RUN_STORE_ACCELERATOR_USER RUN_STORE_ACCELERATOR_PASSWORD RUN_STORE_ACCELERATOR_PARAMS GORILLA_RUN_STORE_ACCELERATOR_ADDRESS MIGRATE_RUN_STORE_ACCELERATOR_DB MIGRATE_RUNS_ACCELERATOR_DB; do
+        val=$(printenv "$var" || true)
+        if [ -z "$val" ]; then
+          echo "FAIL: $var is not set"
+          fail=1
+        else
+          echo "OK: $var is set"
+        fi
+      done
+      exit $fail
+  restartPolicy: Never
+---
 # Source: operator-wandb/templates/tests/test-weave.yaml
 apiVersion: v1
 kind: Pod
@@ -8803,6 +9011,27 @@ spec:
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
         - name: MIGRATE_ARTIFACTS_DB
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
+        - name: RUN_STORE_ACCELERATOR_HOST
+          value: chartsnap-clickhouse-headless
+        - name: RUN_STORE_ACCELERATOR_PORT
+          value: "9000"
+        - name: RUN_STORE_ACCELERATOR_DATABASE
+          value: runs
+        - name: RUN_STORE_ACCELERATOR_USER
+          value: default
+        - name: RUN_STORE_ACCELERATOR_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: RUN_STORE_ACCELERATOR_PASSWORD
+              name: chartsnap-olap-run-store-accelerator
+        - name: RUN_STORE_ACCELERATOR_PARAMS
+          value: ?tls=false
+        - name: GORILLA_RUN_STORE_ACCELERATOR_ADDRESS
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
+        - name: MIGRATE_RUN_STORE_ACCELERATOR_DB
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
+        - name: MIGRATE_RUNS_ACCELERATOR_DB
+          value: $(MIGRATE_RUN_STORE_ACCELERATOR_DB)
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY
@@ -8907,6 +9136,27 @@ spec:
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
         - name: MIGRATE_ARTIFACTS_DB
           value: clickhouse://$(REGISTRY_SEARCH_USER):$(REGISTRY_SEARCH_PASSWORD)@$(REGISTRY_SEARCH_HOST):$(REGISTRY_SEARCH_PORT)/$(REGISTRY_SEARCH_DATABASE)$(REGISTRY_SEARCH_PARAMS)
+        - name: RUN_STORE_ACCELERATOR_HOST
+          value: chartsnap-clickhouse-headless
+        - name: RUN_STORE_ACCELERATOR_PORT
+          value: "9000"
+        - name: RUN_STORE_ACCELERATOR_DATABASE
+          value: runs
+        - name: RUN_STORE_ACCELERATOR_USER
+          value: default
+        - name: RUN_STORE_ACCELERATOR_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: RUN_STORE_ACCELERATOR_PASSWORD
+              name: chartsnap-olap-run-store-accelerator
+        - name: RUN_STORE_ACCELERATOR_PARAMS
+          value: ?tls=false
+        - name: GORILLA_RUN_STORE_ACCELERATOR_ADDRESS
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
+        - name: MIGRATE_RUN_STORE_ACCELERATOR_DB
+          value: clickhouse://$(RUN_STORE_ACCELERATOR_USER):$(RUN_STORE_ACCELERATOR_PASSWORD)@$(RUN_STORE_ACCELERATOR_HOST):$(RUN_STORE_ACCELERATOR_PORT)/$(RUN_STORE_ACCELERATOR_DATABASE)$(RUN_STORE_ACCELERATOR_PARAMS)
+        - name: MIGRATE_RUNS_ACCELERATOR_DB
+          value: $(MIGRATE_RUN_STORE_ACCELERATOR_DB)
         - name: BUCKET_PROXY
           value: "true"
         - name: GLOBAL_ADMIN_API_KEY

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -642,6 +642,14 @@ metadata:
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
+  00-logger-console.xml: |
+    <clickhouse>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+    </clickhouse>
   01-listen.xml: |
     <yandex>
         <listen_host>::</listen_host>
@@ -718,6 +726,63 @@ data:
                 </server>
             </raft_configuration>
         </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/keeper/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-keeper
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: keeper
+    app.kubernetes.io/part-of: clickhouse
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+        <path>/var/lib/clickhouse-keeper</path>
+        <keeper_server>
+            <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"></server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/usersd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-usersd
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: clickhouse
+    app.kubernetes.io/part-of: clickhouse
+data:
+  zz-admin-user.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                <access_management>1</access_management>
+            </default>
+        </users>
     </clickhouse>
 ---
 # Source: operator-wandb/charts/mysql/templates/configmap.yaml
@@ -5930,6 +5995,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/configuration: 28e8b3cc3e08583128d3083fc8d3547900b45b5c2eb0c22dda06c7d62fa35c4e
         checksum/configd-configuration: bfdea18bbc1786d95702e6f773f35a312de0f1cd6f51dc27fdf091b40320afdd
       labels:
         app.kubernetes.io/instance: chartsnap
@@ -5963,7 +6029,7 @@ spec:
       initContainers:
       containers:
       - name: keeper
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-keeper:26.4
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -5978,6 +6044,12 @@ spec:
           seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
+        command:
+        - sh
+        - -ec
+        - |
+          export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+          exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
         env:
         - name: BITNAMI_DEBUG
           value: "false"
@@ -6021,7 +6093,10 @@ spec:
             memory: 64Mi
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse-keeper
+          mountPath: /var/lib/clickhouse-keeper
+        - name: configuration
+          mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.xml
+          subPath: keeper_config.xml
         - name: configd-configuration
           mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.d
         - name: empty-dir
@@ -6039,6 +6114,9 @@ spec:
       volumes:
       - name: empty-dir
         emptyDir: {}
+      - name: configuration
+        configMap:
+          name: chartsnap-clickhouse-keeper
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-keeper-configd
@@ -6094,7 +6172,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configd-configuration: dc3b278f99d27bba9daa9c189b7500c5cf80a73866e54f4e92475777381f9c59
+        checksum/configd-configuration: 8c243af91e23c69d4ed85ebb3e0cce24367419fb43919bd4db0b432991ddc1f4
+        checksum/usersd-configuration: c5ab1093996fc7b5fa2ffe1abae40154115d076f3592fa2bfc6de8efd7147bca
       labels:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
@@ -6128,7 +6207,7 @@ spec:
       initContainers:
       containers:
       - name: clickhouse
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-server:26.4
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -6164,8 +6243,11 @@ spec:
               fieldPath: metadata.name
         - name: CLICKHOUSE_ADMIN_USER
           value: "default"
-        - name: CLICKHOUSE_ADMIN_PASSWORD_FILE
-          value: /opt/bitnami/clickhouse/secrets/CLICKHOUSE_PASSWORD
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-clickhouse
+              key: CLICKHOUSE_PASSWORD
         resources:
           requests:
             cpu: 40m
@@ -6200,12 +6282,11 @@ spec:
             port: http
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse
+          mountPath: /var/lib/clickhouse
         - name: configd-configuration
           mountPath: /bitnami/clickhouse/etc/config.d
-        - name: secrets
-          mountPath: /opt/bitnami/clickhouse/secrets
-          readOnly: true
+        - name: usersd-configuration-configuration
+          mountPath: /bitnami/clickhouse/etc/users.d
         - name: empty-dir
           mountPath: /opt/bitnami/clickhouse/etc
           subPath: app-conf-dir
@@ -6218,16 +6299,21 @@ spec:
         - name: empty-dir
           mountPath: /tmp
           subPath: tmp-dir
+        - mountPath: /etc/clickhouse-server/config.d
+          name: configd-configuration
+        - mountPath: /etc/clickhouse-server/users.d
+          name: usersd-configuration-configuration
       volumes:
       - name: empty-dir
         emptyDir: {}
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-configd
-      - name: secrets
-        secret:
-          secretName: chartsnap-clickhouse
-          defaultMode: 256
+      - name: usersd-configuration-configuration
+        projected:
+          sources:
+          - configMap:
+              name: chartsnap-clickhouse-usersd
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -679,6 +679,14 @@ metadata:
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
+  00-logger-console.xml: |
+    <clickhouse>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+    </clickhouse>
   01-listen.xml: |
     <yandex>
         <listen_host>::</listen_host>
@@ -755,6 +763,63 @@ data:
                 </server>
             </raft_configuration>
         </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/keeper/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-keeper
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: keeper
+    app.kubernetes.io/part-of: clickhouse
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+        <path>/var/lib/clickhouse-keeper</path>
+        <keeper_server>
+            <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"></server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/usersd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-usersd
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: clickhouse
+    app.kubernetes.io/part-of: clickhouse
+data:
+  zz-admin-user.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                <access_management>1</access_management>
+            </default>
+        </users>
     </clickhouse>
 ---
 # Source: operator-wandb/charts/mysql/templates/configmap.yaml
@@ -6851,6 +6916,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/configuration: 28e8b3cc3e08583128d3083fc8d3547900b45b5c2eb0c22dda06c7d62fa35c4e
         checksum/configd-configuration: bfdea18bbc1786d95702e6f773f35a312de0f1cd6f51dc27fdf091b40320afdd
       labels:
         app.kubernetes.io/instance: chartsnap
@@ -6884,7 +6950,7 @@ spec:
       initContainers:
       containers:
       - name: keeper
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-keeper:26.4
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -6899,6 +6965,12 @@ spec:
           seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
+        command:
+        - sh
+        - -ec
+        - |
+          export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+          exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
         env:
         - name: BITNAMI_DEBUG
           value: "false"
@@ -6942,7 +7014,10 @@ spec:
             memory: 64Mi
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse-keeper
+          mountPath: /var/lib/clickhouse-keeper
+        - name: configuration
+          mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.xml
+          subPath: keeper_config.xml
         - name: configd-configuration
           mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.d
         - name: empty-dir
@@ -6960,6 +7035,9 @@ spec:
       volumes:
       - name: empty-dir
         emptyDir: {}
+      - name: configuration
+        configMap:
+          name: chartsnap-clickhouse-keeper
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-keeper-configd
@@ -7015,7 +7093,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configd-configuration: dc3b278f99d27bba9daa9c189b7500c5cf80a73866e54f4e92475777381f9c59
+        checksum/configd-configuration: 8c243af91e23c69d4ed85ebb3e0cce24367419fb43919bd4db0b432991ddc1f4
+        checksum/usersd-configuration: c5ab1093996fc7b5fa2ffe1abae40154115d076f3592fa2bfc6de8efd7147bca
       labels:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
@@ -7049,7 +7128,7 @@ spec:
       initContainers:
       containers:
       - name: clickhouse
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-server:26.4
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -7085,8 +7164,11 @@ spec:
               fieldPath: metadata.name
         - name: CLICKHOUSE_ADMIN_USER
           value: "default"
-        - name: CLICKHOUSE_ADMIN_PASSWORD_FILE
-          value: /opt/bitnami/clickhouse/secrets/password
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-settings-secret
+              key: password
         resources:
           requests:
             cpu: 40m
@@ -7121,12 +7203,11 @@ spec:
             port: http
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse
+          mountPath: /var/lib/clickhouse
         - name: configd-configuration
           mountPath: /bitnami/clickhouse/etc/config.d
-        - name: secrets
-          mountPath: /opt/bitnami/clickhouse/secrets
-          readOnly: true
+        - name: usersd-configuration-configuration
+          mountPath: /bitnami/clickhouse/etc/users.d
         - name: empty-dir
           mountPath: /opt/bitnami/clickhouse/etc
           subPath: app-conf-dir
@@ -7139,16 +7220,21 @@ spec:
         - name: empty-dir
           mountPath: /tmp
           subPath: tmp-dir
+        - mountPath: /etc/clickhouse-server/config.d
+          name: configd-configuration
+        - mountPath: /etc/clickhouse-server/users.d
+          name: usersd-configuration-configuration
       volumes:
       - name: empty-dir
         emptyDir: {}
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-configd
-      - name: secrets
-        secret:
-          secretName: clickhouse-settings-secret
-          defaultMode: 256
+      - name: usersd-configuration-configuration
+        projected:
+          sources:
+          - configMap:
+              name: chartsnap-clickhouse-usersd
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -965,6 +965,14 @@ metadata:
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
+  00-logger-console.xml: |
+    <clickhouse>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+    </clickhouse>
   01-listen.xml: |
     <yandex>
         <listen_host>::</listen_host>
@@ -1041,6 +1049,63 @@ data:
                 </server>
             </raft_configuration>
         </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/keeper/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-keeper
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: keeper
+    app.kubernetes.io/part-of: clickhouse
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+        <path>/var/lib/clickhouse-keeper</path>
+        <keeper_server>
+            <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"></server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/usersd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-usersd
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: clickhouse
+    app.kubernetes.io/part-of: clickhouse
+data:
+  zz-admin-user.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                <access_management>1</access_management>
+            </default>
+        </users>
     </clickhouse>
 ---
 # Source: operator-wandb/charts/mysql/templates/configmap.yaml
@@ -7849,6 +7914,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/configuration: 28e8b3cc3e08583128d3083fc8d3547900b45b5c2eb0c22dda06c7d62fa35c4e
         checksum/configd-configuration: bfdea18bbc1786d95702e6f773f35a312de0f1cd6f51dc27fdf091b40320afdd
       labels:
         app.kubernetes.io/instance: chartsnap
@@ -7882,7 +7948,7 @@ spec:
       initContainers:
       containers:
       - name: keeper
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-keeper:26.4
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -7897,6 +7963,12 @@ spec:
           seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
+        command:
+        - sh
+        - -ec
+        - |
+          export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+          exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
         env:
         - name: BITNAMI_DEBUG
           value: "false"
@@ -7940,7 +8012,10 @@ spec:
             memory: 64Mi
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse-keeper
+          mountPath: /var/lib/clickhouse-keeper
+        - name: configuration
+          mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.xml
+          subPath: keeper_config.xml
         - name: configd-configuration
           mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.d
         - name: empty-dir
@@ -7958,6 +8033,9 @@ spec:
       volumes:
       - name: empty-dir
         emptyDir: {}
+      - name: configuration
+        configMap:
+          name: chartsnap-clickhouse-keeper
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-keeper-configd
@@ -8013,7 +8091,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configd-configuration: dc3b278f99d27bba9daa9c189b7500c5cf80a73866e54f4e92475777381f9c59
+        checksum/configd-configuration: 8c243af91e23c69d4ed85ebb3e0cce24367419fb43919bd4db0b432991ddc1f4
+        checksum/usersd-configuration: c5ab1093996fc7b5fa2ffe1abae40154115d076f3592fa2bfc6de8efd7147bca
       labels:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
@@ -8047,7 +8126,7 @@ spec:
       initContainers:
       containers:
       - name: clickhouse
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-server:26.4
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -8083,8 +8162,11 @@ spec:
               fieldPath: metadata.name
         - name: CLICKHOUSE_ADMIN_USER
           value: "default"
-        - name: CLICKHOUSE_ADMIN_PASSWORD_FILE
-          value: /opt/bitnami/clickhouse/secrets/CLICKHOUSE_PASSWORD
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-clickhouse
+              key: CLICKHOUSE_PASSWORD
         resources:
           requests:
             cpu: 40m
@@ -8119,12 +8201,11 @@ spec:
             port: http
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse
+          mountPath: /var/lib/clickhouse
         - name: configd-configuration
           mountPath: /bitnami/clickhouse/etc/config.d
-        - name: secrets
-          mountPath: /opt/bitnami/clickhouse/secrets
-          readOnly: true
+        - name: usersd-configuration-configuration
+          mountPath: /bitnami/clickhouse/etc/users.d
         - name: empty-dir
           mountPath: /opt/bitnami/clickhouse/etc
           subPath: app-conf-dir
@@ -8137,16 +8218,21 @@ spec:
         - name: empty-dir
           mountPath: /tmp
           subPath: tmp-dir
+        - mountPath: /etc/clickhouse-server/config.d
+          name: configd-configuration
+        - mountPath: /etc/clickhouse-server/users.d
+          name: usersd-configuration-configuration
       volumes:
       - name: empty-dir
         emptyDir: {}
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-configd
-      - name: secrets
-        secret:
-          secretName: chartsnap-clickhouse
-          defaultMode: 256
+      - name: usersd-configuration-configuration
+        projected:
+          sources:
+          - configMap:
+              name: chartsnap-clickhouse-usersd
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -752,6 +752,14 @@ metadata:
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
 data:
+  00-logger-console.xml: |
+    <clickhouse>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+    </clickhouse>
   01-listen.xml: |
     <yandex>
         <listen_host>::</listen_host>
@@ -828,6 +836,63 @@ data:
                 </server>
             </raft_configuration>
         </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/keeper/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-keeper
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: keeper
+    app.kubernetes.io/part-of: clickhouse
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+        <logger>
+            <console>1</console>
+            <log remove="remove"></log>
+            <errorlog remove="remove"></errorlog>
+        </logger>
+        <path>/var/lib/clickhouse-keeper</path>
+        <keeper_server>
+            <tcp_port from_env="CLICKHOUSE_KEEPER_TCP_PORT"></tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"></server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        </keeper_server>
+    </clickhouse>
+---
+# Source: operator-wandb/charts/clickhouse/templates/usersd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-clickhouse-usersd
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/version: 25.7.5
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: clickhouse
+    app.kubernetes.io/part-of: clickhouse
+data:
+  zz-admin-user.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password from_env="CLICKHOUSE_ADMIN_PASSWORD"></password>
+                <access_management>1</access_management>
+            </default>
+        </users>
     </clickhouse>
 ---
 # Source: operator-wandb/charts/mysql/templates/configmap.yaml
@@ -7103,6 +7168,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/configuration: 28e8b3cc3e08583128d3083fc8d3547900b45b5c2eb0c22dda06c7d62fa35c4e
         checksum/configd-configuration: bfdea18bbc1786d95702e6f773f35a312de0f1cd6f51dc27fdf091b40320afdd
       labels:
         app.kubernetes.io/instance: chartsnap
@@ -7136,7 +7202,7 @@ spec:
       initContainers:
       containers:
       - name: keeper
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-keeper:26.4
         imagePullPolicy: "IfNotPresent"
         securityContext:
           allowPrivilegeEscalation: false
@@ -7151,6 +7217,12 @@ spec:
           seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
+        command:
+        - sh
+        - -ec
+        - |
+          export KEEPER_SERVER_ID="${CLICKHOUSE_KEEPER_SERVER_ID##*-}"
+          exec clickhouse-keeper --config-file=/bitnami/clickhouse-keeper/etc/keeper_config.xml
         env:
         - name: BITNAMI_DEBUG
           value: "false"
@@ -7194,7 +7266,10 @@ spec:
             memory: 64Mi
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse-keeper
+          mountPath: /var/lib/clickhouse-keeper
+        - name: configuration
+          mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.xml
+          subPath: keeper_config.xml
         - name: configd-configuration
           mountPath: /bitnami/clickhouse-keeper/etc/keeper_config.d
         - name: empty-dir
@@ -7212,6 +7287,9 @@ spec:
       volumes:
       - name: empty-dir
         emptyDir: {}
+      - name: configuration
+        configMap:
+          name: chartsnap-clickhouse-keeper
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-keeper-configd
@@ -7267,7 +7345,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configd-configuration: dc3b278f99d27bba9daa9c189b7500c5cf80a73866e54f4e92475777381f9c59
+        checksum/configd-configuration: 8c243af91e23c69d4ed85ebb3e0cce24367419fb43919bd4db0b432991ddc1f4
+        checksum/usersd-configuration: c5ab1093996fc7b5fa2ffe1abae40154115d076f3592fa2bfc6de8efd7147bca
       labels:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
@@ -7301,7 +7380,7 @@ spec:
       initContainers:
       containers:
       - name: clickhouse
-        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
+        image: us-docker.pkg.dev/wandb-production/public/clickhouse/clickhouse-server:26.4
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -7337,8 +7416,11 @@ spec:
               fieldPath: metadata.name
         - name: CLICKHOUSE_ADMIN_USER
           value: "default"
-        - name: CLICKHOUSE_ADMIN_PASSWORD_FILE
-          value: /opt/bitnami/clickhouse/secrets/CLICKHOUSE_PASSWORD
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-clickhouse
+              key: CLICKHOUSE_PASSWORD
         resources:
           requests:
             cpu: 40m
@@ -7373,12 +7455,11 @@ spec:
             port: http
         volumeMounts:
         - name: data
-          mountPath: /bitnami/clickhouse
+          mountPath: /var/lib/clickhouse
         - name: configd-configuration
           mountPath: /bitnami/clickhouse/etc/config.d
-        - name: secrets
-          mountPath: /opt/bitnami/clickhouse/secrets
-          readOnly: true
+        - name: usersd-configuration-configuration
+          mountPath: /bitnami/clickhouse/etc/users.d
         - name: empty-dir
           mountPath: /opt/bitnami/clickhouse/etc
           subPath: app-conf-dir
@@ -7391,16 +7472,21 @@ spec:
         - name: empty-dir
           mountPath: /tmp
           subPath: tmp-dir
+        - mountPath: /etc/clickhouse-server/config.d
+          name: configd-configuration
+        - mountPath: /etc/clickhouse-server/users.d
+          name: usersd-configuration-configuration
       volumes:
       - name: empty-dir
         emptyDir: {}
       - name: configd-configuration
         configMap:
           name: chartsnap-clickhouse-configd
-      - name: secrets
-        secret:
-          secretName: chartsnap-clickhouse
-          defaultMode: 256
+      - name: usersd-configuration-configuration
+        projected:
+          sources:
+          - configMap:
+              name: chartsnap-clickhouse-usersd
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/test-configs/operator-wandb/olap-features-enabled.yaml
+++ b/test-configs/operator-wandb/olap-features-enabled.yaml
@@ -33,11 +33,8 @@ global:
         tls: "false"
     registrySearch:
       enabled: true
-    # The runs-accelerator schema needs text indexes (GA in ClickHouse >= 26),
-    # which the bundled bitnamilegacy/clickhouse 25.7 image cannot parse.
-    # Re-enable when the bundled ClickHouse image is upgraded.
     runStoreAccelerator:
-      enabled: false
+      enabled: true
     history:
       enabled: true
   size: "testing"


### PR DESCRIPTION
## Summary

The bundled ClickHouse subchart pulls `bitnamilegacy/clickhouse:25.7`, a frozen snapshot of the pre-Broadcom Bitnami catalog that will never publish 26.x. Production (ClickHouse Cloud) and core's CI both run 26.x, and core's `runs-accelerator` migrations use 26.x-GA syntax (`text` index) that 25.7 cannot parse — which is what broke the `olap-features-enabled` CI jobs.

This switches the bundled chart to the official `clickhouse/clickhouse-server:26.4` / `clickhouse-keeper:26.4` images, values-only (no subchart template changes):

- Config/users fragments re-mounted at official paths via `extraVolumeMounts`; admin user declared via `usersdFiles` (replacing the Bitnami entrypoint's provisioning); console logging; data under `/var/lib/clickhouse`.
- Keeper gets a full config plus a small command wrapper to derive the numeric server id from the pod ordinal (the Bitnami entrypoint used to do this).
- One vendored-chart default fix: `keeper.configuration` `{}` -> `""` so a string override doesn't trigger a Helm coalesce warning (which chartsnap captures into every snapshot).
- Re-enables `runStoreAccelerator` in the OLAP CI config.

Validated in kind by applying the exact rendered manifests: server + 3 keepers ready, keeper quorum up, and all core ClickHouse migrations (runs-accelerator incl. the text index, history, artifacts) pass on 26.4.5. Data survives pod restart.

## Test plan

- [x] `format_templates.py`, unit tests, `check_template_maintainability.py`
- [x] Snapshots regenerated and verified (helm v3.20.1)
- [x] Rendered manifests applied to kind: pods ready, keeper quorum, all core CH migrations pass on 26.4
- [ ] CI green after mirror images are seeded