### PR TITLE
feat/watchtower-routing

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.5
+version: 0.44.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_ingress.tpl
+++ b/charts/operator-wandb/templates/_ingress.tpl
@@ -194,4 +194,13 @@ It expects a dictionary with two entries:
       name: {{ $.Release.Name }}-console
       port:
         number: 8082
+  {{- if .Values.watchtower.install }}
+- pathType: Prefix
+  path: /watchtower
+  backend:
+    service:
+      name: {{ $.Release.Name }}-watchtower
+      port:
+        number: 8080
+  {{- end }}
 {{- end }}

--- a/charts/operator-wandb/templates/nginx.yaml
+++ b/charts/operator-wandb/templates/nginx.yaml
@@ -33,6 +33,18 @@ data:
         location /console {
           proxy_pass http://{{ .Release.Name }}-console:8082;
         }
+{{- if .Values.watchtower.install }}
+        # Watchtower streams deploy progress over SSE, so buffering stays off.
+        location /watchtower {
+          proxy_pass http://{{ .Release.Name }}-watchtower:8080;
+          proxy_buffering off;
+          proxy_cache off;
+          proxy_read_timeout 86400s;
+          proxy_set_header Connection '';
+          proxy_http_version 1.1;
+          chunked_transfer_encoding off;
+        }
+{{- end }}
 {{- if .Values.global.api.enabled }}
   {{- if .Values.global.api.additionalPaths.analytics }}
         location /analytics {

--- a/charts/operator-wandb/tests/watchtower_routing_test.yaml
+++ b/charts/operator-wandb/tests/watchtower_routing_test.yaml
@@ -1,0 +1,66 @@
+suite: watchtower routing
+templates:
+  - templates/nginx.yaml
+  - templates/ingress.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: routes /watchtower through nginx when watchtower is installed
+    template: templates/nginx.yaml
+    set:
+      watchtower.install: true
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location /watchtower \{\s+proxy_pass http://wandb-watchtower:8080;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "proxy_buffering off;"
+
+  - it: leaves /watchtower out of nginx by default
+    template: templates/nginx.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: "location /watchtower"
+
+  - it: adds the /watchtower ingress path when watchtower is installed
+    template: templates/ingress.yaml
+    documentSelector:
+      path: kind
+      value: Ingress
+    set:
+      global.host: "https://wandb.example.com"
+      watchtower.install: true
+    asserts:
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            pathType: Prefix
+            path: /watchtower
+            backend:
+              service:
+                name: wandb-watchtower
+                port:
+                  number: 8080
+
+  - it: leaves the /watchtower ingress path out by default
+    template: templates/ingress.yaml
+    documentSelector:
+      path: kind
+      value: Ingress
+    set:
+      global.host: "https://wandb.example.com"
+    asserts:
+      - notContains:
+          path: spec.rules[0].http.paths
+          content:
+            pathType: Prefix
+            path: /watchtower
+            backend:
+              service:
+                name: wandb-watchtower
+                port:
+                  number: 8080

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -1180,6 +1180,12 @@ console:
         resources: ["weightsandbiases"]
         verbs: ["get"]
 
+# Watchtower is deployed outside of this chart. Setting install: true only
+# routes /watchtower to the {{ .Release.Name }}-watchtower service, through
+# both the in-cluster nginx and the ingress.
+watchtower:
+  install: false
+
 executor:
   podLabels:
     azure.workload.identity/use: '{{ include `wandb.azureStorageIdentityEnabled` . }}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `/watchtower` routing through NGINX and ingress when Watchtower is enabled.
  - Configured streaming-friendly behavior for Watchtower connections, including extended timeouts and disabled buffering.
  - Added a `watchtower.install` setting, disabled by default.

- **Bug Fixes**
  - Improved reliable access to Watchtower services through supported deployment routes.

- **Tests**
  - Added coverage for enabled and default-disabled Watchtower routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->