### PR TITLE
chore(weave): allowlist weave-evaluate-model-worker SA on gorilla

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.43.9
+version: 0.43.10
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -784,6 +784,8 @@ app:
       issuer: "https://kubernetes.default.svc.cluster.local"
     - subject: "system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-weave-trace-worker"
       issuer: "https://kubernetes.default.svc.cluster.local"
+    - subject: "system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-weave-evaluate-model-worker"
+      issuer: "https://kubernetes.default.svc.cluster.local"
   env:
     GORILLA_LICENSE_CERT_PATH: "/var/app/jwks.json"
     GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE: "/usr/local/bin/view-spec-updater-linux"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -1552,7 +1552,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
-  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-evaluate-model-worker": "https://kubernetes.default.svc.cluster.local"}'
   GORILLA_WEAVE_TRACE_SERVER_URL: "https://wandb.example.com/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -1696,7 +1696,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
-  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-evaluate-model-worker": "https://kubernetes.default.svc.cluster.local"}'
   GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -1867,7 +1867,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
-  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-evaluate-model-worker": "https://kubernetes.default.svc.cluster.local"}'
   GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -1654,7 +1654,7 @@ data:
   GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
   GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
-  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local"}'
+  GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS: '{"system:serviceaccount:default:chartsnap-weave-trace": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-trace-worker": "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:default:chartsnap-weave-evaluate-model-worker": "https://kubernetes.default.svc.cluster.local"}'
   GORILLA_WEAVE_TRACE_SERVER_URL: "http://localhost:8080/traces"
   GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
   GORILLA_LOCAL_SERVICE_BYPASS: 'false'


### PR DESCRIPTION
## Summary
- Adds `<release>-weave-evaluate-model-worker`'s service account to `app.internalJWTMap` so gorilla's `GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS` accepts internal JWTs signed by this worker.
- Bumps `operator-wandb` chart to 0.43.10 and refreshes the four snapshots that render the map.

## Context
Follows #598, which added the initial `weave-trace-worker` allowlist entry. `weave-evaluate-model-worker` (introduced in #505) also mounts `WANDB_INTERNAL_SERVICE_TOKEN` and calls back into gorilla, but its SA was never added to the allowlist — gorilla rejects the JWT (`issuer/subject` mismatch) and the failure surfaces as a generic 500 to upstream callers such as the playground custom-provider flow.

`weave-trace-agent-scoring-worker` has the same gap; I'll open a separate PR for it.

## Test plan
- [x] `python3 scripts/format_templates.py` — no diff
- [x] `python3 -m unittest discover -s scripts/tests` — 16 pass
- [x] `python3 scripts/check_template_maintainability.py` — pass
- [x] `./snapshots.sh update operator-wandb` — diff limited to the 4 snapshots that render `GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS` (`mcp-server.snap`, `olap-features-enabled.snap`, `weave-trace.snap`, `weave-trace-with-worker.snap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)