### PR TITLE
feat(orchestrator): support additional ingress hosts

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/orchestrator/templates/ingress.yaml
+++ b/charts/orchestrator/templates/ingress.yaml
@@ -1,5 +1,13 @@
 {{- if .Values.ingress.create }}
   {{- $fqdn := .Values.global.fqdn | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+  {{- $releaseName := .Release.Name -}}
+  {{- $hosts := list $fqdn -}}
+  {{- range .Values.ingress.additionalHosts }}
+    {{- $host := . | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+    {{- if $host }}
+      {{- $hosts = append $hosts $host -}}
+    {{- end }}
+  {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -20,7 +28,9 @@ spec:
   {{- if and $fqdn .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-        - {{ $fqdn }}
+    {{- range $hosts }}
+        - {{ . }}
+    {{- end }}
       secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "orchestrator.fullname" .)) }}
   {{- end }}
   defaultBackend:
@@ -29,16 +39,17 @@ spec:
       port:
         number: 3000
   rules:
-    - {{- if $fqdn }}
-      host: {{ $fqdn }}
-{{- end }}
+  {{- range $hosts }}
+    - {{- if . }}
+      host: {{ . }}
+  {{- end }}
       http:
         paths:
           - pathType: Prefix
             path: /
             backend:
               service:
-                name: {{ .Release.Name }}-web
+                name: {{ $releaseName }}-web
                 port:
                   number: 3000
           # Identity (apps/identity) owns /api/* — better-auth (/api/auth),
@@ -47,7 +58,7 @@ spec:
             path: /api
             backend:
               service:
-                name: {{ .Release.Name }}-identity
+                name: {{ $releaseName }}-identity
                 port:
                   number: 8081
           # The workspace-engine serves its Connect API under /engine natively
@@ -56,7 +67,8 @@ spec:
             path: /engine
             backend:
               service:
-                name: {{ .Release.Name }}-workspace-engine
+                name: {{ $releaseName }}-workspace-engine
                 port:
                   number: 8086
+{{- end }}
 {{- end }}

--- a/charts/orchestrator/tests/ingress_additional_hosts_test.yaml
+++ b/charts/orchestrator/tests/ingress_additional_hosts_test.yaml
@@ -1,0 +1,67 @@
+suite: ingress additional hosts
+templates:
+  - templates/ingress.yaml
+release:
+  name: orchestrator
+
+tests:
+  - it: renders every application route for an additional host
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+      ingress:
+        additionalHosts:
+          - "https://orca-qa.wandb.io/"
+    asserts:
+      - equal:
+          path: spec.rules[1].host
+          value: orca-qa.wandb.io
+      - contains:
+          path: spec.rules[1].http.paths
+          content:
+            pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: orchestrator-web
+                port:
+                  number: 3000
+          any: true
+      - contains:
+          path: spec.rules[1].http.paths
+          content:
+            pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: orchestrator-identity
+                port:
+                  number: 8081
+          any: true
+      - contains:
+          path: spec.rules[1].http.paths
+          content:
+            pathType: Prefix
+            path: /engine
+            backend:
+              service:
+                name: orchestrator-workspace-engine
+                port:
+                  number: 8086
+          any: true
+
+  - it: includes additional hosts in the TLS host list
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+      ingress:
+        additionalHosts:
+          - "orca-qa.wandb.io"
+        tls:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts
+          value:
+            - ctrlplane-qa.wandb.io
+            - orca-qa.wandb.io

--- a/charts/orchestrator/tests/ingress_additional_hosts_test.yaml
+++ b/charts/orchestrator/tests/ingress_additional_hosts_test.yaml
@@ -65,3 +65,23 @@ tests:
           value:
             - ctrlplane-qa.wandb.io
             - orca-qa.wandb.io
+
+  - it: omits empty additional host entries
+    set:
+      global:
+        fqdn: "ctrlplane-qa.wandb.io"
+      ingress:
+        additionalHosts:
+          - ""
+        tls:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: ctrlplane-qa.wandb.io
+      - notExists:
+          path: spec.rules[1]
+      - equal:
+          path: spec.tls[0].hosts
+          value:
+            - ctrlplane-qa.wandb.io

--- a/charts/orchestrator/tests/ingress_test.yaml
+++ b/charts/orchestrator/tests/ingress_test.yaml
@@ -161,7 +161,7 @@ tests:
                   number: 3000
           any: true
 
-  - it: routes /api to api on port 8081
+  - it: routes /api to identity on port 8081
     asserts:
       - contains:
           path: spec.rules[0].http.paths
@@ -170,7 +170,7 @@ tests:
             path: /api
             backend:
               service:
-                name: orchestrator-api
+                name: orchestrator-identity
                 port:
                   number: 8081
           any: true

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -180,7 +180,8 @@ ingress:
   labels: {}
   annotations: {}
   # Hostnames that share the canonical global.fqdn routes and TLS configuration.
-  # Values may be bare hostnames or URLs; global.fqdn remains required.
+  # Entries may be bare hostnames or origin URLs without paths, query strings,
+  # or fragments. global.fqdn remains required.
   additionalHosts: []
   tls:
     enabled: false

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -179,6 +179,9 @@ ingress:
   class: ""
   labels: {}
   annotations: {}
+  # Hostnames that share the canonical global.fqdn routes and TLS configuration.
+  # Values may be bare hostnames or URLs; global.fqdn remains required.
+  additionalHosts: []
   tls:
     enabled: false
     secretName: ""


### PR DESCRIPTION
## What

Adds optional additional ingress hostnames to the orchestrator chart and bumps the chart to 1.4.4. Each additional hostname receives the same root, API, and engine routes as the canonical hostname and is included in the normal TLS host list.

The canonical global.fqdn behavior is unchanged.

## Why

QA needs to serve orca-qa.wandb.io from the existing ctrlplane ingress without changing the canonical ctrlplane-qa.wandb.io application and authentication URLs.

## How

- Adds ingress.additionalHosts with an empty default for backward compatibility.
- Normalizes optional URL schemes and trailing slashes before rendering hosts.
- Reuses the existing service routing for every hostname.
- Keeps the canonical hostname first.

## Testing

- 19 focused Helm ingress tests pass.
- Template formatting and maintainability checks pass.
- Orchestrator chart snapshots match.
- Chart Testing lint passes with Helm 3.20.1, matching CI.

## Anything Else

This chart must be merged and version 1.4.4 published before the QA routing PR can merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring additional hostnames for the orchestrator ingress.
  - Additional hostnames now share the same web, identity API, workspace engine routes, and TLS configuration as the primary hostname.
  - Hostnames can be provided as names or URLs.

- **Bug Fixes**
  - Corrected `/api` routing to use the identity service while retaining port 8081.

- **Chores**
  - Updated the orchestrator Helm chart version to 1.4.4.
  - Added coverage to verify ingress routing and TLS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->