### PR TITLE
fix: drop Linux capabilities by default

### DIFF
--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
-digest: sha256:60d1023fe307cba27e2dfe573be514601dc0dcacb6d72f91323615fedaa42772
-generated: "2026-07-29T18:00:40.632395-05:00"
+  version: 0.12.7
+digest: sha256:6a4d35030d930a8ad4f6a1ada246116749584e084a7a6f2b2f2f48de13e0c990
+generated: "2026-08-17T13:29:39.702668-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,39 +82,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:039ae3137a49174b04980ea7cafdd5f83fc517a898b577278b76a587b1723266
-generated: "2026-08-05T08:44:45.513577-05:00"
+digest: sha256:1986ad265b0aaca94ee3286ce5b4f08e3841c9813bf22a16cc7ec97925d61a52
+generated: "2026-08-17T13:30:14.814813-05:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.5
+version: 0.44.6
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: console
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,20 +109,20 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: filestream
-    version: "0.12.6"
+    version: "0.12.7"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
+  version: 0.12.7
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.6
-digest: sha256:e2514816c2f8ca70a4f0db5e1f76ce8a211f106d46c2d685094f7ae8da4855b6
-generated: "2026-07-29T18:00:53.549681-05:00"
+  version: 0.12.7
+digest: sha256:31d5aeb4b27d864b5238e142b54c7a95426c64d4c408afaadee643e6dcb7b78e
+generated: "2026-08-17T13:29:44.05901-05:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.6"
+    version: "0.12.7"
     repository: "file://../wandb-base"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.6
+version: 0.12.7
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/values.yaml
+++ b/charts/wandb-base/values.yaml
@@ -111,7 +111,8 @@ podSecurityContext:
 securityContext:
   capabilities:
     add: []
-    drop: []
+    drop:
+      - ALL
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
   privileged: false

--- a/test-configs/lumen/__snapshots__/default.snap
+++ b/test-configs/lumen/__snapshots__/default.snap
@@ -122,7 +122,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -220,7 +221,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"

--- a/test-configs/lumen/__snapshots__/gcp-workload-identity.snap
+++ b/test-configs/lumen/__snapshots__/gcp-workload-identity.snap
@@ -140,7 +140,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -238,7 +239,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"

--- a/test-configs/lumen/__snapshots__/onprem.snap
+++ b/test-configs/lumen/__snapshots__/onprem.snap
@@ -122,7 +122,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -220,7 +221,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -2700,7 +2700,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -2973,7 +2974,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3075,7 +3077,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3387,7 +3390,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3630,7 +3634,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3692,7 +3697,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4217,7 +4223,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4565,7 +4572,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4641,7 +4649,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -2704,7 +2704,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -2977,7 +2978,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3079,7 +3081,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3391,7 +3394,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3634,7 +3638,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3696,7 +3701,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4221,7 +4227,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4569,7 +4576,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4645,7 +4653,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -2444,7 +2444,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -2714,7 +2715,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -2816,7 +2818,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -3120,7 +3123,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3360,7 +3364,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -3419,7 +3424,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -3709,7 +3715,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4029,7 +4036,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -4109,7 +4117,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -2418,7 +2418,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -2692,7 +2693,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -2794,7 +2796,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -3102,7 +3105,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3342,7 +3346,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -3401,7 +3406,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -3695,7 +3701,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4015,7 +4022,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -4095,7 +4103,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -2460,7 +2460,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -2728,7 +2729,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -2830,7 +2832,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -3132,7 +3135,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3399,7 +3403,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -3482,7 +3487,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -3600,7 +3606,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -3659,7 +3666,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -3947,7 +3955,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4377,7 +4386,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -4457,7 +4467,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -3082,7 +3082,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -3362,7 +3363,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -3483,7 +3485,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -3629,7 +3632,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -3940,7 +3944,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4287,7 +4292,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -4356,7 +4362,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -4933,7 +4940,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5282,7 +5290,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -5379,7 +5388,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -3331,7 +3331,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3672,7 +3673,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3955,7 +3957,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4293,7 +4296,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4597,7 +4601,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4731,7 +4736,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5064,7 +5070,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5374,7 +5381,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5692,7 +5700,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5998,7 +6007,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6149,7 +6159,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -6472,7 +6483,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6809,7 +6821,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6951,7 +6964,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -7276,7 +7290,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7636,7 +7651,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7727,7 +7743,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -8316,7 +8333,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8668,7 +8686,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8780,7 +8799,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -3053,7 +3053,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3372,7 +3373,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3635,7 +3637,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3754,7 +3757,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4065,7 +4069,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4353,7 +4358,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4482,7 +4488,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -4783,7 +4790,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4922,7 +4930,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5225,7 +5234,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5563,7 +5573,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -5632,7 +5643,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6199,7 +6211,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6596,7 +6609,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -6686,7 +6700,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -6778,7 +6793,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:0.78.0-rc.1771864722"

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -3180,7 +3180,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3499,7 +3500,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3760,7 +3762,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4076,7 +4079,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4358,7 +4362,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4470,7 +4475,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4781,7 +4787,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5069,7 +5076,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5198,7 +5206,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5499,7 +5508,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5633,7 +5643,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5936,7 +5947,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6274,7 +6286,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6343,7 +6356,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6910,7 +6924,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7240,7 +7255,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7330,7 +7346,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -3158,7 +3158,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3477,7 +3478,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3738,7 +3740,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4054,7 +4057,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4336,7 +4340,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4448,7 +4453,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4759,7 +4765,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5047,7 +5054,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5176,7 +5184,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5477,7 +5486,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5611,7 +5621,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5914,7 +5925,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6252,7 +6264,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6321,7 +6334,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6888,7 +6902,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7218,7 +7233,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7308,7 +7324,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -3158,7 +3158,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3477,7 +3478,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3738,7 +3740,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4054,7 +4057,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4336,7 +4340,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4448,7 +4453,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4759,7 +4765,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5047,7 +5054,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5176,7 +5184,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5477,7 +5486,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5611,7 +5621,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5914,7 +5925,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6252,7 +6264,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6321,7 +6334,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6888,7 +6902,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7218,7 +7233,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7308,7 +7324,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -2704,7 +2704,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -2977,7 +2978,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3079,7 +3081,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3391,7 +3394,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3634,7 +3638,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3696,7 +3701,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4221,7 +4227,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4569,7 +4576,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4645,7 +4653,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -2738,7 +2738,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3011,7 +3012,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3113,7 +3115,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3414,7 +3417,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3709,7 +3713,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3952,7 +3957,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4014,7 +4020,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4539,7 +4546,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4917,7 +4925,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4993,7 +5002,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -2738,7 +2738,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3011,7 +3012,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3113,7 +3115,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3409,7 +3412,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3704,7 +3708,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3947,7 +3952,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4009,7 +4015,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4534,7 +4541,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4944,7 +4952,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5020,7 +5029,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -2704,7 +2704,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -2977,7 +2978,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3079,7 +3081,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3383,7 +3386,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3626,7 +3630,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3688,7 +3693,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4173,7 +4179,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4549,7 +4556,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4625,7 +4633,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -3048,7 +3048,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3367,7 +3368,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3630,7 +3632,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3749,7 +3752,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4060,7 +4064,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4348,7 +4353,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4477,7 +4483,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -4778,7 +4785,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4917,7 +4925,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5220,7 +5229,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5558,7 +5568,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -5627,7 +5638,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6194,7 +6206,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6591,7 +6604,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -6681,7 +6695,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -6773,7 +6788,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:0.78.0-rc.1771864722"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -3158,7 +3158,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3477,7 +3478,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3740,7 +3742,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4057,7 +4060,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4337,7 +4341,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4449,7 +4454,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4760,7 +4766,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5048,7 +5055,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5177,7 +5185,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5478,7 +5487,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5617,7 +5627,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5920,7 +5931,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6258,7 +6270,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6327,7 +6340,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6894,7 +6908,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7291,7 +7306,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7381,7 +7397,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7473,7 +7490,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:0.78.0-rc.1771864722"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -2769,7 +2769,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3042,7 +3043,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3144,7 +3146,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3324,7 +3327,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/mcp-server:0.3.5"
@@ -3631,7 +3635,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3874,7 +3879,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3936,7 +3942,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4461,7 +4468,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4802,7 +4810,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4878,7 +4887,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -2769,7 +2769,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3042,7 +3043,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3144,7 +3146,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3324,7 +3327,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/mcp-server:0.3.5"
@@ -3631,7 +3635,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3874,7 +3879,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3936,7 +3942,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4461,7 +4468,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4802,7 +4810,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4878,7 +4887,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -2769,7 +2769,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3042,7 +3043,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3144,7 +3146,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3322,7 +3325,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/mcp-server:0.3.5"
@@ -3629,7 +3633,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3872,7 +3877,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3934,7 +3940,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4459,7 +4466,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4800,7 +4808,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4876,7 +4885,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -3722,7 +3722,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3983,7 +3984,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4299,7 +4301,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4581,7 +4584,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4693,7 +4697,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5004,7 +5009,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5217,7 +5223,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/mcp-server:0.3.5"
@@ -5349,7 +5356,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5652,7 +5660,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6017,7 +6026,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -6110,7 +6120,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -6238,7 +6249,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6307,7 +6319,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7242,7 +7255,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7703,7 +7717,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7793,7 +7808,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -3158,7 +3158,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3477,7 +3478,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3738,7 +3740,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4054,7 +4057,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4336,7 +4340,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4448,7 +4453,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4759,7 +4765,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5047,7 +5054,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5176,7 +5184,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5477,7 +5486,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5611,7 +5621,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5914,7 +5925,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6252,7 +6264,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6321,7 +6334,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6888,7 +6902,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7218,7 +7233,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7308,7 +7324,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -3168,7 +3168,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3497,7 +3498,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3768,7 +3770,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4094,7 +4097,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4386,7 +4390,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4498,7 +4503,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4809,7 +4815,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5097,7 +5104,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5226,7 +5234,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5527,7 +5536,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5661,7 +5671,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5964,7 +5975,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6302,7 +6314,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6371,7 +6384,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6938,7 +6952,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7268,7 +7283,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7358,7 +7374,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -3708,7 +3708,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -4061,7 +4062,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4356,7 +4358,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4672,7 +4675,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4954,7 +4958,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -5066,7 +5071,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5377,7 +5383,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5665,7 +5672,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5794,7 +5802,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -6129,7 +6138,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6263,7 +6273,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -6583,7 +6594,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6948,7 +6960,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7041,7 +7054,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7169,7 +7183,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7238,7 +7253,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -8190,7 +8206,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8797,7 +8814,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8887,7 +8905,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -9060,7 +9079,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -9185,7 +9205,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -3267,7 +3267,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3562,7 +3563,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3878,7 +3880,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4160,7 +4163,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4272,7 +4276,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4421,7 +4426,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -4756,7 +4762,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4890,7 +4897,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5193,7 +5201,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5531,7 +5540,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -5600,7 +5610,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6167,7 +6178,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6609,7 +6621,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -6699,7 +6712,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -6853,7 +6867,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6959,7 +6974,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"

--- a/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
+++ b/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
@@ -3475,7 +3475,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3804,7 +3805,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4075,7 +4077,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4401,7 +4404,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4693,7 +4697,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4815,7 +4820,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5136,7 +5142,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5434,7 +5441,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5728,7 +5736,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5867,7 +5876,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -6178,7 +6188,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6322,7 +6333,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -6635,7 +6647,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7124,7 +7137,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7262,7 +7276,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7341,7 +7356,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -8244,7 +8260,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8584,7 +8601,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8684,7 +8702,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -3441,7 +3441,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3770,7 +3771,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4041,7 +4043,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4367,7 +4370,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4659,7 +4663,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4781,7 +4786,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5102,7 +5108,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5400,7 +5407,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5694,7 +5702,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5833,7 +5842,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -6144,7 +6154,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6288,7 +6299,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -6601,7 +6613,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6949,7 +6962,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7028,7 +7042,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7905,7 +7920,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8245,7 +8261,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8345,7 +8362,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -3158,7 +3158,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3491,7 +3492,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3766,7 +3768,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4096,7 +4099,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4392,7 +4396,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4504,7 +4509,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4815,7 +4821,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5103,7 +5110,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5232,7 +5240,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5533,7 +5542,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5667,7 +5677,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5970,7 +5981,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6308,7 +6320,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6377,7 +6390,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6944,7 +6958,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7274,7 +7289,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7364,7 +7380,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -3004,7 +3004,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3265,7 +3266,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3581,7 +3583,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -3863,7 +3866,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -3975,7 +3979,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4124,7 +4129,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -4251,7 +4257,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -4554,7 +4561,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4804,7 +4812,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -4873,7 +4882,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -5440,7 +5450,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5770,7 +5781,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -5860,7 +5872,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -3628,7 +3628,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3923,7 +3924,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4239,7 +4241,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4521,7 +4524,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4633,7 +4637,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4782,7 +4787,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5117,7 +5123,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5251,7 +5258,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5571,7 +5579,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5821,7 +5830,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -5890,7 +5900,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6842,7 +6853,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7339,7 +7351,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7429,7 +7442,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7602,7 +7616,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7727,7 +7742,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -2808,7 +2808,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3062,7 +3063,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3366,7 +3368,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3639,7 +3642,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3741,7 +3745,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4053,7 +4058,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4296,7 +4302,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4358,7 +4365,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4915,7 +4923,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5284,7 +5293,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5360,7 +5370,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -2808,7 +2808,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3062,7 +3063,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3366,7 +3368,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3639,7 +3642,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3743,7 +3747,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4055,7 +4060,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4298,7 +4304,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4360,7 +4367,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4917,7 +4925,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5286,7 +5295,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5362,7 +5372,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -2808,7 +2808,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3062,7 +3063,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3366,7 +3368,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3639,7 +3642,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3743,7 +3747,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4055,7 +4060,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4298,7 +4304,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4360,7 +4367,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4917,7 +4925,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5286,7 +5295,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5362,7 +5372,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -2752,7 +2752,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/anaconda2:latest"
@@ -3079,7 +3080,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3353,7 +3355,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3459,7 +3462,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3767,7 +3771,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4099,7 +4104,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4162,7 +4168,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4723,7 +4730,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5047,7 +5055,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5131,7 +5140,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -2896,7 +2896,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/anaconda2@sha256:anacdigest12excludefromlabel"
@@ -3207,7 +3208,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3461,7 +3463,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3765,7 +3768,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -4038,7 +4042,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -4140,7 +4145,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4443,7 +4449,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary@sha256:execdigest12excludefromlabel"
@@ -4732,7 +4739,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary@sha256:filestream12excludefromlabel"
@@ -5011,7 +5019,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary@sha256:frfudigest12excludefromlabel"
@@ -5295,7 +5304,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -5607,7 +5617,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -5850,7 +5861,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -5912,7 +5924,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -6597,7 +6610,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -6966,7 +6980,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -7042,7 +7057,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -2896,7 +2896,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/anaconda2:anacondatag"
@@ -3207,7 +3208,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3461,7 +3463,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3765,7 +3768,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -4038,7 +4042,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -4140,7 +4145,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4443,7 +4449,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:executortag"
@@ -4732,7 +4739,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:filestreamtag"
@@ -5011,7 +5019,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:flatrunfieldsupdatertag"
@@ -5295,7 +5304,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -5607,7 +5617,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -5850,7 +5861,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -5912,7 +5924,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -6597,7 +6610,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -6966,7 +6980,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -7042,7 +7057,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -2794,7 +2794,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3067,7 +3068,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3169,7 +3171,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3483,7 +3486,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3726,7 +3730,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3788,7 +3793,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4172,7 +4178,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -4464,7 +4471,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4812,7 +4820,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4888,7 +4897,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -2792,7 +2792,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3065,7 +3066,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3167,7 +3169,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3481,7 +3484,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3724,7 +3728,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3786,7 +3791,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4170,7 +4176,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -4462,7 +4469,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4810,7 +4818,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4886,7 +4895,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -2804,7 +2804,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3077,7 +3078,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3179,7 +3181,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3493,7 +3496,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3736,7 +3740,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3798,7 +3803,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4182,7 +4188,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -4474,7 +4481,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4878,7 +4886,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4954,7 +4963,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -2773,7 +2773,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3046,7 +3047,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3148,7 +3150,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3460,7 +3463,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3703,7 +3707,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3765,7 +3770,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4149,7 +4155,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -4423,7 +4430,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4771,7 +4779,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4847,7 +4856,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -2775,7 +2775,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3048,7 +3049,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3150,7 +3152,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3462,7 +3465,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3705,7 +3709,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3767,7 +3772,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4151,7 +4157,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
@@ -4425,7 +4432,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4773,7 +4781,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4849,7 +4858,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -2902,7 +2902,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3168,7 +3169,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3495,7 +3497,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3782,7 +3785,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3903,7 +3907,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4228,7 +4233,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4487,7 +4493,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4559,7 +4566,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -5139,7 +5147,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5527,7 +5536,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5617,7 +5627,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -2809,7 +2809,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3063,7 +3064,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3367,7 +3369,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3640,7 +3643,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3742,7 +3746,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4054,7 +4059,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4297,7 +4303,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4359,7 +4366,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4916,7 +4924,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5285,7 +5294,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5361,7 +5371,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -2834,7 +2834,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3098,7 +3099,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3412,7 +3414,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3695,7 +3698,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3797,7 +3801,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4109,7 +4114,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4352,7 +4358,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4414,7 +4421,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4971,7 +4979,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5340,7 +5349,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5416,7 +5426,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -2834,7 +2834,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3098,7 +3099,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3412,7 +3414,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3695,7 +3698,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3797,7 +3801,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4109,7 +4114,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4352,7 +4358,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4414,7 +4421,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4971,7 +4979,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5340,7 +5349,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5416,7 +5426,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -2753,7 +2753,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/anaconda2:latest"
@@ -3081,7 +3082,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3355,7 +3357,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3462,7 +3465,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3771,7 +3775,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4104,7 +4109,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4167,7 +4173,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4730,7 +4737,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5055,7 +5063,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5140,7 +5149,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -2716,7 +2716,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -2994,7 +2995,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3096,7 +3098,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3413,7 +3416,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3656,7 +3660,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3718,7 +3723,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4248,7 +4254,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4596,7 +4603,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4672,7 +4680,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -2706,7 +2706,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -2981,7 +2982,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3083,7 +3085,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3397,7 +3400,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3640,7 +3644,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3702,7 +3707,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4229,7 +4235,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -4577,7 +4584,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -4653,7 +4661,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -3014,7 +3014,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/anaconda2:latest"
@@ -3338,7 +3339,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3593,7 +3595,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3909,7 +3912,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -4185,7 +4189,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -4302,7 +4307,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -4615,7 +4621,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -4911,7 +4918,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -5227,7 +5235,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -5570,7 +5579,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -5633,7 +5643,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -6216,7 +6227,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -6551,7 +6563,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -6646,7 +6659,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -3158,7 +3158,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3477,7 +3478,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -3738,7 +3740,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4054,7 +4057,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4336,7 +4340,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4448,7 +4453,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -4759,7 +4765,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5047,7 +5054,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5176,7 +5184,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5477,7 +5486,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5611,7 +5621,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -5914,7 +5925,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6252,7 +6264,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6321,7 +6334,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6890,7 +6904,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7220,7 +7235,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -7310,7 +7326,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -2756,7 +2756,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3029,7 +3030,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/local:latest"
@@ -3131,7 +3133,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/console:latest"
@@ -3443,7 +3446,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/megabinary:latest"
@@ -3722,7 +3726,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-trace:latest"
@@ -3816,7 +3821,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-trace:latest"
@@ -3934,7 +3940,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -3996,7 +4003,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "wandb/weave-python:latest"
@@ -4553,7 +4561,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "wandb/megabinary:latest"
@@ -5018,7 +5027,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
@@ -5094,7 +5104,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -3569,7 +3569,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3914,7 +3915,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4201,7 +4203,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4520,7 +4523,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4805,7 +4809,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4917,7 +4922,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5231,7 +5237,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5522,7 +5529,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5651,7 +5659,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5978,7 +5987,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6112,7 +6122,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -6418,7 +6429,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6756,7 +6768,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -6825,7 +6838,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7766,7 +7780,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8157,7 +8172,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8247,7 +8263,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8386,7 +8403,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8477,7 +8495,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -3973,7 +3973,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -4292,7 +4293,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4553,7 +4555,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4869,7 +4872,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -5151,7 +5155,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -5263,7 +5268,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5574,7 +5580,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5862,7 +5869,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5991,7 +5999,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -6292,7 +6301,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6426,7 +6436,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -6729,7 +6740,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -7094,7 +7106,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7246,7 +7259,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7407,7 +7421,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7500,7 +7515,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7628,7 +7644,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7697,7 +7714,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -8932,7 +8950,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -9372,7 +9391,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -9462,7 +9482,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -3666,7 +3666,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:latest"
@@ -3985,7 +3986,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4246,7 +4248,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -4562,7 +4565,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4844,7 +4848,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/local:latest"
@@ -4956,7 +4961,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/console:latest"
@@ -5267,7 +5273,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5555,7 +5562,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -5684,7 +5692,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:latest"
@@ -5985,7 +5994,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6119,7 +6129,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/nginxinc/nginx-unprivileged:latest"
@@ -6422,7 +6433,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -6787,7 +6799,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -6880,7 +6893,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-trace:latest"
@@ -7008,7 +7022,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -7077,7 +7092,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/wandb/weave-python:latest"
@@ -8012,7 +8028,8 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 add: []
-                drop: []
+                drop:
+                - ALL
               privileged: false
               readOnlyRootFilesystem: false
             image: "us-docker.pkg.dev/wandb-production/public/wandb/megabinary:latest"
@@ -8452,7 +8469,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"
@@ -8542,7 +8560,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "us-docker.pkg.dev/wandb-production/public/alpine/k8s:1.31.12"

--- a/test-configs/orchestrator/__snapshots__/default.snap
+++ b/test-configs/orchestrator/__snapshots__/default.snap
@@ -569,7 +569,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "orchestrator/identity:latest"
@@ -667,7 +668,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "orchestrator/web:latest"
@@ -804,7 +806,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "orchestrator/workspace-engine:latest"
@@ -1017,7 +1020,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "orchestrator/identity:latest"
@@ -1149,7 +1153,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "orchestrator/workspace-engine:latest"
@@ -1281,7 +1286,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "orchestrator/workspace-engine:latest"

--- a/test-configs/wandb-base/__snapshots__/global-volumeMounts-override.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumeMounts-override.snap
@@ -65,7 +65,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"
@@ -87,7 +88,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"

--- a/test-configs/wandb-base/__snapshots__/global-volumes-and-mounts.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumes-and-mounts.snap
@@ -74,7 +74,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"
@@ -98,7 +99,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"

--- a/test-configs/wandb-base/__snapshots__/global-volumes-override.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumes-override.snap
@@ -65,7 +65,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"
@@ -87,7 +88,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"

--- a/test-configs/wandb-base/__snapshots__/global-volumes.snap
+++ b/test-configs/wandb-base/__snapshots__/global-volumes.snap
@@ -71,7 +71,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"
@@ -93,7 +94,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"

--- a/test-configs/wandb-base/__snapshots__/job-fields.snap
+++ b/test-configs/wandb-base/__snapshots__/job-fields.snap
@@ -36,7 +36,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add: []
-            drop: []
+            drop:
+            - ALL
           privileged: false
           readOnlyRootFilesystem: false
         image: "debian:12-slim"


### PR DESCRIPTION
## What

- Drop all Linux capabilities by default in `wandb-base` container security contexts.
- Bump `wandb-base` to 0.12.7 and update the exact dependency pins for `operator-wandb`, Lumen, and orchestrator.
- Regenerate dependency locks and rendered snapshots.

## Why

The Kubernetes Restricted Pod Security Standard requires containers to drop `ALL` capabilities. `allowPrivilegeEscalation: false` prevents gaining new privileges but does not explicitly remove capabilities granted at container startup.

This addresses the Kyverno restricted-policy capability findings for workloads that inherit the `wandb-base` security context.

## CIS coverage

This directly addresses these capability-specific controls reported through Kyverno policy `westest-cis-pod-security-restricted/restricted`:

- CIS 5.2.8 — Minimize the admission of containers with the `NET_RAW` capability (`capabilities_baseline`).
- CIS 5.2.9 — Minimize the admission of containers with capabilities assigned (`capabilities_restricted`).

Kyverno reports the Restricted Pod Security Standard as one aggregate rule. A workload will continue to fail that rule if it has another Restricted PSS violation, such as privileged mode, host namespaces, `allowPrivilegeEscalation`, root execution, or seccomp configuration.

This does not directly clear a capability-specific kube-bench finding in the supplied results. It contributes to GKE's aggregate PSS Baseline-or-stricter control, but does not satisfy that control by itself.

## Impact

Containers and init containers using the default `wandb-base` security context will render:

```yaml
capabilities:
  add: []
  drop:
    - ALL
```

Stock W&B services already run non-root and use unprivileged ports, so no functional change is expected. The chart should still be rolled through QA before wider Dedicated promotion, with particular attention to migration jobs and custom-CA startup.

## Testing

- `python3 scripts/format_templates.py`
- `python3 -m unittest discover -s scripts/tests`
- `python3 scripts/check_template_maintainability.py`
- `ct lint` for `wandb-base`, `operator-wandb`, Lumen, and orchestrator
- Snapshot suites for all four affected charts
- `helm unittest ./charts/operator-wandb/` — 49 tests passed
- Focused render assertion confirming main and init containers inherit `drop: [ALL]`
- `git diff --check`
