### PR TITLE
fix(operator-wandb): protect standalone Console ownership

### DIFF
--- a/charts/operator-wandb/templates/console-ownership-validation.yaml
+++ b/charts/operator-wandb/templates/console-ownership-validation.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.console.install .Values.console.service.enabled -}}
+  {{- $defaultServiceName := printf "%s-console" .Release.Name -}}
+  {{- $rawServiceName := (dig "service" "name" "" .Values.console) | default $defaultServiceName -}}
+  {{- $serviceName := tpl $rawServiceName . | trunc 63 | trimSuffix "-" -}}
+  {{- $service := (lookup "v1" "Service" .Release.Namespace $serviceName) | default dict -}}
+  {{- $metadata := (get $service "metadata") | default dict -}}
+  {{- $annotations := (get $metadata "annotations") | default dict -}}
+  {{- $owningRelease := (get $annotations "meta.helm.sh/release-name") | default "" -}}
+  {{- $standaloneConsoleOwnsService := and (eq $owningRelease "console") (ne .Release.Name "console") -}}
+  {{- if $standaloneConsoleOwnsService -}}
+    {{- fail (printf "bundled Console cannot use Service %s/%s because Helm release console owns it; keep console.install=false while standalone Console is installed" .Release.Namespace $serviceName) -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/operator-wandb/tests/console_ownership_test.yaml
+++ b/charts/operator-wandb/tests/console_ownership_test.yaml
@@ -1,0 +1,139 @@
+suite: Console service ownership preflight
+templates:
+  - templates/console-ownership-validation.yaml
+release:
+  name: wandb
+  namespace: customer
+kubernetesProvider:
+  scheme:
+    "v1/Service":
+      gvr:
+        version: v1
+        resource: services
+      namespaced: true
+
+tests:
+  - it: allows the standalone Console service when bundled Console is disabled
+    set:
+      console.install: false
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: wandb-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: console
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: allows bundled Console when the target service does not exist
+    set:
+      console.install: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: allows bundled Console when another release owns the target service
+    set:
+      console.install: true
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: wandb-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: another-release
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: allows the Console release to reconcile its own service
+    release:
+      name: console
+      namespace: customer
+    set:
+      console.install: true
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: console-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: console
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips the check when the bundled Console service is disabled
+    set:
+      console.install: true
+      console.service.enabled: false
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: wandb-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: console
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rejects bundled Console when the standalone release owns the default service
+    set:
+      console.install: true
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: wandb-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: console
+    asserts:
+      - failedTemplate:
+          errorMessage: bundled Console cannot use Service customer/wandb-console because Helm release console owns it; keep console.install=false while standalone Console is installed
+
+  - it: checks an explicitly configured Console service name
+    set:
+      console.install: true
+      console.service.name: custom-console
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: custom-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: console
+    asserts:
+      - failedTemplate:
+          errorMessage: bundled Console cannot use Service customer/custom-console because Helm release console owns it; keep console.install=false while standalone Console is installed
+
+  - it: resolves a templated Console service name before checking ownership
+    set:
+      console.install: true
+      console.service.name: '{{ .Release.Name }}-console'
+    kubernetesProvider:
+      objects:
+        - apiVersion: v1
+          kind: Service
+          metadata:
+            name: wandb-console
+            namespace: customer
+            annotations:
+              meta.helm.sh/release-name: console
+    asserts:
+      - failedTemplate:
+          errorMessage: bundled Console cannot use Service customer/wandb-console because Helm release console owns it; keep console.install=false while standalone Console is installed


### PR DESCRIPTION
## What

Add a Helm preflight that looks up the exact Console Service before rendering bundled Console. If Helm release `console` owns that Service, rendering fails with a controlled message and keeps `console.install=false` as the required state.

## Why

A transient values merge could enable bundled Console while the standalone child release already owns `wandb-console`.

## Validation

- Eight ownership tests covering disabled/absent/other-owner/self-owner/default/custom/templated names
- Full Helm unit suite: 57 tests passed
- Helm lint, formatter, maintainability checks
- Exact Helm 3.20.1 snapshot suite: all snapshots matched