### PR TITLE
feat(wandb-base): add per-container Go memory limit

### DIFF
--- a/.github/workflows/test-operator-wandb.yaml
+++ b/.github/workflows/test-operator-wandb.yaml
@@ -3,6 +3,7 @@ name: Test operator-wandb Chart
 on:
   pull_request:
     paths:
+      - charts/wandb-base/**
       - charts/operator-wandb/**
       - test-configs/operator-wandb/**
       - scripts/normalize_snapshot_chart_versions.py

--- a/.github/workflows/test-orchestrator.yaml
+++ b/.github/workflows/test-orchestrator.yaml
@@ -3,6 +3,7 @@ name: Test orchestrator Chart
 on:
   pull_request:
     paths:
+      - charts/wandb-base/**
       - charts/orchestrator/**
       - test-configs/orchestrator/**
       - scripts/normalize_snapshot_chart_versions.py

--- a/.github/workflows/test-wandb-base.yaml
+++ b/.github/workflows/test-wandb-base.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - charts/wandb-base/**
       - test-configs/wandb-base/**
+      - scripts/test_wandb_base_go_memory_limit.sh
       - scripts/normalize_snapshot_chart_versions.py
       - snapshots.sh
       - .github/workflows/test-wandb-base.yaml
@@ -24,5 +25,8 @@ jobs:
         run: |
           helm plugin install https://github.com/origranot/helm-cascade
           helm cascade build ./charts/wandb-base/
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.1.1
+          helm unittest ./charts/wandb-base/
+          HELM_BIN=helm bash ./scripts/test_wandb_base_go_memory_limit.sh
           helm plugin install https://github.com/jlandowner/helm-chartsnap
           ./snapshots.sh run wandb-base

--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
-digest: sha256:60d1023fe307cba27e2dfe573be514601dc0dcacb6d72f91323615fedaa42772
-generated: "2026-07-29T18:00:40.632395-05:00"
+  version: 0.12.7
+digest: sha256:6a4d35030d930a8ad4f6a1ada246116749584e084a7a6f2b2f2f48de13e0c990
+generated: "2026-08-12T01:31:14.52289-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,39 +82,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:039ae3137a49174b04980ea7cafdd5f83fc517a898b577278b76a587b1723266
-generated: "2026-08-05T08:44:45.513577-05:00"
+digest: sha256:1986ad265b0aaca94ee3286ce5b4f08e3841c9813bf22a16cc7ec97925d61a52
+generated: "2026-08-12T01:33:18.968809-05:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.5
+version: 0.44.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: console
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,20 +109,20 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: filestream
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -193,6 +193,10 @@ Each component can be configured independently. For example, to configure the AP
 api:
   enabled: true
   replicaCount: 2
+  containers:
+    api:
+      # Optional; no fleet or chart default is set.
+      goMemoryLimit: "8GiB"
   resources:
     requests:
       cpu: 100m
@@ -201,6 +205,22 @@ api:
       cpu: 1000m
       memory: 1Gi
 ```
+
+`goMemoryLimit` is scoped to the named main container. Setting
+`api.containers.api.goMemoryLimit` replaces the API container's generated
+`GOMEMLIMIT` with the literal value; API migration/init containers, updater
+workloads, and every other component keep their existing
+`limits.memory`-derived value unless configured independently. The value must
+be a quoted positive Go byte count such as `8GiB`, must fit in Go's signed
+64-bit byte-count range after applying the suffix, and cannot be combined with
+any direct or inherited `env.GOMEMLIMIT`.
+
+Core also reads `GOMEMLIMIT` as the denominator for API deep-readiness and
+request-pressure sampling. Lowering it can change the reported heap fraction
+and shadow trip point. This Helm field does not enable deep-readiness or
+backpressure enforcement, change probes, or change any gate value; review the
+effective gates separately before a rollout. Removing the field restores the
+resource-derived value.
 
 ## Use External Stateful Data
 

--- a/charts/operator-wandb/tests/go_memory_limit_test.yaml
+++ b/charts/operator-wandb/tests/go_memory_limit_test.yaml
@@ -1,0 +1,85 @@
+suite: container-scoped Go memory limit
+templates:
+  - charts/api/templates/deployment.yaml
+  - charts/flat-run-fields-updater/templates/deployment.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: gives only the main API container a literal GOMEMLIMIT
+    template: charts/api/templates/deployment.yaml
+    set:
+      global.api.enabled: true
+      api.containers.api.goMemoryLimit: 8GiB
+      flat-run-fields-updater.install: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            value: 8GiB
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+
+  - it: leaves the updater on its memory-limit-derived GOMEMLIMIT when only API is set
+    template: charts/flat-run-fields-updater/templates/deployment.yaml
+    set:
+      global.api.enabled: true
+      api.containers.api.goMemoryLimit: 8GiB
+      flat-run-fields-updater.install: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+
+  - it: leaves API on its memory-limit-derived GOMEMLIMIT when only the updater is set
+    template: charts/api/templates/deployment.yaml
+    set:
+      global.api.enabled: true
+      flat-run-fields-updater.install: true
+      flat-run-fields-updater.containers.flat-run-fields-updater.goMemoryLimit: 4GiB
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+
+  - it: gives only the independently configured updater a literal GOMEMLIMIT
+    template: charts/flat-run-fields-updater/templates/deployment.yaml
+    set:
+      global.api.enabled: true
+      flat-run-fields-updater.install: true
+      flat-run-fields-updater.containers.flat-run-fields-updater.goMemoryLimit: 4GiB
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            value: 4GiB

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
-digest: sha256:e2514816c2f8ca70a4f0db5e1f76ce8a211f106d46c2d685094f7ae8da4855b6
-generated: "2026-07-29T18:00:53.549681-05:00"
+  version: 0.12.7
+digest: sha256:31d5aeb4b27d864b5238e142b54c7a95426c64d4c408afaadee643e6dcb7b78e
+generated: "2026-08-12T01:31:15.392601-05:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.6
+version: 0.12.7
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/README.md
+++ b/charts/wandb-base/README.md
@@ -60,6 +60,32 @@ envFrom:
   app-secrets: "secretRef"
 ```
 
+### Go Runtime Memory Limit
+
+Named containers can set an optional, positive Go runtime soft memory limit:
+
+```yaml
+containers:
+  api:
+    goMemoryLimit: "8GiB"
+```
+
+The field accepts only quoted Go byte-count strings matching
+`^[1-9][0-9]*(([KMGT]i)?B)?$` whose value, after applying the suffix, does not
+exceed Go's signed 64-bit maximum of 9,223,372,036,854,775,807 bytes. For
+example, `1024`, `512MiB`, and `8GiB` are valid strings; zero, null, YAML
+numbers, fractional values, overflowing quantities, `8Gi`, and `8GB` are
+rejected. When the field is absent, the chart does not add a literal
+`GOMEMLIMIT`, so an existing templated environment entry such as a Kubernetes
+`limits.memory` `resourceFieldRef` renders exactly as before.
+
+The value applies only to the named container. It is not inherited by other
+main containers, init containers, Job containers, or CronJob containers. Those
+containers can opt in independently at their own `goMemoryLimit` field. Do not
+also set `GOMEMLIMIT` through container, chart, sizing, extra, or global `env`;
+the chart rejects that ambiguous configuration instead of choosing precedence.
+Remove `goMemoryLimit` to restore the previous environment source.
+
 ### Volumes
 
 Volumes can be defined at multiple levels and are combined by name. The chart uses the pod- or chart-level volume when a name collides with a global volume.
@@ -489,6 +515,8 @@ containers:
       tag: v1.0.0
     command: ["./start.sh"]
     args: ["--config", "/etc/config/config.yaml"]
+    # Optional; there is no chart default.
+    goMemoryLimit: "8GiB"
     env:
       LOG_LEVEL: "debug"
     ports:

--- a/charts/wandb-base/templates/_containers.tpl
+++ b/charts/wandb-base/templates/_containers.tpl
@@ -49,6 +49,41 @@
         {{- end -}}
       {{- end -}}
 
+      {{- if hasKey $container "goMemoryLimit" -}}
+        {{- $goMemoryLimit := get $container "goMemoryLimit" -}}
+        {{- $goMemoryLimitPath := printf "%s.%s.goMemoryLimit" $.source $containerName -}}
+        {{- if not (kindIs "string" $goMemoryLimit) -}}
+          {{- fail (printf "%s must be a positive Go byte-count string matching ^[1-9][0-9]*(([KMGT]i)?B)?$" $goMemoryLimitPath) -}}
+        {{- end -}}
+        {{- if not (regexMatch "^[1-9][0-9]*(([KMGT]i)?B)?$" $goMemoryLimit) -}}
+          {{- fail (printf "%s must be a positive Go byte-count string matching ^[1-9][0-9]*(([KMGT]i)?B)?$" $goMemoryLimitPath) -}}
+        {{- end -}}
+        {{- $goMemoryLimitSuffix := regexFind "([KMGT]iB|B)$" $goMemoryLimit -}}
+        {{- $goMemoryLimitMagnitude := trimSuffix $goMemoryLimitSuffix $goMemoryLimit -}}
+        {{- $goMemoryLimitMaxima := dict
+        "" "9223372036854775807"
+        "B" "9223372036854775807"
+        "KiB" "9007199254740991"
+        "MiB" "8796093022207"
+        "GiB" "8589934591"
+        "TiB" "8388607"
+        -}}
+        {{- $goMemoryLimitMaximum := get $goMemoryLimitMaxima $goMemoryLimitSuffix -}}
+        {{- if or
+        (gt (len $goMemoryLimitMagnitude) (len $goMemoryLimitMaximum))
+        (and
+        (eq (len $goMemoryLimitMagnitude) (len $goMemoryLimitMaximum))
+        (gt $goMemoryLimitMagnitude $goMemoryLimitMaximum)
+        )
+        -}}
+          {{- fail (printf "%s exceeds Go's maximum signed 64-bit memory limit" $goMemoryLimitPath) -}}
+        {{- end -}}
+        {{- if hasKey $container.env "GOMEMLIMIT" -}}
+          {{- fail (printf "%s cannot be combined with env.GOMEMLIMIT" $goMemoryLimitPath) -}}
+        {{- end -}}
+        {{- $_ = set $container.env "GOMEMLIMIT" $goMemoryLimit -}}
+      {{- end -}}
+
       {{- /* We prerender the envTpls and put them into an array for searching */ -}}
       {{- $envTpls := list }}
       {{- if $.root.Values.envTpls -}}

--- a/charts/wandb-base/templates/_containers.tpl
+++ b/charts/wandb-base/templates/_containers.tpl
@@ -69,13 +69,11 @@
         "TiB" "8388607"
         -}}
         {{- $goMemoryLimitMaximum := get $goMemoryLimitMaxima $goMemoryLimitSuffix -}}
-        {{- if or
-        (gt (len $goMemoryLimitMagnitude) (len $goMemoryLimitMaximum))
-        (and
-        (eq (len $goMemoryLimitMagnitude) (len $goMemoryLimitMaximum))
-        (gt $goMemoryLimitMagnitude $goMemoryLimitMaximum)
-        )
-        -}}
+        {{- $goMemoryLimitHasMoreDigits := gt (len $goMemoryLimitMagnitude) (len $goMemoryLimitMaximum) -}}
+        {{- $goMemoryLimitHasEqualDigits := eq (len $goMemoryLimitMagnitude) (len $goMemoryLimitMaximum) -}}
+        {{- $goMemoryLimitIsLexicallyLarger := gt $goMemoryLimitMagnitude $goMemoryLimitMaximum -}}
+        {{- $goMemoryLimitExceedsMaximum := or $goMemoryLimitHasMoreDigits (and $goMemoryLimitHasEqualDigits $goMemoryLimitIsLexicallyLarger) -}}
+        {{- if $goMemoryLimitExceedsMaximum -}}
           {{- fail (printf "%s exceeds Go's maximum signed 64-bit memory limit" $goMemoryLimitPath) -}}
         {{- end -}}
         {{- if hasKey $container.env "GOMEMLIMIT" -}}

--- a/charts/wandb-base/tests/go_memory_limit_test.yaml
+++ b/charts/wandb-base/tests/go_memory_limit_test.yaml
@@ -1,0 +1,135 @@
+suite: per-container Go memory limit
+templates:
+  - templates/deployment.yaml
+  - templates/job.yaml
+  - templates/cronjob.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: replaces only the selected deployment container GOMEMLIMIT
+    template: templates/deployment.yaml
+    set:
+      envTpls:
+        - |-
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      containers:
+        api:
+          goMemoryLimit: 8GiB
+      initContainers:
+        migrate-db: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            value: 8GiB
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+
+  - it: applies an init-container override without changing the main container
+    template: templates/deployment.yaml
+    set:
+      envTpls:
+        - |-
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      containers:
+        api: {}
+      initContainers:
+        migrate-db:
+          goMemoryLimit: 512MiB
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GOMEMLIMIT
+            value: 512MiB
+
+  - it: applies an override to one Job container only
+    template: templates/job.yaml
+    set:
+      jobs:
+        compact:
+          containers:
+            main:
+              goMemoryLimit: 2GiB
+            sidecar: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            value: 2GiB
+      - equal:
+          path: spec.template.spec.containers[1].env
+          value: null
+
+  - it: applies an override to one CronJob container only
+    template: templates/cronjob.yaml
+    set:
+      cronJobs:
+        cleanup:
+          schedule: "0 2 * * *"
+          containers:
+            main:
+              goMemoryLimit: 3GiB
+            sidecar: {}
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+            value: 3GiB
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[1].env
+          value: null
+
+  - it: rejects a direct GOMEMLIMIT conflict
+    template: templates/deployment.yaml
+    set:
+      containers:
+        api:
+          goMemoryLimit: 8GiB
+          env:
+            GOMEMLIMIT: 7GiB
+    asserts:
+      - failedTemplate:
+          errorMessage: 'containers.api.goMemoryLimit cannot be combined with env.GOMEMLIMIT'
+
+  - it: rejects an inherited GOMEMLIMIT conflict
+    template: templates/deployment.yaml
+    set:
+      env:
+        GOMEMLIMIT: 7GiB
+      containers:
+        api:
+          goMemoryLimit: 8GiB
+    asserts:
+      - failedTemplate:
+          errorMessage: 'containers.api.goMemoryLimit cannot be combined with env.GOMEMLIMIT'

--- a/charts/wandb-base/values.schema.json
+++ b/charts/wandb-base/values.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "wandb-base values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "containers": {
+      "$ref": "#/definitions/containerMap"
+    },
+    "initContainers": {
+      "$ref": "#/definitions/containerMap"
+    },
+    "jobs": {
+      "$ref": "#/definitions/podResourceMap"
+    },
+    "cronJobs": {
+      "$ref": "#/definitions/podResourceMap"
+    }
+  },
+  "definitions": {
+    "container": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "goMemoryLimit": {
+          "description": "Optional positive Go runtime memory limit for this container. The value must use Go's byte-count grammar and fit in a signed 64-bit byte count after applying its suffix.",
+          "$comment": "The schema caps suffix-specific magnitude widths; the template performs the exact upper-bound comparison for equal-width values.",
+          "type": "string",
+          "pattern": "^([1-9][0-9]{0,18}B?|[1-9][0-9]{0,15}KiB|[1-9][0-9]{0,12}MiB|[1-9][0-9]{0,9}GiB|[1-9][0-9]{0,6}TiB)$"
+        }
+      }
+    },
+    "containerMap": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/container"
+      }
+    },
+    "podResource": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "containers": {
+          "$ref": "#/definitions/containerMap"
+        },
+        "initContainers": {
+          "$ref": "#/definitions/containerMap"
+        }
+      }
+    },
+    "podResourceMap": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/podResource"
+      }
+    }
+  }
+}

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -140,6 +140,10 @@ containers: {}
 #  nginx:
 #    command: ["nginx"]
 #    args: ["-g", "daemon off;"]
+#    # Optional per-container Go runtime soft memory limit. When omitted, this
+#    # chart does not add a literal GOMEMLIMIT. Quote the value so schema
+#    # validation can enforce Go's positive, signed-64-bit byte-count grammar.
+#    # goMemoryLimit: "1GiB"
 #    env:
 #      NGINX_HOST: "example.com"
 #      NGINX_PORT: "80"

--- a/scripts/test_wandb_base_go_memory_limit.sh
+++ b/scripts/test_wandb_base_go_memory_limit.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+chart_dir="${script_dir}/../charts/wandb-base"
+helm_bin="${HELM_BIN:-helm}"
+
+base_args=(
+  --set-string containers.test.image.repository=example.invalid/test
+  --set-string containers.test.image.tag=test
+)
+
+expect_success() {
+  local label="$1"
+  shift
+  if ! "${helm_bin}" template go-memory-limit "${chart_dir}" "${base_args[@]}" "$@" >/dev/null; then
+    echo "expected ${label} to render successfully" >&2
+    return 1
+  fi
+}
+
+expect_failure() {
+  local label="$1"
+  shift
+  if "${helm_bin}" template go-memory-limit "${chart_dir}" "${base_args[@]}" "$@" >/dev/null 2>&1; then
+    echo "expected ${label} to fail rendering" >&2
+    return 1
+  fi
+}
+
+expect_failure_containing() {
+  local label="$1"
+  local expected="$2"
+  local output
+  shift 2
+  if output=$("${helm_bin}" template go-memory-limit "${chart_dir}" "${base_args[@]}" "$@" 2>&1); then
+    echo "expected ${label} to fail rendering" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"${expected}"* ]]; then
+    echo "expected ${label} failure to contain: ${expected}" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+expect_success "an absent value"
+
+for value in 1 1B 1KiB 1MiB 8GiB 1TiB; do
+  expect_success "valid value ${value}" --set-string "containers.test.goMemoryLimit=${value}"
+done
+
+boundary_failures=0
+for value in \
+  9223372036854775807 \
+  9223372036854775807B \
+  9007199254740991KiB \
+  8796093022207MiB \
+  8589934591GiB \
+  8388607TiB; do
+  expect_success "maximum valid value ${value}" \
+    --set-string "containers.test.goMemoryLimit=${value}" || boundary_failures=1
+  expect_success "maximum valid value ${value} with schema skipped" \
+    --skip-schema-validation \
+    --set-string "containers.test.goMemoryLimit=${value}" || boundary_failures=1
+done
+
+for value in \
+  9223372036854775808 \
+  9223372036854775808B \
+  9007199254740992KiB \
+  8796093022208MiB \
+  8589934592GiB \
+  8388608TiB; do
+  expect_failure "overflow value ${value}" \
+    --set-string "containers.test.goMemoryLimit=${value}" || boundary_failures=1
+  expect_failure_containing "overflow value ${value} with schema skipped" \
+    "exceeds Go's maximum signed 64-bit memory limit" \
+    --skip-schema-validation \
+    --set-string "containers.test.goMemoryLimit=${value}" || boundary_failures=1
+done
+
+for value in \
+  10000000000000000000 \
+  10000000000000000000B \
+  10000000000000000KiB \
+  10000000000000MiB \
+  10000000000GiB \
+  10000000TiB; do
+  expect_failure_containing "schema magnitude limit ${value}" \
+    "values don't meet the specifications of the schema" \
+    --set-string "containers.test.goMemoryLimit=${value}" || boundary_failures=1
+done
+
+if ((boundary_failures)); then
+  exit 1
+fi
+
+for value in '' 0 0B 11Gi 11GB 1.5GiB -1GiB; do
+  expect_failure "invalid string value ${value:-<empty>}" --set-string "containers.test.goMemoryLimit=${value}"
+done
+
+for value_path in \
+  initContainers.test.goMemoryLimit \
+  jobs.compact.containers.test.goMemoryLimit \
+  cronJobs.cleanup.containers.test.goMemoryLimit; do
+  expect_failure "invalid ${value_path}" --set-string "${value_path}=11Gi"
+done
+
+expect_failure "a numeric YAML value" --set containers.test.goMemoryLimit=1024
+expect_failure "a null YAML value" --set-json containers.test.goMemoryLimit=null
+
+for env_path in \
+  containers.test.env.GOMEMLIMIT \
+  env.GOMEMLIMIT \
+  extraEnv.GOMEMLIMIT \
+  global.env.GOMEMLIMIT \
+  global.extraEnv.GOMEMLIMIT; do
+  expect_failure "conflicting ${env_path}" \
+    --set-string containers.test.goMemoryLimit=8GiB \
+    --set-string "${env_path}=7GiB"
+done
+
+expect_failure "conflicting sizing environment" \
+  --set-string containers.test.goMemoryLimit=8GiB \
+  --set-string size=conflict-test \
+  --set-string sizing.conflict-test.env.GOMEMLIMIT=7GiB
+
+expect_failure "template string validation with schema skipped" \
+  --skip-schema-validation \
+  --set-string containers.test.goMemoryLimit=11Gi
+
+expect_failure "template type validation for a number with schema skipped" \
+  --skip-schema-validation \
+  --set containers.test.goMemoryLimit=1024

--- a/test-configs/operator-wandb/__snapshots__/go-memory-limit.snap
+++ b/test-configs/operator-wandb/__snapshots__/go-memory-limit.snap
@@ -1,0 +1,6077 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: operator-wandb/charts/redis/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: chartsnap-redis
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: redis
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - {}
+  ingress:
+  # Allow inbound connections
+  - ports:
+    - port: 6379
+---
+# Source: operator-wandb/charts/api/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/app/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-app
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: app
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/console/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-console
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/flat-run-fields-updater/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-flat-run-fields-updater
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: flat-run-fields-updater
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: flat-run-fields-updater
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/nginx/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/parquet/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-parquet
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: parquet
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/weave/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-weave
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: weave
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: operator-wandb/charts/api/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/app/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-app
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-console
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/flat-run-fields-updater/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-flat-run-fields-updater
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: flat-run-fields-updater
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/nginx/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/otel/charts/daemonset/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-otel-daemonset
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: operator-wandb/charts/parquet/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-parquet
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+  namespace: default
+---
+# Source: operator-wandb/charts/redis/templates/master/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: false
+metadata:
+  name: chartsnap-redis-master
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+---
+# Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "chartsnap"
+  labels:
+    app: chartsnap-reloader
+    chart: "reloader-1.3.0"
+    release: "chartsnap"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+  name: chartsnap-reloader
+  namespace: default
+---
+# Source: operator-wandb/charts/weave/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-weave
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/templates/bucket.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-bucket
+  labels:
+data:
+---
+# Source: operator-wandb/templates/clickhouse.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-clickhouse
+  annotations:
+    "helm.sh/resource-policy": "keep"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "chartsnap-.*"
+  labels:
+data:
+  CLICKHOUSE_PASSWORD: '###DYNAMIC_FIELD###'
+---
+# Source: operator-wandb/templates/global.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-global-secret
+  labels:
+  annotations:
+    "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "chartsnap-.*"
+data:
+  GORILLA_STATSIG_KEY:
+  GORILLA_SLACK_CLIENT_ID:
+  GORILLA_SLACK_SECRET:
+  SLACK_CLIENT_ID:
+  SLACK_SECRET:
+---
+# Source: operator-wandb/templates/kafka.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-kafka
+  labels:
+data:
+  KAFKA_CLIENT_PASSWORD:
+---
+# Source: operator-wandb/templates/license.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-license
+  annotations:
+    "helm.sh/resource-policy": "keep"
+  labels:
+data:
+  license: ""
+---
+# Source: operator-wandb/templates/mysql.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-mysql
+  annotations:
+    "helm.sh/resource-policy": "keep"
+  labels:
+data:
+  MYSQL_ROOT_PASSWORD: '###DYNAMIC_FIELD###'
+  MYSQL_PASSWORD: '###DYNAMIC_FIELD###'
+---
+# Source: operator-wandb/templates/parquet.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-parquet-secret
+  labels:
+data: {}
+---
+# Source: operator-wandb/templates/redis.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "chartsnap-redis-secret"
+  labels:
+data:
+  REDIS_PASSWORD:
+  REDIS_CA_CERT:
+---
+# Source: operator-wandb/templates/session-key.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-gorilla-session-key
+  annotations:
+    "helm.sh/resource-policy": "keep"
+  labels:
+type: Opaque
+data:
+  # Retrieve the secret data using lookup function and when not exists, return an empty dictionary / map as result
+  # Set $gorillaSessionKey to existing secret data or generate a random one when not exists
+  GORILLA_SESSION_KEY: "###DYNAMIC_FIELD###"
+  GORILLA_AUTH_JWK_URL: "aHR0cDovL2NoYXJ0c25hcC1hcHA6ODA4My9hcGkvandrcy5qc29u"
+---
+# Source: operator-wandb/templates/smtp.yaml
+# Any time the password is not a map, we need to create this secret manually
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "chartsnap-smtp-secret"
+  labels:
+data:
+  SMTP_PASSWORD: ""
+---
+# Source: operator-wandb/charts/mysql/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-mysql-initdb
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+data:
+  my.cnf: |
+    [mysqld]
+    binlog_format = 'ROW'
+    innodb_online_alter_log_max_size = 268435456
+    sync_binlog = 1
+    innodb_flush_log_at_trx_commit = 1
+    binlog_row_image = 'MINIMAL'
+    local-infile = 1
+    sort_buffer_size = 33554432
+  # We need RELOAD, SELECT, and LOCK TABLES for making backups
+  initdb.sql: |
+    GRANT SESSION_VARIABLES_ADMIN,RELOAD,SELECT,LOCK TABLES ON *.* TO `wandb`@`%`;
+---
+# Source: operator-wandb/charts/otel/charts/daemonset/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-otel-daemonset
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+data:
+  config: |
+    exporters:
+      debug: {}
+      debug/detailed:
+        verbosity: detailed
+      prometheus:
+        endpoint: 0.0.0.0:9109
+    extensions:
+      health_check: {}
+      memory_ballast:
+        size_in_percentage: 40
+    processors:
+      batch: {}
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key_regex: (.*)
+            tag_name: $$1
+          labels:
+          - from: pod
+            key_regex: (.*)
+            tag_name: $$1
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      filelog:
+        exclude: []
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_log_size: 102400
+          output: extract_metadata_from_filepath
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_log_size: 102400
+          output: extract_metadata_from_filepath
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - id: extract_metadata_from_filepath
+          parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          to: body
+          type: move
+        start_at: end
+      hostmetrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory: null
+          network: null
+      k8s_cluster:
+        collection_interval: 10s
+      k8sobjects:
+        objects:
+        - exclude_watch_type:
+          - DELETED
+          group: events.k8s.io
+          mode: watch
+          name: events
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 20s
+        endpoint: https://${env:K8S_NODE_NAME}:10250
+        insecure_skip_verify: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      statsd:
+        endpoint: 0.0.0.0:8125
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          - k8sattributes
+          receivers:
+          - filelog
+        metrics:
+          exporters:
+          - debug
+          - prometheus
+          processors:
+          - memory_limiter
+          - batch
+          - k8sattributes
+          receivers:
+          - hostmetrics
+          - k8s_cluster
+          - kubeletstats
+        traces:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - batch
+          - k8sattributes
+          receivers:
+          - otlp
+      telemetry:
+        metrics:
+          address: ${env:POD_IP}:8888
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+  namespace: default
+data:
+  allow-snippet-annotations: "false"
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/alerting_rules.yml
+    - /etc/config/rules
+    - /etc/config/alerts
+    scrape_configs:
+    - job_name: prometheus
+      static_configs:
+      - targets:
+        - localhost:9090
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-apiservers
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: default;kubernetes;https
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes-cadvisor
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints-slow
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+    - honor_labels: true
+      job_name: prometheus-pushgateway
+      kubernetes_sd_configs:
+      - role: service
+      relabel_configs:
+      - action: keep
+        regex: pushgateway
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+    - honor_labels: true
+      job_name: kubernetes-services
+      kubernetes_sd_configs:
+      - role: service
+      metrics_path: /probe
+      params:
+        module:
+        - http_2xx
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+      - source_labels:
+        - __address__
+        target_label: __param_target
+      - replacement: blackbox
+        target_label: __address__
+      - source_labels:
+        - __param_target
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+    - honor_labels: true
+      job_name: kubernetes-pods
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-pods-slow
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+  recording_rules.yml: |
+    {}
+  rules: |
+    {}
+---
+# Source: operator-wandb/charts/redis/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-redis-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  redis.conf: |-
+    # User-supplied common configuration:
+    # Enable AOF https://redis.io/topics/persistence#append-only-file
+    appendonly yes
+    # Disable RDB persistence, AOF persistence already enabled.
+    save ""
+    # End of common configuration
+  master.conf: |-
+    dir /data
+    # User-supplied master configuration:
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
+    # End of master configuration
+  replica.conf: |-
+    dir /data
+    # User-supplied replica configuration:
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
+    # End of replica configuration
+---
+# Source: operator-wandb/charts/redis/templates/health-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-redis-health
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  ping_readiness_local.sh: |-
+    #!/bin/bash
+
+    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
+    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
+    response=$(
+      timeout -s 15 $1 \
+      redis-cli \
+        -h localhost \
+        -p $REDIS_PORT \
+        ping
+    )
+    if [ "$?" -eq "124" ]; then
+      echo "Timed out"
+      exit 1
+    fi
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_liveness_local.sh: |-
+    #!/bin/bash
+
+    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
+    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
+    response=$(
+      timeout -s 15 $1 \
+      redis-cli \
+        -h localhost \
+        -p $REDIS_PORT \
+        ping
+    )
+    if [ "$?" -eq "124" ]; then
+      echo "Timed out"
+      exit 1
+    fi
+    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
+    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ] && [ "$responseFirstWord" != "MASTERDOWN" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_readiness_master.sh: |-
+    #!/bin/bash
+
+    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
+    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
+    response=$(
+      timeout -s 15 $1 \
+      redis-cli \
+        -h $REDIS_MASTER_HOST \
+        -p $REDIS_MASTER_PORT_NUMBER \
+        ping
+    )
+    if [ "$?" -eq "124" ]; then
+      echo "Timed out"
+      exit 1
+    fi
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_liveness_master.sh: |-
+    #!/bin/bash
+
+    [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
+    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
+    response=$(
+      timeout -s 15 $1 \
+      redis-cli \
+        -h $REDIS_MASTER_HOST \
+        -p $REDIS_MASTER_PORT_NUMBER \
+        ping
+    )
+    if [ "$?" -eq "124" ]; then
+      echo "Timed out"
+      exit 1
+    fi
+    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
+    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_readiness_local_and_master.sh: |-
+    script_dir="$(dirname "$0")"
+    exit_status=0
+    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
+    exit $exit_status
+  ping_liveness_local_and_master.sh: |-
+    script_dir="$(dirname "$0")"
+    exit_status=0
+    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
+    exit $exit_status
+---
+# Source: operator-wandb/charts/redis/templates/scripts-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-redis-scripts
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+data:
+  start-master.sh: |
+    #!/bin/bash
+
+    [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
+    if [[ -f /opt/bitnami/redis/mounted-etc/master.conf ]];then
+        cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
+    fi
+    if [[ -f /opt/bitnami/redis/mounted-etc/redis.conf ]];then
+        cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
+    fi
+    ARGS=("--port" "${REDIS_PORT}")
+    ARGS+=("--protected-mode" "no")
+    ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
+    ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
+    exec redis-server "${ARGS[@]}"
+---
+# Source: operator-wandb/templates/anaconda2.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-anaconda2-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  ANACONDA2_DISABLE_FILE_LOGGING: "true"
+  DD_SERVICE: "anaconda2"
+  PORT: "8082"
+---
+# Source: operator-wandb/templates/api.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-api-configmap
+  labels:
+data:
+  GORILLA_PORT: "8081"
+  # GORILLA_FILE_HOST is confusingly used for the oidc client host and must be set to the public host.
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_FRONTEND_HOST: "http://localhost:8080"
+  GORILLA_LICENSE_CERT_PATH: "/jwks.json"
+  GORILLA_FILE_METADATA_SOURCE_IS_INTERNAL: "true"
+  GORILLA_SESSION_LENGTH: "720h"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
+  GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE: "/view-spec-updater-linux"
+  GORILLA_PARQUET_RPC_PATH: "/_goRPC_"
+  GORILLA_ONPREM_API_KEY_PREFIX: "local"
+  GORILLA_SCHEMA_FILE: "/schema.graphql"
+  GORILLA_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_ACTIVITY_STORE_ENABLE: "true"
+  GORILLA_ACTIVITY_STORE_SERVE: "true"
+  GORILLA_PARQUET_PORT: "8087"
+  GORILLA_PARQUET_GRPC_PORT: "8088"
+  GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+  GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_LOCAL_SERVICE_BYPASS: 'false'
+---
+# Source: operator-wandb/templates/app.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  WEAVE_SERVICE: "chartsnap-weave:9994"
+  WEAVE_ENABLED: "true"
+  PARQUET_ENABLED: "true"
+  PARQUET_HOST: "http://chartsnap-parquet:8087"
+  OPERATOR_ENABLED: "true"
+  LOGGING_ENABLED: "true"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
+  ANACONDA_ENABLED: "true"
+---
+# Source: operator-wandb/templates/bucket.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-bucket-configmap
+  labels:
+data:
+  BUCKET_NAME: "minio:9000/bucket"
+  BUCKET_PATH: ""
+  AWS_REGION: "us-east-1"
+  AWS_S3_KMS_ID: ""
+  GORILLA_DEFAULT_REGION: "minio-local"
+---
+# Source: operator-wandb/templates/certs.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-ca-certs
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+---
+# Source: operator-wandb/templates/console.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-console-configmap
+  labels:
+data:
+  # ex: AWS("arn:aws:iam::{acc_number}:role/{customer_namespace}-node")
+  BUCKET_ACCESS_IDENTITY: "unknown"
+  AUTH_SERVICE: "chartsnap-app:8080"
+  OPERATOR_NAMESPACE: "default"
+  RELEASE_NAME: "chartsnap"
+  RELEASE_NAMESPACE: "default"
+  PROMETHEUS_SERVER: "http://chartsnap-prometheus-server"
+  BANNERS: "{}"
+---
+# Source: operator-wandb/templates/executor.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-executor-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+---
+# Source: operator-wandb/templates/filestream.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-filestream-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data: {}
+---
+# Source: operator-wandb/templates/flat-run-fields-updater.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-flat-run-fields-updater-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+---
+# Source: operator-wandb/templates/frontend.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-frontend-configmap
+  labels:
+data:
+  FRONTEND_APP_BACKEND: "chartsnap-app:8080"
+  FRONTEND_AUTH_BACKEND: "chartsnap-app:8080"
+  FRONTEND_LOCAL_BACKEND: "chartsnap-app:8083"
+  FRONTEND_WEAVE_BACKEND: "chartsnap-weave:9994"
+  REACT_APP_GIT_TAG: "HEAD"
+  REACT_APP_HOST: "http://localhost:8080"
+  REACT_APP_ENVIRONMENT_NAME: "local"
+  REACT_APP_ENVIRONMENT_IS_PRIVATE: "true"
+  REACT_APP_ANALYTICS_DISABLED: "true"
+  WEAVE_TRACES_ENABLED: 'false'
+  SERVER_FLAG_WEAVE_1_PERCENTAGE: "100"
+  WEAVE_ENABLED: "true"
+  OPERATOR_ENABLED: "true"
+---
+# Source: operator-wandb/templates/frontend.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-frontend-patch-env-js
+  labels:
+data:
+  02_patch_env_js.sh: |
+    #!/bin/bash
+    function append_env_js() {
+      local key=$1
+      local value=$2
+      local env_js_path="$BUILD_DIR/env.js"
+      if [ -w "$env_js_path" ]; then
+        printf "Object.assign(window.CONFIG, {%s: %s});\n" "$key" "$value" >> "$env_js_path"
+      fi
+    }
+    function extract_server_flags() {
+      # This function builds a javascript string that gets appended to env.js
+      # it defines a SERVER_FLAGS object maping env vars which start with "SERVER_FLAG_"
+      # where each key is the rest of that env var name and the value is that as a string.
+      local env_js_path="$BUILD_DIR/env.js"
+      local new_js=""
+      # define the object and open it with '{ '
+      # pad with a <space> incase no server flags are set
+      printf -v new_js "const SERVER_FLAGS = { "
+      for name in "${!SERVER_FLAG_@}"; do
+        # append the to the new_js bash variable the key/value pair
+        printf -v new_js '%s"%s": "%s",' "${new_js}" "${name:12}" "${!name}"
+      done
+      # remove the trailing comma and close the object
+      local length="${#new_js}"-1
+      printf "${new_js:0:length}};\n" >> "$env_js_path"
+      append_env_js "SERVER_FLAGS" "SERVER_FLAGS"
+     }
+    function known_additional_flags() {
+      if [ "$CI" == "1" ]; then
+        append_env_js "CI" "true"
+        echo "WARN: use REACT_APP_CI instead"
+      fi
+      if [ "$(echo "$DISABLE_TELEMETRY" | tr '[:lower:]')" == "true" ]; then
+        append_env_js "DISABLE_TELEMETRY" "true"
+        echo "WARN: use REACT_APP_DISABLE_TELEMETRY instead"
+      fi
+      if [ "$WEAVE_ENABLED" == "true" ]; then
+        echo "WARN: use REACT_APP_WEAVE_BACKEND_HOST instead"
+        append_env_js "WEAVE_BACKEND_HOST" \"/__weave\"
+      fi
+      if [ "$WEAVE_TRACES_ENABLED" == "true" ]; then
+        append_env_js "TRACE_BACKEND_BASE_URL" \"/traces\"
+      fi
+      if [ "$ENABLE_RBAC_UI" == "true" ]; then
+        append_env_js "ENABLE_RBAC_UI" "true"
+      fi
+      if [ "$OPERATOR_ENABLED" = "true" ]; then
+        append_env_js "OPERATOR_ENABLED" "true"
+      fi
+      # GORILLA_CUSTOMER_SECRET_STORE_SOURCE is populated by terraform in the global secrets map
+      # which determines ENABLE_SECRET_STORE
+      if [[ -n "$GORILLA_CUSTOMER_SECRET_STORE_SOURCE" && "$GORILLA_CUSTOMER_SECRET_STORE_SOURCE" != "noop://" ]]; then
+        append_env_js "ENABLE_SECRET_STORE" "true"
+      fi
+      if [ -n "$BANNERS" ]; then
+        append_env_js "BANNERS" "$BANNERS"
+      else
+        append_env_js "BANNERS" "{}"
+      fi
+      if [ "$ENABLE_REGISTRY_UI" == "true" ]; then
+        append_env_js "ENABLE_REGISTRY_UI" "true"
+      fi
+    }
+
+    function main() {
+      # Server flag templating
+      if ! grep -q 'const SERVER_FLAGS =' "$BUILD_DIR/env.js"; then
+        extract_server_flags
+        known_additional_flags
+      else
+        echo "WARN: Server Flag already completed."
+      fi
+    }
+    main "$@"
+---
+# Source: operator-wandb/templates/global.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-global-configmap
+  labels:
+  annotations:
+    "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "chartsnap-.*"
+data:
+  # Statsd configuration (matches existing GORILLA_STATSD_PORT from gorilla.yaml)
+  GORILLA_STATSD_HOST: ""
+  GORILLA_STATSD_PORT: "0"
+  GORILLA_LICENSE_CERT_PATH: /jwks.json
+  # T-shirt size for deployment
+  GORILLA_TSHIRT_SIZE: "testing"
+  GORILLA_ONPREM: "true"
+  ONPREM: "true"
+---
+# Source: operator-wandb/templates/glue.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-glue-configmap
+  labels:
+data:
+  # Basic service configuration
+  GORILLA_GLUE_CONTAINER_PORT: "8080"
+  GORILLA_GLUE_FRONTEND_HOST: "http://localhost:8080"
+  GORILLA_GLUE_LICENSE_CERT_PATH: "/jwks.json"
+  # Values that correspond to existing configurations from gorilla.yaml
+  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-app:8082"
+  GORILLA_GLUE_SESSION_LENGTH: "720h"
+  GORILLA_GLUE_DEV: "false"
+  GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_GLUE_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_GLUE_COLLECT_AUDIT_LOGS: "true"
+  GORILLA_GLUE_TASK_QUEUE_WORKER_ENABLED: "false"
+  GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE: "/view-spec-updater-linux"
+  GORILLA_GLUE_DEFAULT_REGION: "minio-local"
+  GORILLA_GLUE_DISABLE_TELEMETRY: "true"
+  GORILLA_GLUE_FILE_STORE_IS_PROXIED: "false"
+  GORILLA_GLUE_ARTIFACT_GC_ENABLED: "false"
+  GORILLA_ARTIFACTS_GC_BATCH_SIZE: "0"
+  GORILLA_ARTIFACTS_GC_NUM_WORKERS: "0"
+  GORILLA_ARTIFACTS_GC_DELETE_FILES_NUM_WORKERS: "0"
+  # Task configuration (existing values)
+  GORILLA_GLUE_TASK_PROVIDER: "memory://"
+  GORILLA_GLUE_TASK_CONFIG_PATH: "/gorilla_glue_tasks_local.yaml"
+  GORILLA_GLUE_TASK_STORE: "memory://"
+  # ClickHouse configuration using existing clickhouse variables
+  GORILLA_GLUE_CLICKHOUSE_ADDRESS: "http://$(WF_CLICKHOUSE_HOST):$(WF_CLICKHOUSE_PORT)"
+  # Activity store configuration (see global.activityStore)
+  GORILLA_GLUE_ACTIVITY_STORE_ENABLE: "true"
+  GORILLA_GLUE_ACTIVITY_STORE_SERVE: "true"
+  GORILLA_GLUE_ACTIVITY_STORE_BACKFILL_ENABLE: "true"
+  # Monitoring configurations
+
+  # Clear task dedupe key configuration
+  GORILLA_GLUE_CLEAR_TASK_DEDUPE_KEY_ENABLED: "false"
+  GORILLA_GLUE_LOCAL_SERVICE_BYPASS: "false"
+---
+# Source: operator-wandb/templates/history-updater.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-history-updater-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+---
+# Source: operator-wandb/templates/kafka.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-kafka-configmap
+  labels:
+data:
+  KAFKA_BROKER_HOST: "bufstream.bufstream.svc.cluster.local"
+  KAFKA_BROKER_PORT: "9092"
+  KAFKA_CLIENT_USER: ""
+  KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE: "chartsnap-run-updates-shadow"
+  KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS: "100"
+---
+# Source: operator-wandb/templates/local.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-local-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  GLUE_ENABLED: "true"
+  GORILLA_GLUE_CONTAINER_PORT: "9173"
+  HOST: "http://localhost:8080"
+  LOCAL_K8S_SIGNER_SECRET_NAME: "chartsnap-internal-signer"
+  LOCAL_K8S_SIGNER_NAMESPACE: "default"
+---
+# Source: operator-wandb/templates/lumen.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-lumen-configmap
+data:
+  LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_CUSTOMER_NAME: ""
+  LUMEN_DATA_ROOT: ""
+  LUMEN_STAGING_ROOT: "file:///vol/staging"
+---
+# Source: operator-wandb/templates/lumen.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-lumen-rules
+data:
+  managed-install.yaml: |
+    keyRuleSets:
+      - name: k8s-metadata-noise
+        keyRules:
+          - keyRegex: "^metadata__managedFields"
+          - keyRegex: "^metadata__resourceVersion$"
+          - keyRegex: "^metadata__uid$"
+          - keyRegex: "^metadata__generation$"
+          - keyRegex: "^metadata__creationTimestamp$"
+          - keyRegex: "^metadata__selfLink$"
+          - keyRegex: "^metadata__annotations__kubectl\\.kubernetes\\.io/last-applied-configuration$"
+          - keyRegex: "^status$"
+          - keyRegex: "^status__"
+      - name: k8s-pod-noise
+        keyRules:
+          - keyRegex: "^spec__(containers|initContainers)__[^_]+__env__"
+          - keyRegex: "^spec__(containers|initContainers)__[^_]+__envFrom__"
+          - keyRegex: "^spec__(containers|initContainers)__[^_]+__volumeMounts__"
+          - keyRegex: "^spec__containers__[^_]+__(startup|liveness|readiness)Probe__"
+          - keyRegex: "^spec__tolerations"
+          - keyRegex: "^spec__topology"
+          - keyRegex: "^spec__volumes"
+          - keyRegex: "^status$"
+          - keyRegex: "^status__"
+      - name: standard-redactions
+        keyRules:
+          - keyRegex: "secret"
+            ignoreCase: true
+          - keyRegex: "password"
+            ignoreCase: true
+          - keyRegex: "key$"
+            ignoreCase: true
+          - keyRegex: "token$"
+            ignoreCase: true
+          - keyRegex: "license$"
+            ignoreCase: true
+          - keyRegex: "cert$"
+            ignoreCase: true
+
+    scrapers:
+      - name: wandb-configmaps
+        connection:
+          kubernetes:
+            discover:
+              kind: ConfigMap
+              namespace: default
+              nameRegex: "^wandb-.*-configmap$"
+        prune:
+          keyRules:
+            - use: [ k8s-metadata-noise ]
+            - keyRegex: "apiVersion"
+        redact:
+          keyRules:
+            - use: [ standard-redactions ]
+          valueHooks:
+            - URIPassword
+
+      - name: wandb-secrets
+        connection:
+          kubernetes:
+            discover:
+              kind: Secret
+              namespace: default
+              nameRegex: "^wandb-(bucket|clickhouse|global|gorilla|internal-signer|kafka|license|mysql|parquet|redis|smtp)"
+              nameExceptions:
+                - "-backup"
+        prune:
+          keyRules:
+            - use: [ k8s-metadata-noise ]
+            - keyRegex: "type"
+            - keyRegex: "apiVersion"
+        redact:
+          keyRules:
+            - use: [ standard-redactions ]
+          valueHooks:
+            - URIPassword
+
+      - name: wandb-pods
+        connection:
+          kubernetes:
+            discover:
+              kind: Pod
+              namespace: default
+              nameRegex: "^wandb-(anaconda2|api|app|executor|filemeta|flat-run-fields-updater|frontend|glue|parquet|weave).*"
+        prune:
+          keyRules:
+            - use: [ k8s-metadata-noise, k8s-pod-noise ]
+        redact:
+          keyRules:
+            - use: [ standard-redactions ]
+          valueHooks:
+            - URIPassword
+
+      - name: wandb-pull-with-httpget
+        connection:
+          kubernetes:
+            discover:
+              kind: Pod
+              namespace: default
+              annotations:
+                - key: lumen.wandb.ai/agent
+                  value: "true"
+            pull:
+              type: k8sHttpGet
+              httpGet:
+                portName: lumen
+                listPath: /lumen/list
+        prune:
+          keyRules:
+            - use: [ k8s-metadata-noise ]
+            - keyRegex: "apiVersion"
+        redact:
+          keyRules:
+            - use: [ standard-redactions ]
+          valueHooks:
+            - URIPassword
+
+      - name: wandb-specs
+        connection:
+          kubernetes:
+            discover:
+              kind: Secret
+              namespace: default
+              nameRegex: "wandb-spec-(active|user)$"
+        prune:
+          keyRules:
+            - use: [ k8s-metadata-noise ]
+            - keyRegex: "status"
+            - keyRegex: "apiVersion"
+        redact:
+          keyRules:
+            - use: [ standard-redactions ]
+          valueHooks:
+            - URIPassword
+
+      - name: wandb-cr
+        connection:
+          kubernetes:
+            discover:
+              kind: WeightsAndBiases
+              namespace: default
+        prune:
+          keyRules:
+            - use: [ k8s-metadata-noise ]
+            - keyRegex: "status"
+            - keyRegex: "apiVersion"
+        redact:
+          keyRules:
+            - use: [ standard-redactions ]
+          valueHooks:
+            - URIPassword
+---
+# Source: operator-wandb/templates/nginx.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-nginx-configmap
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  nginx.conf: |
+    worker_processes  auto;
+
+    error_log  /var/log/nginx/error.log notice;
+    pid        /tmp/nginx.pid;
+
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+      server {
+        listen 8080;
+        proxy_set_header Host $host:8080;
+        client_max_body_size 0;
+        location / {
+          proxy_pass http://chartsnap-app:8080;
+        }
+        location /console {
+          proxy_pass http://chartsnap-console:8082;
+        }
+
+        location /api {
+          proxy_pass http://chartsnap-api:8081;
+        }
+
+        location /graphql {
+          proxy_pass http://chartsnap-api:8081;
+        }
+
+        location /graphql2 {
+          proxy_pass http://chartsnap-api:8081;
+        }
+        location /bucket {
+          proxy_set_header Host minio:9000;
+          proxy_pass http://minio:9000;
+        }
+      }
+    }
+---
+# Source: operator-wandb/templates/parquet.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-parquet-configmap
+  labels:
+data:
+  # Legacy net/rpc configuration
+  GORILLA_PARQUET_PORT: "8087"
+  GORILLA_PARQUET_RPC_PATH: "/_goRPC_"
+  GORILLA_PARQUET_GRPC_PORT: "8088"
+  # Task queue configuration
+  GORILLA_TASK_QUEUE_WORKER_ENABLED: "false"
+  # Parquet-specific configuration
+  GORILLA_USE_PARQUET_HISTORY_STORE: "true"
+  GORILLA_PARQUET_ARROW_BUFFER_SIZE: "2147483648" # 2GB
+  GORILLA_COLLECT_AUDIT_LOGS: "true"
+
+# Parquet metadata cache configuration
+---
+# Source: operator-wandb/templates/redis.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-redis-configmap
+  labels:
+data:
+  REDIS_PORT: "6379"
+  REDIS_HOST: "chartsnap-redis-master"
+  REDIS_PARAMS: "?ttlInSeconds=604800"
+---
+# Source: operator-wandb/templates/run-store-accelerator-run-updater.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-run-store-accelerator-run-updater-configmap
+  labels:
+data:
+  GORILLA_FILE_HOST: "http://localhost:8080"
+  GORILLA_RUN_UPDATE_QUEUE_ADDR: "internal://"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_NAME: "wandb"
+  GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_PREFIX: "wandb-overflow"
+---
+# Source: operator-wandb/templates/weave-trace.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-weave-trace-configmap
+  annotations:
+    "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "chartsnap-weave-trace"
+  labels:
+data:
+  PORT: "8080"
+  API_PATH_PREFIX: "/traces"
+  WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
+  WANDB_BASE_URL: "http://chartsnap-api:8081/"
+  WF_TRACE_SERVER_URL: "http://localhost:8080/traces"
+  WF_ENFORCE_PASSWORD_LENGTH: "false"
+  WEAVE_ENABLE_ONLINE_EVAL: "false"
+  WEAVE_ENABLE_EVALUATE_MODEL_WORKER: "false"
+  WEAVE_ENABLE_AGENT_SCORING: "false"
+  WEAVE_TRACE_SERVER_BASE_URL: "http://localhost:8080/traces"
+  WANDB_INTERNAL_SERVICE_TOKEN_SECRET_NAME: "weave-worker-auth"
+  KAFKA_BROKER_HOST: "bufstream.bufstream.svc.cluster.local"
+  KAFKA_BROKER_PORT: "9092"
+  WEAVE_REDIS_URL: "redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
+---
+# Source: operator-wandb/templates/weave.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-weave-configmap
+  labels:
+data:
+  GORILLA_ONPREM: "true"
+  PORT: "9994"
+  WANDB_BASE_URL: "http://chartsnap-api:8081/"
+  WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
+  WEAVE_LOG_FORMAT: "json"
+  WEAVE_SERVER_NUM_WORKERS: "4"
+  WEAVE_SERVER_URL: "http://127.0.0.1:9994"
+  WEAVE_LOCAL_ARTIFACT_DIR: "/vol/weave/cache"
+  WEAVE_CACHE_CLEAR_INTERVAL: "24"
+  WEAVE_CACHE_CHECK_INTERVAL: "60"
+  WEAVE_CACHE_SIZE_LIMIT: "20Gi"
+  WEAVE_CACHE_CLEAR_PERCENT: "80"
+---
+# Source: operator-wandb/charts/mysql/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chartsnap-mysql-data
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "20Gi"
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "8Gi"
+---
+# Source: operator-wandb/charts/console/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chartsnap-console
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - pods/log
+  - configmaps
+  - services
+  - serviceaccounts
+  - events
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  - statefulsets/status
+  - daemonsets/status
+  - replicasets/status
+  verbs:
+  - get
+- apiGroups:
+  - apps.wandb.com
+  resources:
+  - weightsandbiases
+  verbs:
+  - get
+---
+# Source: operator-wandb/charts/otel/charts/daemonset/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chartsnap-otel-daemonset
+  namespace: default
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+rules:
+# kubernetesAttributes
+- apiGroups: [""]
+  resources: ["pods", "namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+# clusterMetrics
+- apiGroups: [""]
+  resources: ["events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["daemonsets", "deployments", "replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "watch"]
+# kubeletMetrics
+- apiGroups: [""]
+  resources: ["nodes/stats"]
+  verbs: ["get", "watch", "list"]
+# kubernetesEvents
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["watch", "list"]
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/proxy
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  - ingresses
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  - "networking.k8s.io"
+  resources:
+  - ingresses/status
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+---
+# Source: operator-wandb/charts/console/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-console
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-console
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: chartsnap-console
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/otel/charts/daemonset/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-otel-daemonset
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: chartsnap-otel-daemonset
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-otel-daemonset
+  namespace: default
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-prometheus-server
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-prometheus-server
+---
+# Source: operator-wandb/templates/oidc.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-oidc-reviewer
+  labels:
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+- kind: Group
+  name: system:unauthenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/api/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+---
+# Source: operator-wandb/charts/app/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-app
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+---
+# Source: operator-wandb/charts/reloader/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "chartsnap"
+  labels:
+    app: chartsnap-reloader
+    chart: "reloader-1.3.0"
+    release: "chartsnap"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+  name: chartsnap-reloader-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - daemonsets
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - update
+  - patch
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: operator-wandb/charts/api/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-api
+  namespace: default
+roleRef:
+  kind: Role
+  name: chartsnap-api
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/app/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-app
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-app
+  namespace: default
+roleRef:
+  kind: Role
+  name: chartsnap-app
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/reloader/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "chartsnap"
+  labels:
+    app: chartsnap-reloader
+    chart: "reloader-1.3.0"
+    release: "chartsnap"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+  name: chartsnap-reloader-role-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-reloader-role
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-reloader
+  namespace: default
+---
+# Source: operator-wandb/charts/api/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8081
+    protocol: TCP
+    targetPort: api
+  selector:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-app
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: app
+    port: 8080
+    protocol: TCP
+  - name: prometheus
+    port: 8181
+    protocol: TCP
+  - name: anaconda
+    port: 8082
+    protocol: TCP
+  - name: local
+    port: 8083
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-console
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: console
+    port: 8082
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/mysql/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-mysql
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: mysql
+  selector:
+    helm.sh/chart: mysql-0.1.0
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: operator-wandb/charts/nginx/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/otel/charts/daemonset/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-otel-daemonset
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9109'
+spec:
+  type:
+  ports:
+  - port: 9109
+    protocol: TCP
+    name: otel-exporter
+  - port: 8125
+    protocol: TCP
+    name: statsd
+  - port: 4317
+    protocol: TCP
+    name: otlp-grpc
+  - port: 4318
+    protocol: TCP
+    name: otlp-http
+  selector:
+    helm.sh/chart: daemonset-0.1.0
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: operator-wandb/charts/parquet/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-parquet
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: parquet
+    port: 8087
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/parquet/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-parquet-grpc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 8088
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+  sessionAffinity: None
+  type: "ClusterIP"
+---
+# Source: operator-wandb/charts/prometheus/charts/mysql-exporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-prometheus-mysql-exporter
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: prometheus-mysql-exporter
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: mysql-exporter-0.1.0
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9104'
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9104
+    protocol: TCP
+    name: mysql-exporter
+  selector:
+    helm.sh/chart: mysql-exporter-0.1.0
+    app.kubernetes.io/name: prometheus-mysql-exporter
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: mysql-exporter-0.1.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: operator-wandb/charts/prometheus/charts/redis-exporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-prometheus-redis-exporter
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: prometheus-redis-exporter
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: redis-exporter-0.1.0
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9121'
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9121
+    protocol: TCP
+    name: redis-exporter
+  selector:
+    helm.sh/chart: redis-exporter-0.1.0
+    app.kubernetes.io/name: prometheus-redis-exporter
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: redis-exporter-0.1.0
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: operator-wandb/charts/redis/templates/headless-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-redis-headless
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: tcp-redis
+    port: 6379
+    targetPort: redis
+  selector:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: redis
+---
+# Source: operator-wandb/charts/redis/templates/master/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-redis-master
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: master
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  sessionAffinity: None
+  ports:
+  - name: tcp-redis
+    port: 6379
+    targetPort: redis
+    nodePort: null
+  selector:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: master
+---
+# Source: operator-wandb/charts/weave/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-weave
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: weave
+    port: 9994
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: operator-wandb/charts/otel/charts/daemonset/templates/deamonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chartsnap-otel-daemonset
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: daemonset
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "0.33.0"
+    wandb.com/app-name: daemonset-0.1.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: daemonset
+      app.kubernetes.io/instance: chartsnap
+      helm.sh/chart: daemonset-0.1.0
+      app.kubernetes.io/name: daemonset
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/version: "0.33.0"
+      wandb.com/app-name: daemonset-0.1.0
+      app.kubernetes.io/managed-by: Helm
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: daemonset
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "0.33.0"
+        wandb.com/app-name: daemonset-0.1.0
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/configmap: 9a93c1a7e19d470e13c897633e852dbfe03075bfe12f97f73b087cb1b4a5971
+    spec:
+      serviceAccountName: chartsnap-otel-daemonset
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+      containers:
+      - name: daemonset
+        image: "us-docker.pkg.dev/wandb-production/public/otel/opentelemetry-collector-contrib:0.97.0"
+        securityContext:
+          capabilities:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          privileged: false
+        command:
+        - /otelcol-contrib
+        - --config=/conf/config.yaml
+        ports:
+        - name: otlp
+          containerPort: 4317
+          protocol: TCP
+          hostPort: 4317
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+          hostPort: 4318
+        - name: prometheus
+          containerPort: 9109
+          protocol: TCP
+          hostPort: 9109
+        - name: statsd
+          containerPort: 8125
+          protocol: TCP
+          hostPort: 8125
+        env:
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "chartsnap-mysql"
+              key: "MYSQL_PASSWORD"
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: "chartsnap-mysql"
+        - name: MYSQL_DATABASE
+          value: "wandb_local"
+        - name: MYSQL_USER
+          value: "wandb"
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: GOMEMLIMIT
+          value: "1600MiB"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: config
+        - name: varlogpods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: hostfs
+          mountPath: /hostfs
+          readOnly: true
+          mountPropagation: HostToContainer
+      volumes:
+      - name: hostfs
+        hostPath:
+          path: /
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: config
+        configMap:
+          name: chartsnap-otel-daemonset
+          items:
+          - key: config
+            path: config.yaml
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      hostNetwork: false
+---
+# Source: operator-wandb/charts/api/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-api
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      annotations:
+        lumen.wandb.ai/agent: "true"
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: api
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
+    spec:
+      containers:
+      - name: api
+        args:
+        - gorilla
+        envFrom:
+        - configMapRef:
+            name: chartsnap-api-configmap
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - secretRef:
+            name: chartsnap-gorilla-session-key
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LIMITER
+          value: noop://
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: GOMEMLIMIT
+          value: "8GiB"
+        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+              name: gorilla-coreweave-observability
+              optional: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: api
+          protocol: TCP
+        - containerPort: 16060
+          name: lumen
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: api
+          periodSeconds: 5
+          successThreshold: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      initContainers:
+      - name: migrate-db
+        command:
+        - bash
+        - -c
+        - |
+          LOG_FILE="/tmp/migrate.log"
+          ./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE --usage-db=$GORILLA_USAGE_STORE 2>&1 | tee -a $LOG_FILE
+          EXIT_CODE=${PIPESTATUS[0]}
+          MIGRATION_FILE_MISSING_ERROR_CODE=101
+          if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq $MIGRATION_FILE_MISSING_ERROR_CODE ]]; then
+            exit 0
+          else
+            # missing migration error log from golang-migrate@v4 -- older versions of megabinary
+            if grep -q "no migration found for version" $LOG_FILE; then
+              exit 0
+            fi
+            exit $EXIT_CODE
+          fi
+        envFrom:
+        - configMapRef:
+            name: chartsnap-api-configmap
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - secretRef:
+            name: chartsnap-gorilla-session-key
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LIMITER
+          value: noop://
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+              name: gorilla-coreweave-observability
+              optional: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+      serviceAccountName: chartsnap-api
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: api
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: api
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - emptyDir: {}
+        name: temp-dir
+---
+# Source: operator-wandb/charts/app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-app-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
+    spec:
+      containers:
+      - name: app
+        envFrom:
+        - configMapRef:
+            name: chartsnap-api-configmap
+        - configMapRef:
+            name: chartsnap-app-configmap
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-frontend-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-glue-configmap
+        - secretRef:
+            name: chartsnap-gorilla-session-key
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LIMITER
+          value: noop://
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_QUEUE
+          value: "internal://"
+        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+              name: gorilla-coreweave-observability
+              optional: true
+        - name: GORILLA_GLUE_CONTAINER_PORT
+          value: "8083"
+        - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
+          value: "/usr/local/bin/view-spec-updater-linux"
+        - name: GORILLA_LICENSE_CERT_PATH
+          value: "/var/app/jwks.json"
+        - name: GORILLA_STORAGE_BUCKET
+          value: "s3://local-files"
+        - name: GORILLA_TASK_CONFIG_PATH
+          value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
+        - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
+          value: "/usr/local/bin/view-spec-updater-linux"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8181
+          name: prometheus
+          protocol: TCP
+        - containerPort: 8082
+          name: anaconda
+          protocol: TCP
+        - containerPort: 8083
+          name: local
+          protocol: TCP
+        - containerPort: 8125
+          name: gorilla-statsd
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 5
+        startupProbe:
+          failureThreshold: 120
+          httpGet:
+            path: /ready
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sleep
+              - "25"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      initContainers:
+      - name: init-db
+        command:
+        - bash
+        - -c
+        - until if [ -f "$MYSQL_CA_CERT_PATH" ]; then mysql -h$MYSQL_HOST -u$MYSQL_USER -p"$(python -c "import sys; from urllib import parse; print(parse.unquote_plus(sys.argv[1]))" $MYSQL_PASSWORD)" -D$MYSQL_DATABASE -P$MYSQL_PORT --ssl-mode=VERIFY_CA --ssl-ca="$MYSQL_CA_CERT_PATH" --execute="SELECT 1"; else mysql -h$MYSQL_HOST -u$MYSQL_USER -p"$(python -c "import sys; from urllib import parse; print(parse.unquote_plus(sys.argv[1]))" $MYSQL_PASSWORD)" -D$MYSQL_DATABASE -P$MYSQL_PORT --ssl-mode=PREFERRED --execute="SELECT 1"; fi; do echo waiting for db; sleep 2; done
+        envFrom:
+        - configMapRef:
+            name: chartsnap-api-configmap
+        - configMapRef:
+            name: chartsnap-app-configmap
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-frontend-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-glue-configmap
+        - secretRef:
+            name: chartsnap-gorilla-session-key
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-local-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LIMITER
+          value: noop://
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: BUCKET_QUEUE
+          value: "internal://"
+        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
+              name: gorilla-coreweave-observability
+              optional: true
+        - name: GORILLA_GLUE_CONTAINER_PORT
+          value: "8083"
+        - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
+          value: "/usr/local/bin/view-spec-updater-linux"
+        - name: GORILLA_LICENSE_CERT_PATH
+          value: "/var/app/jwks.json"
+        - name: GORILLA_STORAGE_BUCKET
+          value: "s3://local-files"
+        - name: GORILLA_TASK_CONFIG_PATH
+          value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
+        - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
+          value: "/usr/local/bin/view-spec-updater-linux"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-app
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: app
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: app
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+---
+# Source: operator-wandb/charts/console/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-console-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
+    spec:
+      containers:
+      - name: console
+        envFrom:
+        - configMapRef:
+            name: chartsnap-console-configmap
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8082
+          name: http
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /console/api/healthz
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /console/api/ready
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 5
+        startupProbe:
+          failureThreshold: 120
+          httpGet:
+            path: /console/api/ready
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 5
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-console
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: console
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: console
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+---
+# Source: operator-wandb/charts/flat-run-fields-updater/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-flat-run-fields-updater-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: flat-run-fields-updater
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flat-run-fields-updater
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      annotations:
+        lumen.wandb.ai/agent: "true"
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: flat-run-fields-updater
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
+    spec:
+      containers:
+      - name: flat-run-fields-updater
+        args:
+        - flat-run-fields-updater
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-flat-run-fields-updater-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_FLAT_RUN_FIELDS_UPDATER
+          value: 'kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=flat-run-fields-updater&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)'
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 16060
+          name: lumen
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-flat-run-fields-updater
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: flat-run-fields-updater
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: flat-run-fields-updater
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+---
+# Source: operator-wandb/charts/nginx/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-nginx
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: nginx
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: nginx
+        envFrom:
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /etc/nginx/nginx.conf
+          name: nginx-config
+          subPath: nginx.conf
+      serviceAccountName: chartsnap-nginx
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: nginx
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: nginx
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - configMap:
+          name: 'chartsnap-nginx-configmap'
+        name: nginx-config
+---
+# Source: operator-wandb/charts/parquet/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-parquet-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: parquet
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      annotations:
+        lumen.wandb.ai/agent: "true"
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: parquet
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+        azure.workload.identity/use: "false"
+    spec:
+      containers:
+      - name: parquet
+        args:
+        - parquet
+        envFrom:
+        - configMapRef:
+            name: chartsnap-bucket-configmap
+        - configMapRef:
+            name: chartsnap-global-configmap
+        - secretRef:
+            name: chartsnap-global-secret
+        - configMapRef:
+            name: chartsnap-kafka-configmap
+        - configMapRef:
+            name: chartsnap-parquet-configmap
+        - configMapRef:
+            name: chartsnap-redis-configmap
+        env:
+        - name: G_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              name: gorilla-coreweave-caios
+              optional: true
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: ACCESS_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_KEY
+              name: chartsnap-bucket
+              optional: true
+        - name: BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_FILE_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_NAME)
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_PASSWORD
+              name: chartsnap-mysql
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: chartsnap-mysql
+        - name: MYSQL_DATABASE
+          value: wandb_local
+        - name: MYSQL_USER
+          value: wandb
+        - name: MYSQL
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_ANALYTICS_SINK
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_METADATA_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_USAGE_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: REDIS_PASSWORD
+              name: chartsnap-redis-secret
+              optional: true
+        - name: REDIS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_AUDITOR_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_FILE_METADATA_SOURCE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_LOCKER
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_METADATA_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_SETTINGS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_USAGE_METRICS_CACHE
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+        - name: GORILLA_TASK_QUEUE
+          value: noop://
+        - name: KAFKA_CLIENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_CLIENT_PASSWORD
+              name: chartsnap-kafka
+              optional: true
+        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+        - name: GORILLA_HISTORY_STORE
+          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+          value: ""
+        - name: GORILLA_STATSIG_KEY
+          valueFrom:
+            secretKeyRef:
+              key: GORILLA_STATSIG_KEY
+              name: gorilla-statsig
+              optional: true
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SMTP_PASSWORD
+              name: chartsnap-smtp-secret
+        - name: GORILLA_EMAIL_SINK
+          value: https://api.wandb.ai/email/dispatch
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: GORILLA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: chartsnap-license
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: GORILLA_LUMEN_ADDR
+          value: :16060
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8087
+          name: parquet
+          protocol: TCP
+        - containerPort: 16060
+          name: lumen
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8087
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 30
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8087
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+      serviceAccountName: chartsnap-parquet
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: parquet
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: parquet
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+---
+# Source: operator-wandb/charts/prometheus/charts/instance/templates/deploy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: chartsnap-prometheus-server
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: chartsnap
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: v2.47.0
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: chartsnap-prometheus-server
+      containers:
+      - name: prometheus-server-configmap-reload
+        image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.67.0"
+        imagePullPolicy: "IfNotPresent"
+        args:
+        - --watched-dir=/etc/config
+        - --reload-url=http://127.0.0.1:9090/-/reload
+        resources: {}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+          readOnly: true
+      - name: prometheus-server
+        image: "quay.io/prometheus/prometheus:v2.47.0"
+        imagePullPolicy: "IfNotPresent"
+        args:
+        - --storage.tsdb.retention.time=15d
+        - --config.file=/etc/config/prometheus.yml
+        - --storage.tsdb.path=/data
+        - --web.console.libraries=/etc/prometheus/console_libraries
+        - --web.console.templates=/etc/prometheus/consoles
+        - --web.enable-lifecycle
+        ports:
+        - containerPort: 9090
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 4
+          failureThreshold: 3
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources: {}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+        - name: storage-volume
+          mountPath: /data
+          subPath: ""
+      dnsPolicy: ClusterFirst
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      terminationGracePeriodSeconds: 300
+      volumes:
+      - name: config-volume
+        configMap:
+          name: chartsnap-prometheus-server
+      - name: storage-volume
+        persistentVolumeClaim:
+          claimName: chartsnap-prometheus-server
+---
+# Source: operator-wandb/charts/reloader/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    meta.helm.sh/release-namespace: "default"
+    meta.helm.sh/release-name: "chartsnap"
+  labels:
+    app: chartsnap-reloader
+    chart: "reloader-1.3.0"
+    release: "chartsnap"
+    heritage: "Helm"
+    app.kubernetes.io/managed-by: "Helm"
+    group: com.stakater.platform
+    provider: stakater
+    version: v1.3.0
+  name: chartsnap-reloader
+  namespace: default
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: chartsnap-reloader
+      release: "chartsnap"
+  template:
+    metadata:
+      labels:
+        app: chartsnap-reloader
+        chart: "reloader-1.3.0"
+        release: "chartsnap"
+        heritage: "Helm"
+        app.kubernetes.io/managed-by: "Helm"
+        group: com.stakater.platform
+        provider: stakater
+        version: v1.3.0
+    spec:
+      containers:
+      - image: "us-docker.pkg.dev/wandb-production/public/stakater/reloader:v1.3.0"
+        imagePullPolicy: IfNotPresent
+        name: chartsnap-reloader
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+              divisor: '1'
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: '1'
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - name: http
+          containerPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: http
+          timeoutSeconds: 5
+          failureThreshold: 5
+          periodSeconds: 10
+          successThreshold: 1
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+          timeoutSeconds: 5
+          failureThreshold: 5
+          periodSeconds: 10
+          successThreshold: 1
+          initialDelaySeconds: 10
+        securityContext: {}
+        args:
+        - "--log-level=info"
+        - "--reload-on-create=true"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: chartsnap-reloader
+---
+# Source: operator-wandb/charts/weave/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-weave-bc
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weave
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: weave
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: weave
+        envFrom:
+        - configMapRef:
+            name: chartsnap-weave-configmap
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9994
+          name: http
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /__weave/hello
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /__weave/hello
+            port: http
+        startupProbe:
+          failureThreshold: 12
+          httpGet:
+            path: /__weave/hello
+            port: http
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+        - mountPath: /vol/weave/cache
+          name: cache
+      - name: weave-cache-clear
+        command:
+        - python
+        - weave-public/weave_query/scripts/clear_cache.py
+        envFrom:
+        - configMapRef:
+            name: chartsnap-weave-configmap
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/ssl/certs/ca-certificates.crt
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 4
+            memory: 12Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - name: wandb-ca-certs-root
+          mountPath: /usr/local/share/ca-certificates/
+        - name: wandb-ca-certs
+          mountPath: /usr/local/share/ca-certificates/inline
+        - name: wandb-ca-certs-user
+          mountPath: /usr/local/share/ca-certificates/configmap
+        - name: redis-ca
+          mountPath: /etc/ssl/certs/redis_ca.pem
+          subPath: redis_ca.pem
+        - mountPath: /tmp/
+          name: temp-dir
+        - mountPath: /vol/weave/cache
+          name: cache
+      serviceAccountName: chartsnap-weave
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: weave
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: wandb-ca-certs-root
+        emptyDir: {}
+      - name: wandb-ca-certs
+        configMap:
+          name: "chartsnap-ca-certs"
+      - name: wandb-ca-certs-user
+        configMap:
+          name: 'noCertProvided'
+          optional: true
+      - name: redis-ca
+        secret:
+          secretName: 'chartsnap-redis-secret'
+          items:
+          - key: REDIS_CA_CERT
+            path: redis_ca.pem
+          optional: true
+      - emptyDir: {}
+        name: temp-dir
+      - emptyDir:
+          medium: ''
+          sizeLimit: '20Gi'
+        name: cache
+---
+# Source: operator-wandb/charts/mysql/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: chartsnap-mysql
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/instance: chartsnap
+      helm.sh/chart: mysql-0.1.0
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/version: "1.16.0"
+      wandb.com/app-name: mysql-0.1.0
+      app.kubernetes.io/managed-by: Helm
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "1.16.0"
+        wandb.com/app-name: mysql-0.1.0
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 0
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+      containers:
+      - name: mysql
+        image: "us-docker.pkg.dev/wandb-production/public/mysql:latest"
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: mysql
+          containerPort: 3306
+          protocol: TCP
+        env:
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "chartsnap-mysql"
+              key: "MYSQL_PASSWORD"
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_HOST
+          value: "chartsnap-mysql"
+        - name: MYSQL_DATABASE
+          value: "wandb_local"
+        - name: MYSQL_USER
+          value: "wandb"
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: chartsnap-mysql
+              key: MYSQL_ROOT_PASSWORD
+        livenessProbe:
+          tcpSocket:
+            port: 3306
+        readinessProbe:
+          tcpSocket:
+            port: 3306
+        startupProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          failureThreshold: 60
+          tcpSocket:
+            port: 3306
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        - name: initdb
+          mountPath: /docker-entrypoint-initdb.d/initdb.sql
+          subPath: initdb.sql
+        - name: initdb
+          mountPath: /etc/mysql/my.cnf
+          subPath: my.cnf
+        resources:
+          limits:
+            cpu: 4000m
+            memory: 8Gi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      volumes:
+      - name: initdb
+        configMap:
+          name: chartsnap-mysql-initdb
+      - name: data
+        persistentVolumeClaim:
+          claimName: chartsnap-mysql-data
+---
+# Source: operator-wandb/charts/redis/templates/master/application.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: chartsnap-redis-master
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/version: 7.2.4
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/component: master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/component: master
+  serviceName: chartsnap-redis-headless
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/version: 7.2.4
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/component: master
+      annotations:
+        checksum/configmap: 86bcc953bb473748a3d3dc60b7c11f34e60c93519234d4c37f42e22ada559d47
+        checksum/health: aff24913d801436ea469d8d374b2ddb3ec4c43ee7ab24663d5f8ff1a1b6991a9
+        checksum/scripts: 43cdf68c28f3abe25ce017a82f74dbf2437d1900fd69df51a55a3edf6193d141
+        checksum/secret: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+    spec:
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
+      serviceAccountName: chartsnap-redis-master
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: chartsnap
+                  app.kubernetes.io/name: redis
+                  app.kubernetes.io/component: master
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+        nodeAffinity:
+      enableServiceLinks: true
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: redis
+        image: us-docker.pkg.dev/wandb-production/public/bitnamilegacy/redis:7.2.4-debian-12-r9
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsGroup: 0
+          runAsNonRoot: true
+          runAsUser: 1001
+          seLinuxOptions: null
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - /opt/bitnami/scripts/start-scripts/start-master.sh
+        env:
+        - name: BITNAMI_DEBUG
+          value: "false"
+        - name: REDIS_REPLICATION_MODE
+          value: master
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: REDIS_TLS_ENABLED
+          value: "no"
+        - name: REDIS_PORT
+          value: "6379"
+        ports:
+        - name: redis
+          containerPort: 6379
+        livenessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          # One second longer than command timeout should prevent generation of zombie processes.
+          timeoutSeconds: 6
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_liveness_local.sh 5
+        readinessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+        volumeMounts:
+        - name: start-scripts
+          mountPath: /opt/bitnami/scripts/start-scripts
+        - name: health
+          mountPath: /health
+        - name: redis-data
+          mountPath: /data
+        - name: config
+          mountPath: /opt/bitnami/redis/mounted-etc
+        - name: empty-dir
+          mountPath: /opt/bitnami/redis/etc/
+          subPath: app-conf-dir
+        - name: empty-dir
+          mountPath: /tmp
+          subPath: tmp-dir
+      volumes:
+      - name: start-scripts
+        configMap:
+          name: chartsnap-redis-scripts
+          defaultMode: 0755
+      - name: health
+        configMap:
+          name: chartsnap-redis-health
+          defaultMode: 0755
+      - name: config
+        configMap:
+          name: chartsnap-redis-configuration
+      - name: empty-dir
+        emptyDir: {}
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: redis-data
+      labels:
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: master
+    spec:
+      accessModes:
+      - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: "8Gi"
+---
+# Source: operator-wandb/charts/parquet/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-parquet-backfill
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "* * * * *"
+  suspend: true
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: parquet
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/version: "latest"
+            app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
+        spec:
+          containers:
+          - name: backfill-job
+            args:
+            - glue
+            envFrom:
+            - configMapRef:
+                name: chartsnap-bucket-configmap
+            - configMapRef:
+                name: chartsnap-global-configmap
+            - secretRef:
+                name: chartsnap-global-secret
+            - configMapRef:
+                name: chartsnap-glue-configmap
+            - configMapRef:
+                name: chartsnap-kafka-configmap
+            - configMapRef:
+                name: chartsnap-parquet-configmap
+            - configMapRef:
+                name: chartsnap-redis-configmap
+            env:
+            - name: G_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+              valueFrom:
+                secretKeyRef:
+                  key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
+                  name: gorilla-coreweave-caios
+                  optional: true
+            - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
+                  name: gorilla-coreweave-caios
+                  optional: true
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: ACCESS_KEY
+                  name: chartsnap-bucket
+                  optional: true
+            - name: BUCKET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: ACCESS_KEY
+                  name: chartsnap-bucket
+                  optional: true
+            - name: BUCKET_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: SECRET_KEY
+                  name: chartsnap-bucket
+                  optional: true
+            - name: BUCKET
+              value: s3://$(BUCKET_NAME)
+            - name: GORILLA_FILE_STORE
+              value: s3://$(BUCKET_NAME)
+            - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+              value: s3://$(BUCKET_NAME)
+            - name: GORILLA_STORAGE_BUCKET
+              value: s3://$(BUCKET_NAME)
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MYSQL_PASSWORD
+                  name: chartsnap-mysql
+            - name: MYSQL_PORT
+              value: "3306"
+            - name: MYSQL_HOST
+              value: chartsnap-mysql
+            - name: MYSQL_DATABASE
+              value: wandb_local
+            - name: MYSQL_USER
+              value: wandb
+            - name: MYSQL
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_ANALYTICS_SINK
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_METADATA_STORE
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_RUN_STORE
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_USAGE_STORE
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_PASSWORD
+                  name: chartsnap-redis-secret
+                  optional: true
+            - name: REDIS
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_AUDITOR_CACHE
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_CACHE
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_FILE_METADATA_SOURCE
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_LOCKER
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_METADATA_CACHE
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_SETTINGS_CACHE
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_USAGE_METRICS_CACHE
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+            - name: GORILLA_TASK_QUEUE
+              value: noop://
+            - name: KAFKA_CLIENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: KAFKA_CLIENT_PASSWORD
+                  name: chartsnap-kafka
+                  optional: true
+            - name: GORILLA_FILE_STREAM_STORE_ADDRESS
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
+              value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
+            - name: GORILLA_HISTORY_STORE
+              value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
+              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
+            - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
+              value: ""
+            - name: GORILLA_STATSIG_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: GORILLA_STATSIG_KEY
+                  name: gorilla-statsig
+                  optional: true
+            - name: SMTP_HOST
+              value: ""
+            - name: SMTP_PORT
+              value: "587"
+            - name: SMTP_USER
+              value: ""
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: SMTP_PASSWORD
+                  name: chartsnap-smtp-secret
+            - name: GORILLA_EMAIL_SINK
+              value: https://api.wandb.ai/email/dispatch
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  key: license
+                  name: chartsnap-license
+            - name: GORILLA_LICENSE
+              valueFrom:
+                secretKeyRef:
+                  key: license
+                  name: chartsnap-license
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
+            - name: SSL_CERT_DIR
+              value: /etc/ssl/certs
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/certs/ca-certificates.crt
+            - name: GORILLA_LUMEN_ADDR
+              value: :16060
+            - name: GORILLA_GLUE_EXECUTE
+              value: "true"
+            - name: GORILLA_GLUE_EXECUTE_TASK_NAME
+              value: "EXPORTHISTORYTOPARQUET"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 1
+                memory: 1Gi
+              requests:
+                cpu: 1
+                memory: 1Gi
+            volumeMounts:
+            - name: wandb-ca-certs-root
+              mountPath: /usr/local/share/ca-certificates/
+            - name: wandb-ca-certs
+              mountPath: /usr/local/share/ca-certificates/inline
+            - name: wandb-ca-certs-user
+              mountPath: /usr/local/share/ca-certificates/configmap
+            - name: redis-ca
+              mountPath: /etc/ssl/certs/redis_ca.pem
+              subPath: redis_ca.pem
+          restartPolicy: Never
+          serviceAccountName: chartsnap-parquet
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: parquet
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: parquet
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          volumes:
+          - name: wandb-ca-certs-root
+            emptyDir: {}
+          - name: wandb-ca-certs
+            configMap:
+              name: "chartsnap-ca-certs"
+          - name: wandb-ca-certs-user
+            configMap:
+              name: 'noCertProvided'
+              optional: true
+          - name: redis-ca
+            secret:
+              secretName: 'chartsnap-redis-secret'
+              items:
+              - key: REDIS_CA_CERT
+                path: redis_ca.pem
+              optional: true
+---
+# Source: operator-wandb/charts/appRenamePostHook/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-app-rename-post-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePostHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/charts/appRenamePreHook/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-app-rename-pre-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePreHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+automountServiceAccountToken: true
+---
+# Source: operator-wandb/templates/app_rename_cleanup.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app-rename-cleanup
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
+data:
+  pre_upgrade.sh: |
+    #!/bin/bash
+
+    NAMESPACE="default"
+    RELEASE="chartsnap"
+    DEPLOYMENTS="app parquet weave weave-trace"
+
+    for deployment in ${DEPLOYMENTS}; do
+      output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
+      status=$?
+      if [ $status -eq 0 ]; then
+        echo "Annotating deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
+        kubectl -n "$NAMESPACE" annotate deployment "${RELEASE}-${deployment}" "helm.sh/resource-policy=keep" --overwrite
+      else
+        if echo "$output" | grep -qi "(NotFound)\|not found"; then
+          echo "Deployment '${RELEASE}-${deployment}' not found; skipping annotation."
+        else
+          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          exit $status
+        fi
+      fi
+    done
+  post_upgrade.sh: |
+    #!/bin/bash
+
+    NAMESPACE="default"
+    RELEASE="chartsnap"
+    DEPLOYMENTS="app parquet weave weave-trace"
+
+    for deployment in ${DEPLOYMENTS}; do
+      output=$(kubectl -n "$NAMESPACE" get deployment "${RELEASE}-${deployment}" 2>&1)
+      status=$?
+      if [ $status -eq 0 ]; then
+        echo "Waiting for deployment '${RELEASE}-${deployment}-bc' to become available..."
+        kubectl -n "$NAMESPACE" rollout status deploy/"${RELEASE}-${deployment}-bc" || exit $?
+
+        echo "Deleting deployment '${RELEASE}-${deployment}' in namespace '$NAMESPACE'..."
+        kubectl -n "$NAMESPACE" delete deployment "${RELEASE}-${deployment}" || exit $?
+      else
+        if echo "$output" | grep -qi "(NotFound)\|not found"; then
+          echo "Deployment '${RELEASE}-${deployment}' not found; skipping delete."
+        else
+          echo "Error checking deployment '${RELEASE}-${deployment}': $output" >&2
+          exit $status
+        fi
+      fi
+    done
+---
+# Source: operator-wandb/charts/appRenamePostHook/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-app-rename-post-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePostHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - delete
+  - list
+  - watch
+---
+# Source: operator-wandb/charts/appRenamePreHook/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-app-rename-pre-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePreHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - patch
+---
+# Source: operator-wandb/charts/appRenamePostHook/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-app-rename-post-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePostHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-app-rename-post-hook
+  namespace: default
+roleRef:
+  kind: Role
+  name: chartsnap-app-rename-post-hook
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/charts/appRenamePreHook/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-app-rename-pre-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePreHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-app-rename-pre-hook
+  namespace: default
+roleRef:
+  kind: Role
+  name: chartsnap-app-rename-pre-hook
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: operator-wandb/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-operator-wandb-test-connection"
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: operator-wandb
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: wandb-verify
+    image: us-docker.pkg.dev/wandb-production/public/python:3.12
+    env:
+    - name: WANDB_BASE_URL
+      value: "http://chartsnap-nginx:8080"
+    - name: WANDB_API_KEY
+      value: ""
+    command:
+    - sh
+    - -c
+    - "pip install wandb && wandb verify"
+  restartPolicy: Never
+---
+# Source: operator-wandb/charts/appRenamePostHook/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-app-rename-post-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePostHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: appRenamePostHook
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "1.31.12"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: app-rename-post-hook
+        command:
+        - sh
+        - -c
+        - /cleanup-scripts/post_upgrade.sh
+        envFrom:
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /cleanup-scripts
+          name: app-rename-cleanup
+      restartPolicy: Never
+      serviceAccountName: chartsnap-app-rename-post-hook
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: appRenamePostHook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: appRenamePostHook
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          defaultMode: 493
+          name: 'chartsnap-app-rename-cleanup'
+        name: app-rename-cleanup
+---
+# Source: operator-wandb/charts/appRenamePreHook/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-app-rename-pre-hook
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: appRenamePreHook
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.31.12"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: appRenamePreHook
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "1.31.12"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: app-rename-pre-hook
+        command:
+        - sh
+        - -c
+        - /cleanup-scripts/pre_upgrade.sh
+        envFrom:
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /cleanup-scripts
+          name: app-rename-cleanup
+      restartPolicy: Never
+      serviceAccountName: chartsnap-app-rename-pre-hook
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: appRenamePreHook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: appRenamePreHook
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          defaultMode: 493
+          name: 'chartsnap-app-rename-cleanup'
+        name: app-rename-cleanup

--- a/test-configs/operator-wandb/go-memory-limit.yaml
+++ b/test-configs/operator-wandb/go-memory-limit.yaml
@@ -1,0 +1,56 @@
+global:
+  host: "http://localhost:8080"
+  api:
+    enabled: true
+  repositoryPrefix: "us-docker.pkg.dev/wandb-production/public"
+  imageRegistry: "us-docker.pkg.dev/wandb-production/public"
+  bucket:
+    provider: "s3"
+    name: "minio:9000/bucket"
+    region: "us-east-1"
+  size: "testing"
+
+api:
+  containers:
+    api:
+      goMemoryLimit: "8GiB"
+
+flat-run-fields-updater:
+  install: true
+
+app:
+  env:
+    GORILLA_STORAGE_BUCKET: "s3://local-files"
+
+nginx:
+  install: true
+  additionalServices:
+    bucket:
+      host: "http://minio:9000"
+      headers:
+        Host: "minio:9000"
+
+ingress:
+  install: false
+  create: false
+
+mysql:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+redis:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+reloader:
+  install: true
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"

--- a/test-configs/wandb-base/__snapshots__/go-memory-limit.snap
+++ b/test-configs/wandb-base/__snapshots__/go-memory-limit.snap
@@ -1,0 +1,255 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: wandb-base/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchExpressions:
+    - key: batch.kubernetes.io/job-name
+      operator: DoesNotExist
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  maxUnavailable: 1
+---
+# Source: wandb-base/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: wandb-base/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-wandb-base
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wandb-base
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: api
+        envFrom:
+        env:
+        - name: GOMEMLIMIT
+          value: "8GiB"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "example.invalid/api:test"
+        imagePullPolicy:
+      - name: sidecar
+        envFrom:
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "example.invalid/sidecar:test"
+        imagePullPolicy:
+      initContainers:
+      - name: migrate-db
+        envFrom:
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "example.invalid/migrate:test"
+        imagePullPolicy:
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chartsnap-compact
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: '###CHART_VERSION###'
+        app.kubernetes.io/name: wandb-base
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+      - name: worker
+        envFrom:
+        env:
+        - name: GOMEMLIMIT
+          value: "2GiB"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop: []
+          privileged: false
+          readOnlyRootFilesystem: false
+        image: "example.invalid/worker:test"
+        imagePullPolicy:
+      restartPolicy: Never
+      serviceAccountName: chartsnap-wandb-base
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 999
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/name: wandb-base
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+---
+# Source: wandb-base/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-cleanup
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: wandb-base
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy:
+  schedule: "0 2 * * *"
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: wandb-base
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/managed-by: Helm
+        spec:
+          containers:
+          - name: worker
+            envFrom:
+            env:
+            - name: GOMEMLIMIT
+              value: "3GiB"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "example.invalid/worker:test"
+            imagePullPolicy:
+          restartPolicy: Never
+          serviceAccountName: chartsnap-wandb-base
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: wandb-base
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: wandb-base
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway

--- a/test-configs/wandb-base/go-memory-limit.yaml
+++ b/test-configs/wandb-base/go-memory-limit.yaml
@@ -1,0 +1,35 @@
+containers:
+  api:
+    goMemoryLimit: "8GiB"
+    image:
+      repository: example.invalid/api
+      tag: test
+  sidecar:
+    image:
+      repository: example.invalid/sidecar
+      tag: test
+
+initContainers:
+  migrate-db:
+    image:
+      repository: example.invalid/migrate
+      tag: test
+
+jobs:
+  compact:
+    containers:
+      worker:
+        goMemoryLimit: "2GiB"
+        image:
+          repository: example.invalid/worker
+          tag: test
+
+cronJobs:
+  cleanup:
+    schedule: "0 2 * * *"
+    containers:
+      worker:
+        goMemoryLimit: "3GiB"
+        image:
+          repository: example.invalid/worker
+          tag: test


### PR DESCRIPTION
## Description

Adds an optional, per-container `goMemoryLimit` value to `wandb-base` and exposes it through `operator-wandb`.

When configured for a named main container, the chart renders that value as the container's literal `GOMEMLIMIT`. When omitted, the existing `limits.memory` `resourceFieldRef` renders unchanged. Init containers, updaters, Jobs, CronJobs, and other main containers are unaffected unless they opt in independently.

The chart rejects ambiguous configurations that also set `GOMEMLIMIT` through another values layer. It also validates Go's byte-count grammar and signed-64-bit limit, including suffix multiplication, so a value accepted by Helm will not make Go fail at startup with a malformed `GOMEMLIMIT`.

This PR adds the capability only. It does not set a chart or fleet default, does not configure a customer, and does not select a production headroom value.

## Motivation and Context

The managed-install OOM investigation found that the API currently receives a soft Go memory limit equal to its hard container limit. That leaves no explicit reserve for non-heap/runtime memory, but the observed reserve varies enough that a safe fleet-wide percentage is not yet established.

This change provides the narrow control needed for a service-specific canary without changing existing deployments. The documentation also calls out that Gorilla uses `GOMEMLIMIT` as the denominator for deep-readiness/request-pressure signals: lowering it can change those signals, so their effective gates must be reviewed independently before a rollout.

Removing `goMemoryLimit` restores the existing resource-derived behavior.

## Testing

- `python3 scripts/format_templates.py --check`
- `python3 -m unittest discover -s scripts/tests` (16 tests)
- `python3 scripts/check_template_maintainability.py`
- `helm unittest ./charts/wandb-base/` (6 tests)
- `helm unittest ./charts/operator-wandb/` (53 tests)
- `helm lint` for `wandb-base`, `operator-wandb`, `lumen`, and `orchestrator`
- `ct lint` for all four affected charts
- Snapshot suites for all four affected charts
- Dedicated render matrix for absent, valid, malformed, conflicting, overflow, main-container, init-container, Job, and CronJob cases
- Boundary parity against Go 1.26: the exact signed-64-bit maximum for raw bytes, `B`, `KiB`, `MiB`, `GiB`, and `TiB` is accepted; maximum + 1 is rejected, including with Helm schema validation skipped
- The final review fix names the compound signed-64-bit overflow predicate and preserves the same boundary behavior; formatter, maintainability, focused chart tests, Helm lint, and snapshots pass on head `81f15a8f5c45`
- `shellcheck`, `bash -n`, `jq empty`, and `git diff --check`
