### PR TITLE
fix(operator): bound and harden app rename rollout hooks

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.5
+version: 0.44.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/app_rename_cleanup.yaml
+++ b/charts/operator-wandb/templates/app_rename_cleanup.yaml
@@ -20,11 +20,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -37,20 +42,33 @@ data:
     RELEASE="{{ .Release.Name }}"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi

--- a/charts/operator-wandb/tests/app_rename_cleanup_test.yaml
+++ b/charts/operator-wandb/tests/app_rename_cleanup_test.yaml
@@ -1,0 +1,37 @@
+suite: app rename cleanup hooks
+templates:
+  - templates/app_rename_cleanup.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: waits for each replacement before safely deleting its predecessor
+    asserts:
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'if ! kubectl -n "\$NAMESPACE" rollout status deploy/"\$\{replacement\}" --timeout=5m; then'
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'if ! kubectl -n "\$NAMESPACE" rollout status deploy/"\$\{replacement\}" --timeout=5m; then\s+echo "Deployment ''\$\{replacement\}'' did not become available; controlled status follows\." >&2\s+log_replacement_status "\$replacement" "\$deployment"\s+exit 1\s+fi\s+echo "Deleting deployment ''\$\{RELEASE\}-\$\{deployment\}'' in namespace ''\$NAMESPACE''\.\.\."\s+kubectl -n "\$NAMESPACE" delete deployment "\$\{RELEASE\}-\$\{deployment\}" --ignore-not-found=true'
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'get deployment "\$replacement" -o .*jsonpath='
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'get replicasets -l "app\.kubernetes\.io/instance=\$\{RELEASE\},app\.kubernetes\.io/name=\$\{component\}" -o .*jsonpath='
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'delete deployment "\$\{RELEASE\}-\$\{deployment\}" --ignore-not-found=true'
+      - matchRegex:
+          path: data["pre_upgrade.sh"]
+          pattern: 'annotate deployment "\$\{RELEASE\}-\$\{deployment\}" "helm\.sh/resource-policy=keep" --overwrite'
+      - matchRegex:
+          path: data["pre_upgrade.sh"]
+          pattern: 'if \[ \$status -eq 0 \]; then[\s\S]*kubectl -n "\$NAMESPACE" annotate deployment "\$\{RELEASE\}-\$\{deployment\}" "helm\.sh/resource-policy=keep" --overwrite[\s\S]*annotation_status=\$\?[\s\S]*if \[ \$annotation_status -ne 0 \]; then[\s\S]*exit "\$annotation_status"[\s\S]*fi[\s\S]*else'
+      - notMatchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'kubectl[^\n]*(describe| -o yaml| -o json)'
+      - notMatchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'rollout status[^\n]*\|\|'

--- a/charts/operator-wandb/tests/app_rename_cleanup_test.yaml
+++ b/charts/operator-wandb/tests/app_rename_cleanup_test.yaml
@@ -29,6 +29,15 @@ tests:
       - matchRegex:
           path: data["pre_upgrade.sh"]
           pattern: 'if \[ \$status -eq 0 \]; then[\s\S]*kubectl -n "\$NAMESPACE" annotate deployment "\$\{RELEASE\}-\$\{deployment\}" "helm\.sh/resource-policy=keep" --overwrite[\s\S]*annotation_status=\$\?[\s\S]*if \[ \$annotation_status -ne 0 \]; then[\s\S]*exit "\$annotation_status"[\s\S]*fi[\s\S]*else'
+      - matchRegex:
+          path: data["pre_upgrade.sh"]
+          pattern: 'else\s+if echo "\$output" \| grep -qi "\(NotFound\)\\\|not found"; then[\s\S]*else\s+echo "Error checking deployment ''\$\{RELEASE\}-\$\{deployment\}'' \(exit status \$status\)\." >&2\s+exit \$status\s+fi'
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'delete deployment "\$\{RELEASE\}-\$\{deployment\}" --ignore-not-found=true \|\| exit \$\?'
+      - matchRegex:
+          path: data["post_upgrade.sh"]
+          pattern: 'else\s+if echo "\$output" \| grep -qi "\(NotFound\)\\\|not found"; then[\s\S]*else\s+echo "Error checking deployment ''\$\{RELEASE\}-\$\{deployment\}'' \(exit status \$status\)\." >&2\s+exit \$status\s+fi'
       - notMatchRegex:
           path: data["post_upgrade.sh"]
           pattern: 'kubectl[^\n]*(describe| -o yaml| -o json)'

--- a/charts/operator-wandb/tests/app_rename_post_hook_role_test.yaml
+++ b/charts/operator-wandb/tests/app_rename_post_hook_role_test.yaml
@@ -1,0 +1,29 @@
+suite: app rename post-upgrade hook role
+templates:
+  - charts/appRenamePostHook/templates/role.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: grants ReplicaSet diagnostics only list access
+    asserts:
+      - equal:
+          path: rules[0].resources
+          value:
+            - deployments
+      - equal:
+          path: rules[0].verbs
+          value:
+            - get
+            - delete
+            - list
+            - watch
+      - equal:
+          path: rules[1].resources
+          value:
+            - replicasets
+      - equal:
+          path: rules[1].verbs
+          value:
+            - list

--- a/charts/operator-wandb/tests/app_rename_post_hook_test.yaml
+++ b/charts/operator-wandb/tests/app_rename_post_hook_test.yaml
@@ -1,0 +1,19 @@
+suite: app rename post-upgrade hook job
+templates:
+  - charts/appRenamePostHook/templates/job.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: bounds cleanup retries while preserving the cleanup script
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 1800
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: /cleanup-scripts/post_upgrade.sh

--- a/charts/operator-wandb/tests/app_rename_pre_hook_test.yaml
+++ b/charts/operator-wandb/tests/app_rename_pre_hook_test.yaml
@@ -1,0 +1,19 @@
+suite: app rename pre-upgrade hook job
+templates:
+  - charts/appRenamePreHook/templates/job.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: bounds annotation retries while preserving the cleanup script
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 1500
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: /cleanup-scripts/pre_upgrade.sh

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1061,7 +1061,9 @@ appRenamePostHook:
     enabled: false
   jobs:
     app-rename-post-hook:
-      # Four sequential five-minute rollout waits leave ten minutes for retry and cleanup overhead.
+      # A failed attempt deletes predecessors whose replacements were ready, so a retry
+      # only waits for the remaining replacement. Four initial waits plus one retry
+      # consume at most 25 minutes, leaving five minutes for backoff and cleanup.
       backoffLimit: 1
       activeDeadlineSeconds: 1800
       containers:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1022,6 +1022,9 @@ appRenamePreHook:
     enabled: false
   jobs:
     app-rename-pre-hook:
+      # Bound annotation retries so a failed pre-upgrade hook always terminates.
+      backoffLimit: 1
+      activeDeadlineSeconds: 1500
       containers:
         app-rename-pre-hook:
           command:
@@ -1058,6 +1061,9 @@ appRenamePostHook:
     enabled: false
   jobs:
     app-rename-post-hook:
+      # Four sequential five-minute rollout waits leave ten minutes for retry and cleanup overhead.
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
       containers:
         app-rename-post-hook:
           command:
@@ -1084,6 +1090,9 @@ appRenamePostHook:
       - apiGroups: ["apps"]
         resources: ["deployments"]
         verbs: ["get", "delete", "list", "watch"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["list"]
 
 console:
   podLabels:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -4367,11 +4367,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4383,20 +4388,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4427,6 +4445,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4544,6 +4568,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4620,6 +4646,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -4371,11 +4371,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4387,20 +4392,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4431,6 +4449,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4548,6 +4572,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4624,6 +4650,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -3831,11 +3831,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -3847,20 +3852,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -3891,6 +3909,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4008,6 +4032,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4088,6 +4114,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -3817,11 +3817,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -3833,20 +3838,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -3877,6 +3895,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3994,6 +4018,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4074,6 +4100,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -4069,11 +4069,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4085,20 +4090,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4203,6 +4221,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4356,6 +4380,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4436,6 +4462,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -5059,11 +5059,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5075,20 +5080,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5121,6 +5139,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5246,6 +5270,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       annotations:
@@ -5343,6 +5369,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       annotations:

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -8438,11 +8438,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8454,20 +8459,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8498,6 +8516,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8615,6 +8639,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -8727,6 +8753,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -6338,11 +6338,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6354,20 +6359,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6398,6 +6416,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6565,6 +6589,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -6655,6 +6681,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -7032,11 +7032,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7048,20 +7053,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7092,6 +7110,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7209,6 +7233,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7299,6 +7325,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -7010,11 +7010,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7026,20 +7031,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7070,6 +7088,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7187,6 +7211,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7277,6 +7303,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -7010,11 +7010,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7026,20 +7031,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7070,6 +7088,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7187,6 +7211,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7277,6 +7303,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -4371,11 +4371,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4387,20 +4392,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4431,6 +4449,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4548,6 +4572,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4624,6 +4650,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -4719,11 +4719,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4735,20 +4740,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4779,6 +4797,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4896,6 +4920,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4972,6 +4998,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -4746,11 +4746,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4762,20 +4767,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4806,6 +4824,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4923,6 +4947,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4999,6 +5025,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -4351,11 +4351,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4367,20 +4372,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4411,6 +4429,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4528,6 +4552,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4604,6 +4630,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -6333,11 +6333,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6349,20 +6354,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6393,6 +6411,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6560,6 +6584,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -6650,6 +6676,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -7033,11 +7033,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7049,20 +7054,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7093,6 +7111,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7260,6 +7284,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7350,6 +7376,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -4583,11 +4583,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4599,20 +4604,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4643,6 +4661,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4781,6 +4805,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4857,6 +4883,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -4583,11 +4583,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4599,20 +4604,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4643,6 +4661,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4781,6 +4805,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4857,6 +4883,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -4581,11 +4581,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4597,20 +4602,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4641,6 +4659,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4779,6 +4803,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4855,6 +4881,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -7364,11 +7364,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7380,20 +7385,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7498,6 +7516,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7672,6 +7696,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7762,6 +7788,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -7010,11 +7010,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7026,20 +7031,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7070,6 +7088,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7187,6 +7211,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7277,6 +7303,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -7060,11 +7060,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7076,20 +7081,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7120,6 +7138,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7237,6 +7261,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7327,6 +7353,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -8312,11 +8312,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8328,20 +8333,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8446,6 +8464,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8766,6 +8790,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -8856,6 +8882,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -6289,11 +6289,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6305,20 +6310,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6349,6 +6367,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6578,6 +6602,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -6668,6 +6694,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
+++ b/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
@@ -8366,11 +8366,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8382,20 +8387,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8426,6 +8444,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8543,6 +8567,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -8643,6 +8669,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -8027,11 +8027,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8043,20 +8048,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8087,6 +8105,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8204,6 +8228,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -8304,6 +8330,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -7066,11 +7066,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7082,20 +7087,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7126,6 +7144,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7243,6 +7267,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7333,6 +7359,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -5562,11 +5562,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5578,20 +5583,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5622,6 +5640,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5739,6 +5763,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5829,6 +5855,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -6964,11 +6964,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6980,20 +6985,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7024,6 +7042,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7308,6 +7332,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7398,6 +7424,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -5086,11 +5086,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5102,20 +5107,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5146,6 +5164,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5263,6 +5287,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5339,6 +5365,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -5088,11 +5088,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5104,20 +5109,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5148,6 +5166,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5265,6 +5289,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5341,6 +5367,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -5088,11 +5088,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5104,20 +5109,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5148,6 +5166,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5265,6 +5289,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5341,6 +5367,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -4845,11 +4845,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4861,20 +4866,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4905,6 +4923,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5022,6 +5046,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5106,6 +5132,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -6768,11 +6768,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6784,20 +6789,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6828,6 +6846,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6945,6 +6969,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7021,6 +7047,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -6768,11 +6768,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6784,20 +6789,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6828,6 +6846,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6945,6 +6969,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7021,6 +7047,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -4614,11 +4614,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4630,20 +4635,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4674,6 +4692,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4791,6 +4815,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4867,6 +4893,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -4612,11 +4612,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4628,20 +4633,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4672,6 +4690,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4789,6 +4813,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4865,6 +4891,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -4680,11 +4680,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4696,20 +4701,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4740,6 +4758,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4857,6 +4881,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4933,6 +4959,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -4573,11 +4573,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4589,20 +4594,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4633,6 +4651,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4750,6 +4774,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4826,6 +4852,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -4575,11 +4575,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4591,20 +4596,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4635,6 +4653,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4752,6 +4776,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4828,6 +4854,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -5319,11 +5319,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5335,20 +5340,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5379,6 +5397,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5496,6 +5520,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5586,6 +5612,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -5087,11 +5087,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5103,20 +5108,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5147,6 +5165,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5264,6 +5288,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5340,6 +5366,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -5142,11 +5142,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5158,20 +5163,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5202,6 +5220,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5319,6 +5343,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5395,6 +5421,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -5142,11 +5142,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5158,20 +5163,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -5202,6 +5220,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5319,6 +5343,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5395,6 +5421,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -4853,11 +4853,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4869,20 +4874,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4913,6 +4931,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5030,6 +5054,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5115,6 +5141,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -4398,11 +4398,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4414,20 +4419,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4458,6 +4476,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4575,6 +4599,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4651,6 +4677,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -4379,11 +4379,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4395,20 +4400,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4439,6 +4457,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4556,6 +4580,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -4632,6 +4658,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -6349,11 +6349,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6365,20 +6370,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -6409,6 +6427,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6526,6 +6550,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -6621,6 +6647,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -7012,11 +7012,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7028,20 +7033,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7072,6 +7090,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7189,6 +7213,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -7279,6 +7305,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -4710,11 +4710,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4726,20 +4731,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -4844,6 +4862,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4997,6 +5021,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -5073,6 +5099,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -7888,11 +7888,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7904,20 +7909,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -7948,6 +7966,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8126,6 +8150,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -8216,6 +8242,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -9054,11 +9054,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -9070,20 +9075,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -9188,6 +9206,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -9341,6 +9365,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -9431,6 +9457,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -8134,11 +8134,16 @@ data:
       if [ $status -eq 0 ]; then
         echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
         kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+        annotation_status=$?
+        if [ $annotation_status -ne 0 ]; then
+          echo "Error annotating deployment '${RELEASE}-${deployment}' (exit status $annotation_status)." >&2
+          exit "$annotation_status"
+        fi
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8150,20 +8155,33 @@ data:
     RELEASE="chartsnap"
     DEPLOYMENTS="app parquet weave weave-trace"
 
+    log_replacement_status() {
+      replacement="$1"
+      component="$2"
+
+      kubectl -n "$NAMESPACE" get deployment "$replacement" -o 'jsonpath={.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} updatedReplicas={.status.updatedReplicas} unavailableReplicas={.status.unavailableReplicas} observedGeneration={.status.observedGeneration} generation={.metadata.generation}{"\n"}' >&2 || true
+      kubectl -n "$NAMESPACE" get replicasets -l "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/name=${component}" -o 'jsonpath={range .items[*]}{.metadata.name} readyReplicas={.status.readyReplicas} availableReplicas={.status.availableReplicas} replicas={.status.replicas} observedGeneration={.status.observedGeneration}{"\n"}{end}' >&2 || true
+    }
+
     for deployment in ${DEPLOYMENTS}; do
       output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
       status=$?
       if [ $status -eq 0 ]; then
-        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
-        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+        replacement="${RELEASE}-${deployment}-bc"
+        echo "Waiting for deployment '${replacement}' to become available..."
+        if ! kubectl -n "$NAMESPACE" rollout status deploy/"${replacement}" --timeout=5m; then
+          echo "Deployment '${replacement}' did not become available; controlled status follows." >&2
+          log_replacement_status "$replacement" "$deployment"
+          exit 1
+        fi
 
         echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
-        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" --ignore-not-found=true || exit $?
       else
         if echo "$output" | grep -qi "(NotFound)\|not found"; then
           echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
         else
-          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          echo "Error checking deployment '${RELEASE}-${deployment}' (exit status $status)." >&2
           exit $status
         fi
       fi
@@ -8268,6 +8286,12 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8421,6 +8445,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
   template:
     metadata:
       labels:
@@ -8511,6 +8537,8 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1500
   template:
     metadata:
       labels:


### PR DESCRIPTION
## What

Bound both app-rename hook Jobs, wait up to five minutes per replacement Deployment, emit controlled readiness diagnostics, and delete each old Deployment only after its replacement is available. The cleanup is idempotent across a Job retry, pre-hook annotation failures are no longer masked, and ReplicaSet RBAC is list-only.

The render tests also pin the failure behavior: non-`NotFound` lookup errors exit in both hooks, annotation and delete failures propagate, and a failed rollout never reaches predecessor deletion.

## Why

Unbounded waits and masked pre-hook annotation failures could allow Helm to proceed without preserving the old Deployment. A failed post-hook attempt deletes only predecessors whose replacements became available; the retry skips those missing predecessors and waits only for the remaining replacement.

With four sequential five-minute rollout waits and one retry, the maximum rollout-wait path is therefore 25 minutes, not two complete 20-minute passes. `activeDeadlineSeconds: 1800` leaves five minutes for Job-controller backoff, scheduling, API calls, and cleanup.

## Rollout dependency

Operator v1 currently uses Helm v4.1.4 with the hook-only wait strategy but does not set the Helm action timeout. Helm v4 maps that zero value to a 30-second hook watcher timeout, so a healthy app-rename hook can outlive the Operator's Helm wait even though this chart correctly permits up to 30 minutes.

This PR can complete chart review independently, but it must not roll to Operator v1 until the separate v1 Helm action-timeout correction is merged, released, and canary-verified. Changing this chart's Job deadline cannot override the Helm SDK watcher deadline.

## Validation

- Helm unit tests: 8 suites / 53 tests passed
- Python script tests: 16 passed
- Helm lint and chart-testing lint passed
- Template formatter, maintainability check, `helmfmt`, and rendered pre/post-hook `shellcheck` passed
- Exact Helm 3.20.1 snapshot suite: all 54 deterministic snapshots matched
- Review-feedback assertions were mutation-checked: removing either non-`NotFound` exit or delete-error propagation makes the focused suite fail



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app rename cleanup during upgrades by detecting annotation and deployment lookup failures.
  * Added rollout monitoring with clearer diagnostics and failure handling.
  * Ensured outdated deployments are safely removed after successful replacement.

* **Reliability**
  * Added bounded retries and execution time limits for upgrade cleanup jobs.
  * Expanded permissions needed to monitor replacement resources.

* **Tests**
  * Added coverage for cleanup behavior, rollout failures, permissions, and job configuration.

* **Chores**
  * Updated the Helm chart version to 0.44.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->