### PR TITLE
feat(orchestrator): configure auth for alternate hosts

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.4
+version: 1.4.5
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/orchestrator/templates/_authhosts.tpl
+++ b/charts/orchestrator/templates/_authhosts.tpl
@@ -3,7 +3,7 @@ Configure Better Auth's dynamic base URL only when the ingress has alternate
 application hosts. Single-host installs retain the static BASE_URL behavior.
 */}}
 {{- define "orchestrator.authHostEnvVars" -}}
-  {{- $hosts := include "orchestrator.applicationHosts" . | fromYamlArray -}}
+  {{- $hosts := include "orchestrator.authHosts" . | fromYamlArray -}}
   {{- if gt (len $hosts) 1 -}}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_ALLOWED_HOSTS" "value" (join "," $hosts)) }}
   {{- end -}}

--- a/charts/orchestrator/templates/_authhosts.tpl
+++ b/charts/orchestrator/templates/_authhosts.tpl
@@ -1,0 +1,10 @@
+{{/*
+Configure Better Auth's dynamic base URL only when the ingress has alternate
+application hosts. Single-host installs retain the static BASE_URL behavior.
+*/}}
+{{- define "orchestrator.authHostEnvVars" -}}
+  {{- $hosts := include "orchestrator.applicationHosts" . | fromYamlArray -}}
+  {{- if gt (len $hosts) 1 -}}
+{{ include "orchestrator.envVar" (dict "name" "AUTH_ALLOWED_HOSTS" "value" (join "," $hosts)) }}
+  {{- end -}}
+{{- end -}}

--- a/charts/orchestrator/templates/_authjwt.tpl
+++ b/charts/orchestrator/templates/_authjwt.tpl
@@ -6,7 +6,12 @@ identity stamps (its BASE_URL = global.fqdn); AUTH_AUDIENCE must equal identity'
 AUTH_JWT_AUDIENCE (both sourced from global.jwt.audience).
 */}}
 {{- define "orchestrator.authJwtEnvVars" -}}
+  {{- $issuers := .Values.global.fqdn -}}
+  {{- $origins := include "orchestrator.applicationOrigins" . | fromYamlArray -}}
+  {{- if gt (len $origins) 1 -}}
+    {{- $issuers = join "," $origins -}}
+  {{- end -}}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_JWKS_URL" "value" (printf "http://%s-identity:%v/api/auth/jwks" .Release.Name .Values.global.jwt.identityPort)) }}
-{{ include "orchestrator.envVar" (dict "name" "AUTH_VALID_ISSUERS" "value" .Values.global.fqdn) }}
+{{ include "orchestrator.envVar" (dict "name" "AUTH_VALID_ISSUERS" "value" $issuers) }}
 {{ include "orchestrator.envVar" (dict "name" "AUTH_AUDIENCE" "value" .Values.global.jwt.audience) }}
 {{- end -}}

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -6,25 +6,47 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Return the unique application hostnames routed by the orchestrator ingress.
-global.fqdn is canonical; global.additionalHosts adds auth-aware alternate names,
-while ingress.additionalHosts remains supported for routing compatibility.
+Return the unique hostnames accepted by authentication. global.fqdn is
+canonical and global.additionalHosts adds auth-aware alternate names.
 */}}
-{{- define "orchestrator.applicationHosts" -}}
+{{- define "orchestrator.authHosts" -}}
   {{- $hosts := list -}}
   {{- $fqdn := .Values.global.fqdn | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
   {{- if $fqdn -}}
     {{- $hosts = append $hosts $fqdn -}}
   {{- end -}}
   {{- $additionalHosts := default (list) .Values.global.additionalHosts -}}
-  {{- if .Values.ingress -}}
-    {{- $additionalHosts = concat $additionalHosts (default (list) .Values.ingress.additionalHosts) -}}
+  {{- $protocol := "https" -}}
+  {{- if hasPrefix "http://" .Values.global.fqdn -}}
+    {{- $protocol = "http" -}}
   {{- end -}}
   {{- range $additionalHosts -}}
+    {{- $configuredHost := . -}}
+    {{- if or (and (hasPrefix "http://" $configuredHost) (ne $protocol "http")) (and (hasPrefix "https://" $configuredHost) (ne $protocol "https")) -}}
+      {{- fail "global.additionalHosts protocols must match global.fqdn" -}}
+    {{- end -}}
+    {{- $host := $configuredHost | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+    {{- if and $host (not (has $host $hosts)) -}}
+      {{- $hosts = append $hosts $host -}}
+    {{- end -}}
+  {{- end -}}
+{{- toYaml $hosts -}}
+{{- end }}
+
+{{/*
+Return the hostnames routed by the ingress. Deprecated ingress.additionalHosts
+remain routing-only and cannot expand the authentication trust boundary.
+*/}}
+{{- define "orchestrator.applicationHosts" -}}
+  {{- $hosts := include "orchestrator.authHosts" . | fromYamlArray -}}
+  {{- range (default (list) .Values.ingress.additionalHosts) -}}
     {{- $host := . | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
     {{- if and $host (not (has $host $hosts)) -}}
       {{- $hosts = append $hosts $host -}}
     {{- end -}}
+  {{- end -}}
+  {{- if eq (len $hosts) 0 -}}
+    {{- $hosts = list "" -}}
   {{- end -}}
 {{- toYaml $hosts -}}
 {{- end }}
@@ -40,7 +62,7 @@ single protocol for every allowed host.
     {{- $protocol = "http" -}}
   {{- end -}}
   {{- $origins := list -}}
-  {{- range (include "orchestrator.applicationHosts" . | fromYamlArray) -}}
+  {{- range (include "orchestrator.authHosts" . | fromYamlArray) -}}
     {{- $origins = append $origins (printf "%s://%s" $protocol .) -}}
   {{- end -}}
 {{- toYaml $origins -}}

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -48,17 +48,11 @@ canonical and global.additionalHosts adds auth-aware alternate names.
 {{- end }}
 
 {{/*
-Return the hostnames routed by the ingress. Deprecated ingress.additionalHosts
-remain routing-only and cannot expand the authentication trust boundary.
+Return the hostnames routed by the ingress, preserving the hostless rule used
+when global.fqdn is empty.
 */}}
 {{- define "orchestrator.applicationHosts" -}}
   {{- $hosts := include "orchestrator.authHosts" . | fromYamlArray -}}
-  {{- range (default (list) .Values.ingress.additionalHosts) -}}
-    {{- $host := . | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
-    {{- if and $host (not (has $host $hosts)) -}}
-      {{- $hosts = append $hosts $host -}}
-    {{- end -}}
-  {{- end -}}
   {{- if eq (len $hosts) 0 -}}
     {{- $hosts = list "" -}}
   {{- end -}}

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -6,6 +6,47 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Return the unique application hostnames routed by the orchestrator ingress.
+global.fqdn is canonical; global.additionalHosts adds auth-aware alternate names,
+while ingress.additionalHosts remains supported for routing compatibility.
+*/}}
+{{- define "orchestrator.applicationHosts" -}}
+  {{- $hosts := list -}}
+  {{- $fqdn := .Values.global.fqdn | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+  {{- if $fqdn -}}
+    {{- $hosts = append $hosts $fqdn -}}
+  {{- end -}}
+  {{- $additionalHosts := default (list) .Values.global.additionalHosts -}}
+  {{- if .Values.ingress -}}
+    {{- $additionalHosts = concat $additionalHosts (default (list) .Values.ingress.additionalHosts) -}}
+  {{- end -}}
+  {{- range $additionalHosts -}}
+    {{- $host := . | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+    {{- if and $host (not (has $host $hosts)) -}}
+      {{- $hosts = append $hosts $host -}}
+    {{- end -}}
+  {{- end -}}
+{{- toYaml $hosts -}}
+{{- end }}
+
+{{/*
+Return the application origins used as valid JWT issuers. Alternate hosts use
+the canonical fqdn's protocol because Better Auth's dynamic base URL accepts a
+single protocol for every allowed host.
+*/}}
+{{- define "orchestrator.applicationOrigins" -}}
+  {{- $protocol := "https" -}}
+  {{- if hasPrefix "http://" .Values.global.fqdn -}}
+    {{- $protocol = "http" -}}
+  {{- end -}}
+  {{- $origins := list -}}
+  {{- range (include "orchestrator.applicationHosts" . | fromYamlArray) -}}
+    {{- $origins = append $origins (printf "%s://%s" $protocol .) -}}
+  {{- end -}}
+{{- toYaml $origins -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -6,26 +6,40 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Normalize an auth hostname the same way ctrlplane does: lowercase it and
+remove the protocol's default port while preserving non-default ports.
+*/}}
+{{- define "orchestrator.normalizeAuthHost" -}}
+  {{- $host := .host | lower | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+  {{- if and (eq .protocol "https") (hasSuffix ":443" $host) -}}
+    {{- $host = trimSuffix ":443" $host -}}
+  {{- else if and (eq .protocol "http") (hasSuffix ":80" $host) -}}
+    {{- $host = trimSuffix ":80" $host -}}
+  {{- end -}}
+{{- $host -}}
+{{- end }}
+
+{{/*
 Return the unique hostnames accepted by authentication. global.fqdn is
 canonical and global.additionalHosts adds auth-aware alternate names.
 */}}
 {{- define "orchestrator.authHosts" -}}
   {{- $hosts := list -}}
-  {{- $fqdn := .Values.global.fqdn | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+  {{- $protocol := "https" -}}
+  {{- if hasPrefix "http://" (.Values.global.fqdn | lower) -}}
+    {{- $protocol = "http" -}}
+  {{- end -}}
+  {{- $fqdn := include "orchestrator.normalizeAuthHost" (dict "host" .Values.global.fqdn "protocol" $protocol) -}}
   {{- if $fqdn -}}
     {{- $hosts = append $hosts $fqdn -}}
   {{- end -}}
   {{- $additionalHosts := default (list) .Values.global.additionalHosts -}}
-  {{- $protocol := "https" -}}
-  {{- if hasPrefix "http://" .Values.global.fqdn -}}
-    {{- $protocol = "http" -}}
-  {{- end -}}
   {{- range $additionalHosts -}}
-    {{- $configuredHost := . -}}
+    {{- $configuredHost := . | lower -}}
     {{- if or (and (hasPrefix "http://" $configuredHost) (ne $protocol "http")) (and (hasPrefix "https://" $configuredHost) (ne $protocol "https")) -}}
       {{- fail "global.additionalHosts protocols must match global.fqdn" -}}
     {{- end -}}
-    {{- $host := $configuredHost | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+    {{- $host := include "orchestrator.normalizeAuthHost" (dict "host" $configuredHost "protocol" $protocol) -}}
     {{- if and $host (not (has $host $hosts)) -}}
       {{- $hosts = append $hosts $host -}}
     {{- end -}}

--- a/charts/orchestrator/templates/ingress.yaml
+++ b/charts/orchestrator/templates/ingress.yaml
@@ -1,13 +1,7 @@
 {{- if .Values.ingress.create }}
   {{- $fqdn := .Values.global.fqdn | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
   {{- $releaseName := .Release.Name -}}
-  {{- $hosts := list $fqdn -}}
-  {{- range .Values.ingress.additionalHosts }}
-    {{- $host := . | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
-    {{- if $host }}
-      {{- $hosts = append $hosts $host -}}
-    {{- end }}
-  {{- end }}
+  {{- $hosts := include "orchestrator.applicationHosts" . | fromYamlArray -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/orchestrator/tests/auth_hosts_test.yaml
+++ b/charts/orchestrator/tests/auth_hosts_test.yaml
@@ -137,37 +137,6 @@ tests:
             value: "https://ctrlplane-qa.wandb.io/"
           any: true
 
-  - it: keeps deprecated ingress hosts out of identity auth configuration
-    template: charts/identity/templates/deployment.yaml
-    set:
-      global:
-        fqdn: "https://ctrlplane-qa.wandb.io"
-      ingress:
-        additionalHosts:
-          - "legacy-route.wandb.io"
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: AUTH_ALLOWED_HOSTS
-          any: true
-
-  - it: keeps deprecated ingress hosts out of valid JWT issuers
-    template: charts/workspace-engine/templates/deployment.yaml
-    set:
-      global:
-        fqdn: "https://ctrlplane-qa.wandb.io"
-      ingress:
-        additionalHosts:
-          - "legacy-route.wandb.io"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: AUTH_VALID_ISSUERS
-            value: "https://ctrlplane-qa.wandb.io"
-          any: true
-
   - it: preserves HTTP for every configured auth issuer
     template: charts/workspace-engine/templates/deployment.yaml
     set:

--- a/charts/orchestrator/tests/auth_hosts_test.yaml
+++ b/charts/orchestrator/tests/auth_hosts_test.yaml
@@ -27,12 +27,26 @@ tests:
         additionalHosts:
           - "https://orca-qa.wandb.io/"
           - ""
+        jwt:
+          audience: ctrlplane
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AUTH_ALLOWED_HOSTS
             value: "ctrlplane-qa.wandb.io,orca-qa.wandb.io"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASE_URL
+            value: "https://ctrlplane-qa.wandb.io"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_JWT_AUDIENCE
+            value: ctrlplane
           any: true
 
   - it: accepts JWT issuers for every routed application host
@@ -43,12 +57,26 @@ tests:
         additionalHosts:
           - "https://orca-qa.wandb.io/"
           - ""
+        jwt:
+          audience: ctrlplane
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AUTH_VALID_ISSUERS
             value: "https://ctrlplane-qa.wandb.io,https://orca-qa.wandb.io"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_JWKS_URL
+            value: "http://orchestrator-identity:8081/api/auth/jwks"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_AUDIENCE
+            value: ctrlplane
           any: true
 
   - it: preserves single-host identity configuration by default
@@ -78,3 +106,60 @@ tests:
             name: AUTH_VALID_ISSUERS
             value: "https://ctrlplane-qa.wandb.io/"
           any: true
+
+  - it: keeps deprecated ingress hosts out of identity auth configuration
+    template: charts/identity/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+      ingress:
+        additionalHosts:
+          - "legacy-route.wandb.io"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_ALLOWED_HOSTS
+          any: true
+
+  - it: keeps deprecated ingress hosts out of valid JWT issuers
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+      ingress:
+        additionalHosts:
+          - "legacy-route.wandb.io"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_VALID_ISSUERS
+            value: "https://ctrlplane-qa.wandb.io"
+          any: true
+
+  - it: preserves HTTP for every configured auth issuer
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "http://ctrlplane.test"
+        additionalHosts:
+          - "http://orca.test/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_VALID_ISSUERS
+            value: "http://ctrlplane.test,http://orca.test"
+          any: true
+
+  - it: rejects an explicit additional-host protocol that differs from the canonical URL
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "http://orca-qa.wandb.io"
+    asserts:
+      - failedTemplate:
+          errorMessage: global.additionalHosts protocols must match global.fqdn

--- a/charts/orchestrator/tests/auth_hosts_test.yaml
+++ b/charts/orchestrator/tests/auth_hosts_test.yaml
@@ -49,6 +49,21 @@ tests:
             value: ctrlplane
           any: true
 
+  - it: normalizes HTTPS default ports in identity auth hosts
+    template: charts/identity/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "https://ORCA-QA.WANDB.IO:443/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_ALLOWED_HOSTS
+            value: "ctrlplane-qa.wandb.io,orca-qa.wandb.io"
+          any: true
+
   - it: accepts JWT issuers for every routed application host
     template: charts/workspace-engine/templates/deployment.yaml
     set:
@@ -77,6 +92,21 @@ tests:
           content:
             name: AUTH_AUDIENCE
             value: ctrlplane
+          any: true
+
+  - it: normalizes HTTPS default ports in valid JWT issuers
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "https://ORCA-QA.WANDB.IO:443/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_VALID_ISSUERS
+            value: "https://ctrlplane-qa.wandb.io,https://orca-qa.wandb.io"
           any: true
 
   - it: preserves single-host identity configuration by default
@@ -144,13 +174,28 @@ tests:
       global:
         fqdn: "http://ctrlplane.test"
         additionalHosts:
-          - "http://orca.test/"
+          - "http://ORCA.TEST:80/"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: AUTH_VALID_ISSUERS
             value: "http://ctrlplane.test,http://orca.test"
+          any: true
+
+  - it: preserves non-default ports in valid JWT issuers
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "https://ORCA-QA.WANDB.IO:8443/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_VALID_ISSUERS
+            value: "https://ctrlplane-qa.wandb.io,https://orca-qa.wandb.io:8443"
           any: true
 
   - it: rejects an explicit additional-host protocol that differs from the canonical URL

--- a/charts/orchestrator/tests/auth_hosts_test.yaml
+++ b/charts/orchestrator/tests/auth_hosts_test.yaml
@@ -1,0 +1,80 @@
+suite: auth hosts
+templates:
+  - templates/ingress.yaml
+  - charts/identity/templates/deployment.yaml
+  - charts/workspace-engine/templates/deployment.yaml
+release:
+  name: orchestrator
+
+tests:
+  - it: routes every globally configured application host
+    template: templates/ingress.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "https://orca-qa.wandb.io/"
+    asserts:
+      - equal:
+          path: spec.rules[1].host
+          value: orca-qa.wandb.io
+
+  - it: configures identity for every routed application host
+    template: charts/identity/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "https://orca-qa.wandb.io/"
+          - ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_ALLOWED_HOSTS
+            value: "ctrlplane-qa.wandb.io,orca-qa.wandb.io"
+          any: true
+
+  - it: accepts JWT issuers for every routed application host
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "https://orca-qa.wandb.io/"
+          - ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_VALID_ISSUERS
+            value: "https://ctrlplane-qa.wandb.io,https://orca-qa.wandb.io"
+          any: true
+
+  - it: preserves single-host identity configuration by default
+    template: charts/identity/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
+        additionalHosts:
+          - "ctrlplane-qa.wandb.io"
+          - ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_ALLOWED_HOSTS
+          any: true
+
+  - it: preserves the canonical JWT issuer for a single-host installation
+    template: charts/workspace-engine/templates/deployment.yaml
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_VALID_ISSUERS
+            value: "https://ctrlplane-qa.wandb.io/"
+          any: true

--- a/charts/orchestrator/tests/ingress_additional_hosts_test.yaml
+++ b/charts/orchestrator/tests/ingress_additional_hosts_test.yaml
@@ -5,11 +5,21 @@ release:
   name: orchestrator
 
 tests:
-  - it: renders every application route for an additional host
+  - it: ignores ingress-scoped additional hosts
     set:
       global:
         fqdn: "https://ctrlplane-qa.wandb.io"
       ingress:
+        additionalHosts:
+          - "legacy-route.wandb.io"
+    asserts:
+      - notExists:
+          path: spec.rules[1]
+
+  - it: renders every application route for an additional host
+    set:
+      global:
+        fqdn: "https://ctrlplane-qa.wandb.io"
         additionalHosts:
           - "https://orca-qa.wandb.io/"
     asserts:
@@ -54,9 +64,9 @@ tests:
     set:
       global:
         fqdn: "https://ctrlplane-qa.wandb.io"
-      ingress:
         additionalHosts:
           - "orca-qa.wandb.io"
+      ingress:
         tls:
           enabled: true
     asserts:
@@ -70,9 +80,9 @@ tests:
     set:
       global:
         fqdn: "ctrlplane-qa.wandb.io"
-      ingress:
         additionalHosts:
           - ""
+      ingress:
         tls:
           enabled: true
     asserts:

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -1,5 +1,9 @@
 global:
   fqdn: ""
+  # Alternate application hostnames routed by the ingress and accepted by auth.
+  # Entries may be bare hostnames or origin URLs without paths, query strings,
+  # or fragments. global.fqdn remains the canonical URL.
+  additionalHosts: []
 
   env: {}
   # env:
@@ -179,9 +183,8 @@ ingress:
   class: ""
   labels: {}
   annotations: {}
-  # Hostnames that share the canonical global.fqdn routes and TLS configuration.
-  # Entries may be bare hostnames or origin URLs without paths, query strings,
-  # or fragments. global.fqdn remains required.
+  # Deprecated: use global.additionalHosts so auth also accepts the hostnames.
+  # This field remains supported for ingress routing and TLS compatibility.
   additionalHosts: []
   tls:
     enabled: false
@@ -231,6 +234,7 @@ identity:
     OTEL_SAMPLER_RATIO: "0.1"
 
   envTpls:
+    - '{{ include "orchestrator.authHostEnvVars" . }}'
     - '{{ include "orchestrator.authProviderEnvVars" . }}'
     - '{{ include "orchestrator.authSyncSecretEnvVars" . }}'
     - '{{ include "orchestrator.authDatabaseEnvVars" . }}'

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -183,9 +183,6 @@ ingress:
   class: ""
   labels: {}
   annotations: {}
-  # Deprecated: use global.additionalHosts so auth also accepts the hostnames.
-  # This field remains supported for ingress routing and TLS compatibility.
-  additionalHosts: []
   tls:
     enabled: false
     secretName: ""


### PR DESCRIPTION
## Summary
- add global.additionalHosts as the shared source for alternate ingress and auth hostnames
- configure identity AUTH_ALLOWED_HOSTS and workspace-engine AUTH_VALID_ISSUERS from that list
- bump the orchestrator chart to 1.4.5

## Dependency
wandb/ctrlplane#149 is merged. Deploy an identity image containing it before enabling global.additionalHosts.

## Acceptance criteria
Applying this chart updates the existing Ingress in place; it does not recreate it. The QA rollout will keep the same rules, load-balancer IP, and Ingress UID while rolling identity/workspace-engine configuration.

## Test plan
- python3 scripts/format_templates.py
- python3 -m unittest discover -s scripts/tests
- python3 scripts/check_template_maintainability.py
- helm unittest -f tests/auth_hosts_test.yaml charts/orchestrator
- helm unittest -f tests/ingress_additional_hosts_test.yaml charts/orchestrator
- helm unittest -f tests/identity_telemetry_test.yaml charts/orchestrator
- helm lint charts/orchestrator

Local snapshot execution is blocked by Helm 4 treating the repository post-renderer as a plugin; CI uses the pinned Helm 3.20.1 path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring multiple application hostnames through a shared additional-hosts setting.
  - Ingress routing and TLS now consistently include configured alternate hostnames.
  - Authentication accepts requests from configured hosts and supports multiple valid token issuers.
  - JWT issuer origins are automatically derived from the configured application hosts.
- **Bug Fixes**
  - Improved consistency between ingress hostnames and authentication settings.
  - Preserved existing single-host behavior when no additional hosts are configured.
- **Chores**
  - Updated the Orchestrator Helm chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->