### PR TITLE
fix(operator-wandb): make OIDC rendering nil-safe

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.5
+version: 0.44.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -490,17 +490,18 @@ Global values will override any chart-specific values.
 {{- end -}}
 
 {{- define "wandb.oidcEnvs" -}}
-  {{- if or .Values.global.auth.oidc.secret "" .Values.global.auth.oidc.oidcSecret.name }}
+  {{- $oidc := include "wandb.oidc.config" . | fromYaml -}}
+  {{- if or $oidc.secret $oidc.oidcSecret.name }}
 - name: GORILLA_OIDC_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ include "wandb.oidc.secretSecret" . | quote }}
-      key: "{{ .Values.global.auth.oidc.oidcSecret.secretKey }}"
+      key: "{{ $oidc.oidcSecret.secretKey }}"
 - name: OIDC_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ include "wandb.oidc.secretSecret" . | quote }}
-      key: "{{ .Values.global.auth.oidc.oidcSecret.secretKey }}"
+      key: "{{ $oidc.oidcSecret.secretKey }}"
   {{- end }}
 {{- end -}}
 

--- a/charts/operator-wandb/templates/_oidc.tpl
+++ b/charts/operator-wandb/templates/_oidc.tpl
@@ -1,11 +1,31 @@
 {{/*
+Return the normalized OIDC configuration so every template can safely consume
+an absent, null, or partial global.auth.oidc map.
+*/}}
+{{- define "wandb.oidc.config" -}}
+  {{- $global := default (dict) .Values.global -}}
+  {{- $auth := default (dict) (get $global "auth") -}}
+  {{- $oidc := default (dict) (get $auth "oidc") -}}
+  {{- $oidcSecret := default (dict) (get $oidc "oidcSecret") -}}
+  {{- toYaml (dict
+    "clientId" (default "" (get $oidc "clientId"))
+    "secret" (default "" (get $oidc "secret"))
+    "authMethod" (default "" (get $oidc "authMethod"))
+    "issuer" (default "" (get $oidc "issuer"))
+    "oidcSecret" (dict
+      "name" (default "" (get $oidcSecret "name"))
+      "secretKey" (default "OIDC_SECRET" (get $oidcSecret "secretKey"))
+  )) -}}
+{{- end -}}
+
+{{/*
 Return the name of the secret where OIDC secret is stored, considering if the custom secret is defined
 */}}
 {{- define "wandb.oidc.secretSecret" -}}
-  {{- if .Values.global.auth.oidc.oidcSecret.name }}
-  {{- .Values.global.auth.oidc.oidcSecret.name -}}
+  {{- $oidc := include "wandb.oidc.config" . | fromYaml -}}
+  {{- if $oidc.oidcSecret.name }}
+  {{- $oidc.oidcSecret.name -}}
   {{- else }}
   {{- print .Release.Name "-oidc-secret" -}}
   {{- end -}}
 {{- end -}}
-

--- a/charts/operator-wandb/templates/api.yaml
+++ b/charts/operator-wandb/templates/api.yaml
@@ -1,3 +1,4 @@
+{{- $oidc := include "wandb.oidc.config" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,7 +13,7 @@ data:
   GORILLA_LICENSE_CERT_PATH: "/jwks.json"
   GORILLA_FILE_METADATA_SOURCE_IS_INTERNAL: "true"
 {{- $corsOrigins := list }}
-{{- if ne .Values.global.auth.oidc.clientId "" }}
+{{- if ne $oidc.clientId "" }}
   {{- $corsOrigins = concat $corsOrigins (list .Values.global.host "null") | compact }}
 {{- end }}
 {{- if .Values.app.extraCors }}
@@ -21,10 +22,10 @@ data:
 {{- if gt (len $corsOrigins) 0 }}
   GORILLA_CORS_ORIGINS: "{{ join "," $corsOrigins }}"
 {{- end }}
-{{- if ne .Values.global.auth.oidc.clientId "" }}
-  GORILLA_OIDC_CLIENT_ID: "{{ .Values.global.auth.oidc.clientId }}"
-  GORILLA_AUTH_METHOD: "{{ .Values.global.auth.oidc.authMethod }}"
-  GORILLA_OIDC_ISSUER: "{{ .Values.global.auth.oidc.issuer }}"
+{{- if ne $oidc.clientId "" }}
+  GORILLA_OIDC_CLIENT_ID: "{{ $oidc.clientId }}"
+  GORILLA_AUTH_METHOD: "{{ $oidc.authMethod }}"
+  GORILLA_OIDC_ISSUER: "{{ $oidc.issuer }}"
 {{- end }}
   GORILLA_SESSION_LENGTH: "{{ .Values.global.auth.sessionLengthHours }}h"
   GORILLA_SWEEP_PROVIDER: "{{ include "wandb.anaconda2.sweepProvider" . }}"

--- a/charts/operator-wandb/templates/local.yaml
+++ b/charts/operator-wandb/templates/local.yaml
@@ -1,3 +1,4 @@
+{{- $oidc := include "wandb.oidc.config" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,10 +10,10 @@ data:
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "{{ .Values.global.host }}"
 
-{{- if ne .Values.global.auth.oidc.clientId ""  }}
-  OIDC_CLIENT_ID: {{ .Values.global.auth.oidc.clientId }}
-  OIDC_AUTH_METHOD: {{ .Values.global.auth.oidc.authMethod }}
-  OIDC_ISSUER: {{ .Values.global.auth.oidc.issuer }}
+{{- if ne $oidc.clientId ""  }}
+  OIDC_CLIENT_ID: {{ $oidc.clientId }}
+  OIDC_AUTH_METHOD: {{ $oidc.authMethod }}
+  OIDC_ISSUER: {{ $oidc.issuer }}
 {{- end }}
 
   LOCAL_K8S_SIGNER_SECRET_NAME: "{{ .Release.Name }}-internal-signer"

--- a/charts/operator-wandb/templates/oidc.yaml
+++ b/charts/operator-wandb/templates/oidc.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.auth.oidc.secret (not .Values.global.auth.oidc.oidcSecret.name) }}
+{{- $oidc := include "wandb.oidc.config" . | fromYaml -}}
+{{- if and $oidc.secret (not $oidc.oidcSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,7 +7,7 @@ metadata:
   labels:
     {{- include "wandb.commonLabels" . | nindent 4 }}
 data:
-  {{ .Values.global.auth.oidc.oidcSecret.secretKey }}: {{ .Values.global.auth.oidc.secret | b64enc }}
+  {{ $oidc.oidcSecret.secretKey }}: {{ $oidc.secret | b64enc }}
 ---
 {{- end }}
 

--- a/charts/operator-wandb/tests/oidc_nil_safe_test.yaml
+++ b/charts/operator-wandb/tests/oidc_nil_safe_test.yaml
@@ -1,0 +1,322 @@
+suite: nil-safe OIDC configuration
+templates:
+  - templates/oidc.yaml
+  - templates/api.yaml
+  - templates/local.yaml
+  - charts/api/templates/deployment.yaml
+  - charts/app/templates/deployment.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: leaves OIDC resources and configuration disabled by default
+    set:
+      global.api.enabled: true
+      app.internalJWTMap: []
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/oidc.yaml
+      - notExists:
+          path: data.GORILLA_OIDC_CLIENT_ID
+        template: templates/api.yaml
+      - notExists:
+          path: data.OIDC_CLIENT_ID
+        template: templates/local.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+          any: true
+        template: charts/api/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+          any: true
+        template: charts/api/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+          any: true
+        template: charts/app/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+          any: true
+        template: charts/app/templates/deployment.yaml
+
+  - it: treats explicitly null OIDC as disabled in every affected template
+    set:
+      global.api.enabled: true
+      app.internalJWTMap: []
+      global.auth.oidc: null
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/oidc.yaml
+      - notExists:
+          path: data.GORILLA_OIDC_CLIENT_ID
+        template: templates/api.yaml
+      - notExists:
+          path: data.OIDC_CLIENT_ID
+        template: templates/local.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+          any: true
+        template: charts/api/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+          any: true
+        template: charts/api/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+          any: true
+        template: charts/app/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+          any: true
+        template: charts/app/templates/deployment.yaml
+
+  - it: renders only supplied OIDC client configuration from a partial map
+    set:
+      global.api.enabled: true
+      app.internalJWTMap: []
+      global.auth.oidc:
+        clientId: synthetic-client
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/oidc.yaml
+      - equal:
+          path: data.GORILLA_OIDC_CLIENT_ID
+          value: synthetic-client
+        template: templates/api.yaml
+      - equal:
+          path: data.GORILLA_AUTH_METHOD
+          value: ""
+        template: templates/api.yaml
+      - equal:
+          path: data.GORILLA_OIDC_ISSUER
+          value: ""
+        template: templates/api.yaml
+      - equal:
+          path: data.OIDC_CLIENT_ID
+          value: synthetic-client
+        template: templates/local.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+          any: true
+        template: charts/api/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+          any: true
+        template: charts/api/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+          any: true
+        template: charts/app/templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+          any: true
+        template: charts/app/templates/deployment.yaml
+
+  - it: creates the chart-owned OIDC secret and uses its configured key
+    set:
+      global.api.enabled: true
+      app.internalJWTMap: []
+      global.auth.oidc:
+        clientId: synthetic-client
+        secret: synthetic-inline-secret
+        authMethod: oidc
+        issuer: https://issuer.invalid
+        oidcSecret:
+          name: ""
+          secretKey: synthetic-secret-key
+    asserts:
+      - equal:
+          path: metadata.name
+          value: wandb-oidc-secret
+        template: templates/oidc.yaml
+        documentSelector:
+          path: kind
+          value: Secret
+      - exists:
+          path: data.synthetic-secret-key
+        template: templates/oidc.yaml
+        documentSelector:
+          path: kind
+          value: Secret
+      - equal:
+          path: data.GORILLA_OIDC_CLIENT_ID
+          value: synthetic-client
+        template: templates/api.yaml
+      - equal:
+          path: data.OIDC_ISSUER
+          value: https://issuer.invalid
+        template: templates/local.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: synthetic-secret-key
+        template: charts/api/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: synthetic-secret-key
+        template: charts/api/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: synthetic-secret-key
+        template: charts/app/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: synthetic-secret-key
+        template: charts/app/templates/deployment.yaml
+
+  - it: defaults a null nested OIDC secret configuration to OIDC_SECRET
+    set:
+      global.api.enabled: true
+      app.internalJWTMap: []
+      global.auth.oidc:
+        secret: synthetic-inline-secret
+        oidcSecret: null
+    asserts:
+      - equal:
+          path: metadata.name
+          value: wandb-oidc-secret
+        template: templates/oidc.yaml
+        documentSelector:
+          path: kind
+          value: Secret
+      - exists:
+          path: data.OIDC_SECRET
+        template: templates/oidc.yaml
+        documentSelector:
+          path: kind
+          value: Secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: OIDC_SECRET
+        template: charts/api/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: OIDC_SECRET
+        template: charts/api/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: OIDC_SECRET
+        template: charts/app/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: wandb-oidc-secret
+                key: OIDC_SECRET
+        template: charts/app/templates/deployment.yaml
+
+  - it: uses an external OIDC secret without creating a chart-owned one
+    set:
+      global.api.enabled: true
+      app.internalJWTMap: []
+      global.auth.oidc:
+        clientId: synthetic-client
+        authMethod: oidc
+        issuer: https://issuer.invalid
+        oidcSecret:
+          name: externally-managed-oidc
+          secretKey: externally-managed-key
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/oidc.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: externally-managed-oidc
+                key: externally-managed-key
+        template: charts/api/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: externally-managed-oidc
+                key: externally-managed-key
+        template: charts/api/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GORILLA_OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: externally-managed-oidc
+                key: externally-managed-key
+        template: charts/app/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: externally-managed-oidc
+                key: externally-managed-key
+        template: charts/app/templates/deployment.yaml


### PR DESCRIPTION
## What

Normalize OIDC configuration through one shared helper and route every affected Secret, ConfigMap, and workload template through it.

## Why

Absent, null, or partially specified OIDC maps could cause Helm nil dereferences during reconciliation.

## Validation

- Missing, null, partial, inline-secret, external-secret, and null nested-secret cases
- Full Helm unit suite: 55 tests passed
- Helm lint, formatter, maintainability checks, representative renders, and snapshots
- Tests assert both OIDC environment variables are absent when disabled and never print secret values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC configuration handling when settings are missing, null, or only partially specified.
  * Preserved support for custom and externally managed secrets, including custom secret keys.
  * Ensured API, local, deployment, and OIDC resources render safely across supported configuration scenarios.

* **Tests**
  * Added comprehensive coverage for default, partial, null, and externally managed OIDC configurations.

* **Chores**
  * Updated the Helm chart version to 0.44.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->