### PR TITLE
feat(operator-wandb): add Weave OLAP compatibility path [WB-39249]

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.6
+version: 0.44.7
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -228,16 +228,19 @@ The following credentials can be pulled from external Kubernetes Secrets:
 |-----------|-------------------|------------------------|
 | **MySQL** | `global.mysql.*` | Each field (host, port, database, user, password) can be a string or a map with `valueFrom` |
 | **Redis** | `global.redis.secret` | `secretName`, `secretKey` |
-| **Weave Trace ClickHouse** | `global.clickhouse.*` (default) or `global.olap.weaveTrace.*` (opt-in) | Each connection field can be a string or a map with `valueFrom` |
+| **Weave Trace ClickHouse** | `global.clickhouse.*` (default) or `global.olap.weaveTrace.*` (opt-in) | Select with `global.weaveTrace.clickhouseSource`; each connection field can be a string or a map with `valueFrom` |
 | **Kafka** | `global.kafka.passwordSecret` | `name`, `passwordKey` |
 | **OIDC** | `global.auth.oidc.oidcSecret` | `name`, `secretKey` |
 | **Session signing** | `global.auth.sessionKey`, `global.auth.sessionKeyPrevious` | Literal value or a map with `valueFrom` |
 | **SMTP** | `global.email.smtp.*` | Each field (host, port, user, password) can be a string or a map with `valueFrom` |
 
-`global.olap.weaveTrace.enabled` is `false` by default. Setting it to `true`
-explicitly switches Weave Trace and its workers to that OLAP connection. The
-chart does not infer enrollment from `global.clickhouse`, so existing and
-bundled ClickHouse installations keep their current behavior.
+`global.weaveTrace.clickhouseSource` defaults to `legacy`, so Weave Trace and
+its workers continue to use `global.clickhouse` even when the OLAP profile is
+enabled. Set `global.olap.weaveTrace.enabled: true` to make the profile
+available, then set `global.weaveTrace.clickhouseSource: olap` to perform the
+cutover. Selecting a disabled OLAP profile or an unknown source fails chart
+rendering. The chart does not infer enrollment from either connection, so
+existing and bundled ClickHouse installations keep their current behavior.
 
 ### Example: Using External Secrets with MySQL/ClickHouse/SMTP
 

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -228,11 +228,16 @@ The following credentials can be pulled from external Kubernetes Secrets:
 |-----------|-------------------|------------------------|
 | **MySQL** | `global.mysql.*` | Each field (host, port, database, user, password) can be a string or a map with `valueFrom` |
 | **Redis** | `global.redis.secret` | `secretName`, `secretKey` |
-| **ClickHouse** | `global.clickhouse.*` | Each field (host, port, database, user, password) can be a string or a map with `valueFrom` |
+| **Weave Trace ClickHouse** | `global.clickhouse.*` (default) or `global.olap.weaveTrace.*` (opt-in) | Each connection field can be a string or a map with `valueFrom` |
 | **Kafka** | `global.kafka.passwordSecret` | `name`, `passwordKey` |
 | **OIDC** | `global.auth.oidc.oidcSecret` | `name`, `secretKey` |
 | **Session signing** | `global.auth.sessionKey`, `global.auth.sessionKeyPrevious` | Literal value or a map with `valueFrom` |
 | **SMTP** | `global.email.smtp.*` | Each field (host, port, user, password) can be a string or a map with `valueFrom` |
+
+`global.olap.weaveTrace.enabled` is `false` by default. Setting it to `true`
+explicitly switches Weave Trace and its workers to that OLAP connection. The
+chart does not infer enrollment from `global.clickhouse`, so existing and
+bundled ClickHouse installations keep their current behavior.
 
 ### Example: Using External Secrets with MySQL/ClickHouse/SMTP
 

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -334,14 +334,22 @@ Global values will override any chart-specific values.
 {{- define "wandb.weaveTraceClickhouseEnvs" -}}
   {{- /*
     Weave Trace still consumes WF_CLICKHOUSE_* variables. Select the new OLAP
-    connection only when it is explicitly enabled; otherwise preserve the
-    legacy global.clickhouse behavior for existing and bundled installations.
+    connection only when global.weaveTrace.clickhouseSource is explicitly set
+    to "olap"; otherwise preserve the legacy global.clickhouse behavior for
+    existing and bundled installations.
 
     OLAP normally emits <PREFIX>_PASSWORD. Weave expects WF_CLICKHOUSE_PASS,
     so this compatibility helper renders the Weave contract directly.
   */ -}}
   {{- $config := include "wandb.olapConfig" (dict "root" . "featureName" "weaveTrace") | fromYaml -}}
-  {{- if $config.enabled }}
+  {{- $source := default "legacy" .Values.global.weaveTrace.clickhouseSource -}}
+  {{- if not (has $source (list "legacy" "olap")) -}}
+    {{- fail (printf "global.weaveTrace.clickhouseSource must be one of: legacy, olap; got %q" $source) -}}
+  {{- end -}}
+  {{- if and (eq $source "olap") (not $config.enabled) -}}
+    {{- fail "global.olap.weaveTrace.enabled must be true when global.weaveTrace.clickhouseSource is olap" -}}
+  {{- end -}}
+  {{- if eq $source "olap" }}
     {{- $envs := list -}}
     {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_HOST" "value" $config.host) | fromYaml) -}}
     {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_PORT" "value" $config.port) | fromYaml) -}}

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -321,6 +321,46 @@ Global values will override any chart-specific values.
 {{ include "wandb.clickhouseConfigEnvs" . }}
 {{- end -}}
 
+{{- define "wandb.weaveTraceOlapEnv" -}}
+  {{- $env := dict "name" .name -}}
+  {{- if kindIs "map" .value -}}
+    {{- $env = merge $env (deepCopy .value) -}}
+  {{- else -}}
+    {{- $_ := set $env "value" (tpl (.value | toString) .root) -}}
+  {{- end -}}
+{{- toYaml $env -}}
+{{- end -}}
+
+{{- define "wandb.weaveTraceClickhouseEnvs" -}}
+  {{- /*
+    Weave Trace still consumes WF_CLICKHOUSE_* variables. Select the new OLAP
+    connection only when it is explicitly enabled; otherwise preserve the
+    legacy global.clickhouse behavior for existing and bundled installations.
+
+    OLAP normally emits <PREFIX>_PASSWORD. Weave expects WF_CLICKHOUSE_PASS,
+    so this compatibility helper renders the Weave contract directly.
+  */ -}}
+  {{- $config := include "wandb.olapConfig" (dict "root" . "featureName" "weaveTrace") | fromYaml -}}
+  {{- if $config.enabled }}
+    {{- $envs := list -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_HOST" "value" $config.host) | fromYaml) -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_PORT" "value" $config.port) | fromYaml) -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_DATABASE" "value" $config.database) | fromYaml) -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_USER" "value" $config.user) | fromYaml) -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_REPLICATED" "value" $config.replicated) | fromYaml) -}}
+    {{- if kindIs "map" $config.password }}
+      {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_PASS" "value" $config.password) | fromYaml) -}}
+    {{- else }}
+      {{- $secretName := include "wandb.olapSecretName" (dict "root" . "featureName" "weaveTrace") }}
+      {{- $secretKey := include "wandb.olapSecretKey" (dict "envVarPrefix" "WEAVE_TRACE") }}
+      {{- $envs = append $envs (dict "name" "WF_CLICKHOUSE_PASS" "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" $secretKey))) -}}
+    {{- end }}
+{{- toYaml $envs }}
+  {{- else }}
+    {{- include "wandb.clickhouseConfigEnvs" . }}
+  {{- end }}
+{{- end -}}
+
 {{- define "wandb.olapFeatureEnvs" -}}
   {{- /*
     Shared template for OLAP feature environment variables.
@@ -458,14 +498,6 @@ Global values will override any chart-specific values.
 {{- define "wandb.historyMigrateEnvs" -}}
 {{- include "wandb.olapFeatureEnvs" (dict "root" . "featureName" "history" "envVarPrefix" "HISTORY" "emitMigrate" true "migratePrefix" "HISTORY" "finalEnvName" "GORILLA_HISTORY_STORAGE_ENGINE_ADDRESS") -}}
 {{- end -}}
-
-{{/* 
-# TODO: uncomment when weave trace is ready to be integrated.
-# Note, right now it is using WF_CLICKHOUSE as the env var prefix, but we might want to change this to something else if not overly coupled in the weaveTrace code.
-# {{- define "wandb.weaveTraceEnvs" -}}
-# {{- include "wandb.olapFeatureEnvs" (dict "root" . "featureName" "weaveTrace" "envVarPrefix" "WEAVE_TRACE" "finalEnvName" "GORILLA_WEAVE_TRACE_ADDRESS") -}}
-# {{- end -}}
-*/}}
 
 {{- define "wandb.historyStoreEnvs" -}}
 - name: GORILLA_HISTORY_STORE

--- a/charts/operator-wandb/templates/tests/test-olap.yaml
+++ b/charts/operator-wandb/templates/tests/test-olap.yaml
@@ -9,8 +9,10 @@
 "registrySearch" (list "GORILLA_REGISTRY_SEARCH_ADDRESS" "MIGRATE_ARTIFACTS_DB")
 "runStoreAccelerator" (list "GORILLA_RUN_STORE_ACCELERATOR_ADDRESS" "MIGRATE_RUN_STORE_ACCELERATOR_DB" "MIGRATE_RUNS_ACCELERATOR_DB")
 -}}
+{{- /* Weave Trace runs its Python migrator in the workload's initContainer. */ -}}
+{{- $featuresWithOwnMigrator := list "weaveTrace" -}}
 {{- range $featureName, $featureConfig := .Values.global.olap -}}
-  {{- if ne $featureName "default" -}}
+  {{- if and (ne $featureName "default") (not (has $featureName $featuresWithOwnMigrator)) -}}
     {{- $config := include "wandb.olapConfig" (dict "root" $ "featureName" $featureName) | fromYaml -}}
     {{- if $config.enabled -}}
       {{- if not (hasKey $featureSpecificVars $featureName) -}}

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -44,6 +44,7 @@ tests:
     template: charts/weave-trace/templates/deployment.yaml
     set:
       weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
       global.olap.weaveTrace:
         enabled: true
         host:
@@ -126,10 +127,36 @@ tests:
                 name: weave-clickhouse
                 key: replicated
 
-  - it: prefers the explicitly enabled OLAP connection over legacy values
+  - it: keeps the legacy connection when the OLAP profile is only enabled
     template: charts/weave-trace/templates/deployment.yaml
     set:
       weave-trace.install: true
+      global.clickhouse.host: legacy-clickhouse.example.com
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: managed-clickhouse
+              key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: legacy-clickhouse.example.com
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+
+  - it: selects the OLAP connection explicitly when both are configured
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
       global.clickhouse.host: legacy-clickhouse.example.com
       global.olap.weaveTrace:
         enabled: true
@@ -150,6 +177,24 @@ tests:
           content:
             name: WF_CLICKHOUSE_HOST
             value: legacy-clickhouse.example.com
+
+  - it: rejects selecting a disabled OLAP connection
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
+    asserts:
+      - failedTemplate:
+          errorMessage: global.olap.weaveTrace.enabled must be true when global.weaveTrace.clickhouseSource is olap
+
+  - it: rejects an unknown ClickHouse source
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: automatic
+    asserts:
+      - failedTemplate:
+          errorMessage: 'global.weaveTrace.clickhouseSource must be one of: legacy, olap; got "automatic"'
 
   - it: stores a literal OLAP password in a chart-owned Secret
     template: templates/olap.yaml
@@ -172,6 +217,7 @@ tests:
     template: charts/weave-trace/templates/deployment.yaml
     set:
       weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
       global.olap.weaveTrace:
         enabled: true
         host: managed-clickhouse.example.com
@@ -207,6 +253,7 @@ tests:
     template: charts/weave-trace-worker/templates/deployment.yaml
     set:
       weave-trace-worker.install: true
+      global.weaveTrace.clickhouseSource: olap
       global.olap.weaveTrace:
         enabled: true
         host: managed-clickhouse.example.com
@@ -226,6 +273,7 @@ tests:
     template: charts/weave-evaluate-model-worker/templates/deployment.yaml
     set:
       weave-evaluate-model-worker.install: true
+      global.weaveTrace.clickhouseSource: olap
       global.olap.weaveTrace:
         enabled: true
         host: managed-clickhouse.example.com
@@ -245,6 +293,7 @@ tests:
     template: charts/weave-trace-agent-scoring-worker/templates/deployment.yaml
     set:
       weave-trace-agent-scoring-worker.install: true
+      global.weaveTrace.clickhouseSource: olap
       global.olap.weaveTrace:
         enabled: true
         host: managed-clickhouse.example.com

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -1,0 +1,261 @@
+suite: Weave Trace ClickHouse environment
+templates:
+  - templates/olap.yaml
+  - charts/weave-trace/templates/deployment.yaml
+  - charts/weave-trace-worker/templates/deployment.yaml
+  - charts/weave-evaluate-model-worker/templates/deployment.yaml
+  - charts/weave-trace-agent-scoring-worker/templates/deployment.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: preserves the legacy ClickHouse configuration by default
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.clickhouse:
+        host: legacy-clickhouse.example.com
+        port: "8443"
+        database: legacy_weave
+        user: legacy-user
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: legacy-clickhouse
+              key: password
+        replicated: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: legacy-clickhouse.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: legacy-clickhouse
+                key: password
+
+  - it: uses OLAP value references for Weave Trace
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.olap.weaveTrace:
+        enabled: true
+        host:
+          valueFrom:
+            configMapKeyRef:
+              name: weave-clickhouse
+              key: host
+        port:
+          valueFrom:
+            configMapKeyRef:
+              name: weave-clickhouse
+              key: port
+        database:
+          valueFrom:
+            configMapKeyRef:
+              name: weave-clickhouse
+              key: database
+        user:
+          valueFrom:
+            secretKeyRef:
+              name: weave-clickhouse
+              key: username
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: weave-clickhouse
+              key: password
+        replicated:
+          valueFrom:
+            configMapKeyRef:
+              name: weave-clickhouse
+              key: replicated
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: weave-clickhouse
+                key: host
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: weave-clickhouse
+                key: port
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: weave-clickhouse
+                key: database
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: weave-clickhouse
+                key: username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: weave-clickhouse
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_REPLICATED
+            valueFrom:
+              configMapKeyRef:
+                name: weave-clickhouse
+                key: replicated
+
+  - it: prefers the explicitly enabled OLAP connection over legacy values
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.clickhouse.host: legacy-clickhouse.example.com
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: managed-clickhouse
+              key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: legacy-clickhouse.example.com
+
+  - it: stores a literal OLAP password in a chart-owned Secret
+    template: templates/olap.yaml
+    set:
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password: test-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: wandb-olap-weave-trace
+      - equal:
+          path: data.WEAVE_TRACE_PASSWORD
+          value: dGVzdC1wYXNzd29yZA==
+
+  - it: references the chart-owned Secret for a literal OLAP password
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password: test-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: wandb-olap-weave-trace
+                key: WEAVE_TRACE_PASSWORD
+
+  - it: keeps bundled ClickHouse on the legacy connection
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      clickhouse.install: true
+      weave-trace.install: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: wandb-clickhouse-headless
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PORT
+            value: "8123"
+
+  - it: wires the OLAP connection into the trace worker
+    template: charts/weave-trace-worker/templates/deployment.yaml
+    set:
+      weave-trace-worker.install: true
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: managed-clickhouse
+              key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+
+  - it: wires the OLAP connection into the evaluate-model worker
+    template: charts/weave-evaluate-model-worker/templates/deployment.yaml
+    set:
+      weave-evaluate-model-worker.install: true
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: managed-clickhouse
+              key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+
+  - it: wires the OLAP connection into the agent-scoring worker
+    template: charts/weave-trace-agent-scoring-worker/templates/deployment.yaml
+    set:
+      weave-trace-agent-scoring-worker.install: true
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: managed-clickhouse
+              key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -227,6 +227,12 @@ global:
   #         name: "clickhouse-settings-secret"
   #         key: "password"
 
+  weaveTrace:
+    # Selects which ClickHouse connection is rendered into Weave Trace workloads.
+    # "legacy" preserves global.clickhouse; "olap" selects global.olap.weaveTrace.
+    # Enabling the OLAP profile alone does not change the active connection.
+    clickhouseSource: legacy
+
   # OLAP database configuration (ClickHouse)
   #
   # Features like Registry Search, Runs Accelerator, and History Updater each
@@ -292,8 +298,8 @@ global:
       params:
         max_open_conns: 300
     # Weave Trace keeps its legacy WF_CLICKHOUSE_* environment variable names.
-    # Enabling this explicitly switches all Weave Trace workloads from
-    # global.clickhouse to this OLAP connection.
+    # Enabling this makes the profile available. Set
+    # global.weaveTrace.clickhouseSource to "olap" to select it.
     weaveTrace:
       enabled: false
       port: "8443"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -291,12 +291,14 @@ global:
       database: "history"
       params:
         max_open_conns: 300
-    # TODO: wire this up when weave trace is ready to be migrated from global.clickhouse. to global.olap.weaveTrace.
-    # weaveTrace:
-    #   enabled: false
-    #   port: 8443
-    #   database: "weave_trace_db"
-    #   params: {} # TBD if even needed.
+    # Weave Trace keeps its legacy WF_CLICKHOUSE_* environment variable names.
+    # Enabling this explicitly switches all Weave Trace workloads from
+    # global.clickhouse to this OLAP connection.
+    weaveTrace:
+      enabled: false
+      port: "8443"
+      database: "weave_trace_db"
+      replicated: false
 
   #
   # FOR ADVANCED USERS:
@@ -3870,7 +3872,7 @@ weave-trace:
     "{{ .Release.Name }}-global-secret": "secretRef"
     "{{ .Release.Name }}-weave-trace-configmap": "configMapRef"
   envTpls:
-    - '{{ include "wandb.clickhouseEnvs" . }}'
+    - '{{ include "wandb.weaveTraceClickhouseEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
   initContainers:
     weave-trace-migrate:
@@ -4012,7 +4014,7 @@ weave-trace-worker:
     "{{ .Release.Name }}-global-secret": "secretRef"
     "{{ .Release.Name }}-weave-trace-configmap": "configMapRef"
   envTpls:
-    - '{{ include "wandb.clickhouseConfigEnvs" . }}'
+    - '{{ include "wandb.weaveTraceClickhouseEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
   env:
     WANDB_INTERNAL_SERVICE_TOKEN:
@@ -4126,7 +4128,7 @@ weave-evaluate-model-worker:
     "{{ .Release.Name }}-global-secret": "secretRef"
     "{{ .Release.Name }}-weave-trace-configmap": "configMapRef"
   envTpls:
-    - '{{ include "wandb.clickhouseConfigEnvs" . }}'
+    - '{{ include "wandb.weaveTraceClickhouseEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
   env:
     WANDB_INTERNAL_SERVICE_TOKEN:
@@ -4232,7 +4234,7 @@ weave-trace-agent-scoring-worker:
     "{{ .Release.Name }}-global-secret": "secretRef"
     "{{ .Release.Name }}-weave-trace-configmap": "configMapRef"
   envTpls:
-    - '{{ include "wandb.clickhouseConfigEnvs" . }}'
+    - '{{ include "wandb.weaveTraceClickhouseEnvs" . }}'
     - '{{ include "wandb.sslCertEnvs" . }}'
   env:
     WANDB_INTERNAL_SERVICE_TOKEN:


### PR DESCRIPTION
## Summary

- add a false-by-default `global.olap.weaveTrace` connection profile
- add `global.weaveTrace.clickhouseSource` as an independent cutover selector, defaulting to `legacy`
- preserve `global.clickhouse` and bundled ClickHouse behavior even when the OLAP profile is staged
- emit the existing `WF_CLICKHOUSE_*` contract for Weave Trace, its migrator, and all three workers
- support both `valueFrom` references and the chart-owned password Secret path

## Safety

Profile creation and consumer cutover are separate operations. Enabling `global.olap.weaveTrace` does not change any Weave workload. Cutover requires `global.weaveTrace.clickhouseSource: olap`, and rendering fails if that selector targets a disabled OLAP profile or contains an unknown value.

## Validation

- `python3 scripts/format_templates.py --check` with helmfmt v0.5.0
- `python3 -m unittest discover -s scripts/tests`
- `python3 scripts/check_template_maintainability.py`
- `helm unittest ./charts/operator-wandb/` (72 tests)
- `helm lint ./charts/operator-wandb/` with Helm v3.20.1
- `./snapshots.sh run` with Helm v3.20.1
- verified profile-only staging, explicit cutover, invalid-state rejection, and all four Weave workloads

Jira: https://coreweave.atlassian.net/browse/WB-39249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional, dedicated OLAP ClickHouse configuration for Weave Trace.
  * Weave Trace and related workers can use the OLAP connection when explicitly selected, while preserving the legacy connection by default.
  * Added secure password configuration through chart-managed secrets.
  * Invalid connection selections or disabled OLAP profiles now produce clear chart errors.

* **Documentation**
  * Updated Helm chart documentation with configuration paths, defaults, and enablement details.

* **Tests**
  * Added coverage for connection selection, secret handling, and worker integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->