### PR TITLE
feat(operator-wandb): split Weave migrator credentials [WB-36557]

### DIFF
--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
-digest: sha256:6a4d35030d930a8ad4f6a1ada246116749584e084a7a6f2b2f2f48de13e0c990
-generated: "2026-08-11T14:59:58.54023-07:00"
+  version: 0.12.8
+digest: sha256:541b57c62629d87b2005d19134e0fba306517057cc9bca65035ecb63b5f2d81d
+generated: "2026-09-02T16:15:46.187432-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,39 +82,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:1986ad265b0aaca94ee3286ce5b4f08e3841c9813bf22a16cc7ec97925d61a52
-generated: "2026-08-11T14:59:55.991901-07:00"
+digest: sha256:e3863561d5089939bc1851ea929bd60df3eb74b730552a944cbbc8e02f422c53
+generated: "2026-09-02T16:08:02.534496-05:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.8
+version: 0.44.9
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: console
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,20 +109,20 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: history-updater
     condition: history-updater.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: filestream
-    version: "0.12.7"
+    version: "0.12.8"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -243,10 +243,12 @@ rendering. The chart does not infer enrollment from either connection, so
 existing and bundled ClickHouse installations keep their current behavior.
 
 For a separate migration identity, enable
-`global.olap.weaveTrace.migrator` and provide its password through a
-Kubernetes `valueFrom` reference. Only the `weave-trace-migrate` init
+`global.olap.weaveTrace.migrator` and provide its user and password through
+Kubernetes `valueFrom` references. Only the `weave-trace-migrate` init
 container receives those credentials. Runtime Weave containers continue to
 use `global.olap.weaveTrace.user` and `global.olap.weaveTrace.password`.
+During A/B rotation, update the runtime and migrator password references to
+the matching slot in the same rollout.
 
 ### Example: Using External Secrets with MySQL/ClickHouse/SMTP
 

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -242,6 +242,12 @@ cutover. Selecting a disabled OLAP profile or an unknown source fails chart
 rendering. The chart does not infer enrollment from either connection, so
 existing and bundled ClickHouse installations keep their current behavior.
 
+For a separate migration identity, enable
+`global.olap.weaveTrace.migrator` and provide its password through a
+Kubernetes `valueFrom` reference. Only the `weave-trace-migrate` init
+container receives those credentials. Runtime Weave containers continue to
+use `global.olap.weaveTrace.user` and `global.olap.weaveTrace.password`.
+
 ### Example: Using External Secrets with MySQL/ClickHouse/SMTP
 
 For MySQL, ClickHouse, and SMTP, each field can be configured as either a simple value or a Kubernetes secret reference:

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -387,6 +387,12 @@ Global values will override any chart-specific values.
     {{- if not (hasKey $migrator.password "valueFrom") -}}
       {{- fail "global.olap.weaveTrace.migrator.password must use valueFrom" -}}
     {{- end -}}
+    {{- if not (kindIs "map" $migrator.user) -}}
+      {{- fail "global.olap.weaveTrace.migrator.user must use valueFrom" -}}
+    {{- end -}}
+    {{- if not (hasKey $migrator.user "valueFrom") -}}
+      {{- fail "global.olap.weaveTrace.migrator.user must use valueFrom" -}}
+    {{- end -}}
     {{- $envs := list -}}
     {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_USER" "value" $migrator.user) | fromYaml) -}}
     {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_PASS" "value" $migrator.password) | fromYaml) -}}

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -369,6 +369,31 @@ Global values will override any chart-specific values.
   {{- end }}
 {{- end -}}
 
+{{- define "wandb.weaveTraceClickhouseMigratorEnvs" -}}
+  {{- /*
+    The migration init container shares the selected Weave ClickHouse
+    connection, but may override its user and password with a dedicated
+    identity. Runtime containers continue to receive the standard Weave
+    credentials.
+  */ -}}
+  {{- $config := include "wandb.olapConfig" (dict "root" . "featureName" "weaveTrace") | fromYaml -}}
+  {{- $source := default "legacy" .Values.global.weaveTrace.clickhouseSource -}}
+  {{- $migrator := default (dict) $config.migrator -}}
+  {{- $migratorEnabled := default false $migrator.enabled -}}
+  {{- if and (eq $source "olap") $migratorEnabled -}}
+    {{- if not (kindIs "map" $migrator.password) -}}
+      {{- fail "global.olap.weaveTrace.migrator.password must use valueFrom" -}}
+    {{- end -}}
+    {{- if not (hasKey $migrator.password "valueFrom") -}}
+      {{- fail "global.olap.weaveTrace.migrator.password must use valueFrom" -}}
+    {{- end -}}
+    {{- $envs := list -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_USER" "value" $migrator.user) | fromYaml) -}}
+    {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_PASS" "value" $migrator.password) | fromYaml) -}}
+{{- toYaml $envs }}
+  {{- end -}}
+{{- end -}}
+
 {{- define "wandb.olapFeatureEnvs" -}}
   {{- /*
     Shared template for OLAP feature environment variables.

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -230,6 +230,26 @@ tests:
       - failedTemplate:
           errorMessage: global.olap.weaveTrace.migrator.password must use valueFrom
 
+  - it: rejects an inline migration user
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        migrator:
+          enabled: true
+          user: weave_migrator
+          password:
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-migrator-a
+                key: password
+    asserts:
+      - failedTemplate:
+          errorMessage: global.olap.weaveTrace.migrator.user must use valueFrom
+
   - it: keeps the legacy connection when the OLAP profile is only enabled
     template: charts/weave-trace/templates/deployment.yaml
     set:

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -126,6 +126,109 @@ tests:
               configMapKeyRef:
                 name: weave-clickhouse
                 key: replicated
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: weave-clickhouse
+                key: username
+
+  - it: gives only the migration init container its dedicated identity
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        user:
+          valueFrom:
+            configMapKeyRef:
+              name: clickhouse-weave
+              key: user
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-weave-a
+              key: password
+        migrator:
+          enabled: true
+          user:
+            valueFrom:
+              configMapKeyRef:
+                name: clickhouse-weave
+                key: migrator-user
+          password:
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-migrator-a
+                key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              configMapKeyRef:
+                name: clickhouse-weave
+                key: migrator-user
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-migrator-a
+                key: password
+      - notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              configMapKeyRef:
+                name: clickhouse-weave
+                key: user
+      - notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-a
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              configMapKeyRef:
+                name: clickhouse-weave
+                key: user
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-a
+                key: password
+
+  - it: rejects an inline migration password
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
+      global.olap.weaveTrace:
+        enabled: true
+        host: managed-clickhouse.example.com
+        migrator:
+          enabled: true
+          password: inline-password
+    asserts:
+      - failedTemplate:
+          errorMessage: global.olap.weaveTrace.migrator.password must use valueFrom
 
   - it: keeps the legacy connection when the OLAP profile is only enabled
     template: charts/weave-trace/templates/deployment.yaml

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -145,25 +145,25 @@ tests:
         host: managed-clickhouse.example.com
         user:
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: clickhouse-weave
-              key: user
+              key: username
         password:
           valueFrom:
             secretKeyRef:
-              name: clickhouse-weave-a
+              name: clickhouse-weave
               key: password
         migrator:
           enabled: true
           user:
             valueFrom:
-              configMapKeyRef:
-                name: clickhouse-weave
-                key: migrator-user
+              secretKeyRef:
+                name: clickhouse-weave-migrator
+                key: username
           password:
             valueFrom:
               secretKeyRef:
-                name: clickhouse-weave-migrator-a
+                name: clickhouse-weave-migrator
                 key: password
     asserts:
       - contains:
@@ -171,48 +171,48 @@ tests:
           content:
             name: WF_CLICKHOUSE_USER
             valueFrom:
-              configMapKeyRef:
-                name: clickhouse-weave
-                key: migrator-user
+              secretKeyRef:
+                name: clickhouse-weave-migrator
+                key: username
       - contains:
           path: spec.template.spec.initContainers[0].env
           content:
             name: WF_CLICKHOUSE_PASS
             valueFrom:
               secretKeyRef:
-                name: clickhouse-weave-migrator-a
+                name: clickhouse-weave-migrator
                 key: password
       - notContains:
           path: spec.template.spec.initContainers[0].env
           content:
             name: WF_CLICKHOUSE_USER
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: clickhouse-weave
-                key: user
+                key: username
       - notContains:
           path: spec.template.spec.initContainers[0].env
           content:
             name: WF_CLICKHOUSE_PASS
             valueFrom:
               secretKeyRef:
-                name: clickhouse-weave-a
+                name: clickhouse-weave
                 key: password
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: WF_CLICKHOUSE_USER
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: clickhouse-weave
-                key: user
+                key: username
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: WF_CLICKHOUSE_PASS
             valueFrom:
               secretKeyRef:
-                name: clickhouse-weave-a
+                name: clickhouse-weave
                 key: password
 
   - it: rejects an inline migration password
@@ -244,7 +244,7 @@ tests:
           password:
             valueFrom:
               secretKeyRef:
-                name: clickhouse-weave-migrator-a
+                name: clickhouse-weave-migrator
                 key: password
     asserts:
       - failedTemplate:

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -305,6 +305,12 @@ global:
       port: "8443"
       database: "weave_trace_db"
       replicated: false
+      # The migration init container can use a separate ClickHouse identity.
+      # Passwords must be supplied through a Kubernetes valueFrom reference.
+      migrator:
+        enabled: false
+        user: "weave_migrator"
+        password: {}
 
   #
   # FOR ADVANCED USERS:
@@ -3883,6 +3889,8 @@ weave-trace:
   initContainers:
     weave-trace-migrate:
       args: ["python", "migrator.py"]
+      envTpls:
+        - '{{ include "wandb.weaveTraceClickhouseMigratorEnvs" . }}'
       volumeMounts:
         - name: temp-dir
           mountPath: /tmp/

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -306,10 +306,10 @@ global:
       database: "weave_trace_db"
       replicated: false
       # The migration init container can use a separate ClickHouse identity.
-      # Passwords must be supplied through a Kubernetes valueFrom reference.
+      # Credentials must be supplied through Kubernetes valueFrom references.
       migrator:
         enabled: false
-        user: "weave_migrator"
+        user: {}
         password: {}
 
   #

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
+  version: 0.12.8
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.7
-digest: sha256:31d5aeb4b27d864b5238e142b54c7a95426c64d4c408afaadee643e6dcb7b78e
-generated: "2026-08-11T15:00:00.655789-07:00"
+  version: 0.12.8
+digest: sha256:3ff5b21b31f6b5cf3e36bde39eabcf427f3757133cd66ef4ce7c2784ffa90e1a
+generated: "2026-09-02T16:15:40.820323-05:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.6
+version: 1.4.7
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.7"
+    version: "0.12.8"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.7"
+    version: "0.12.8"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.7"
+    version: "0.12.8"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.7"
+    version: "0.12.8"
     repository: "file://../wandb-base"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.7
+version: 0.12.8
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/_containers.tpl
+++ b/charts/wandb-base/templates/_containers.tpl
@@ -49,7 +49,7 @@
         {{- end -}}
       {{- end -}}
 
-      {{- /* We prerender the envTpls and put them into an array for searching */ -}}
+      {{- /* Render shared and container-specific env templates. */ -}}
       {{- $envTpls := list }}
       {{- if $.root.Values.envTpls -}}
         {{- range $.root.Values.envTpls }}
@@ -57,7 +57,24 @@
         {{- end -}}
       {{- end -}}
 
-      {{- /* Iterate over the envvars rendered from envTpls, and remove any specified in env to avoid setElementOrder errors */ -}}
+      {{- $containerEnvTpls := list }}
+      {{- if $container.envTpls -}}
+        {{- range $container.envTpls }}
+          {{- $containerEnvTpls = concat $containerEnvTpls (tpl . $.root | fromYamlArray) -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- /* Container templates override shared templates by variable name. */ -}}
+      {{- range $containerEnvVar := $containerEnvTpls }}
+        {{- range $envVar := $envTpls }}
+          {{- if eq $containerEnvVar.name $envVar.name -}}
+            {{- $envTpls = without $envTpls $envVar -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $envTpls = concat $envTpls $containerEnvTpls -}}
+
+      {{- /* Explicit env values override all rendered env templates. */ -}}
       {{- range $index, $envVar := $envTpls }}
         {{- if hasKey $container.env $envVar.name -}}
           {{- $envTpls = without $envTpls $envVar -}}


### PR DESCRIPTION
## Summary

- add an opt-in `global.olap.weaveTrace.migrator` credential path
- override only `WF_CLICKHOUSE_USER` and `WF_CLICKHOUSE_PASS` in the
  `weave-trace-migrate` init container
- require both migrator fields to use Kubernetes `valueFrom` references
- keep runtime Weave containers on the standard Weave credential
- test the stable ESO Secret names produced by `wandb/deployments#858`

The matching `weave` and `weave_migrator` ClickHouse identities are provisioned
by [wandb/deployments#858](https://github.com/wandb/deployments/pull/858). ESO
materializes their GSM credentials as the stable `clickhouse-weave` and
`clickhouse-weave-migrator` Kubernetes Secrets.

During A/B rotation, Delivery Tooling publishes both new GSM versions, confirms
ESO synchronized both Kubernetes Secrets, and rolls the Weave workloads. The
runtime and migrator credentials move together even though their stable Secret
names do not change.

## Safety

- disabled by default
- active only when the explicit Weave OLAP source is selected
- legacy and bundled ClickHouse behavior is unchanged
- inline migrator usernames and passwords are rejected
- runtime and migration credential separation is covered by render tests

## Validation

- `python3 scripts/format_templates.py`
- `python3 -m unittest discover -s scripts/tests` — 16 passing
- `python3 scripts/check_template_maintainability.py`
- `helm lint charts/operator-wandb`
- `helm lint charts/wandb-base`
- `helm unittest charts/operator-wandb` — 75 passing
- operator-wandb snapshots with CI-pinned Helm 3.20.1 — passing
- wandb-base snapshots with CI-pinned Helm 3.20.1 — passing
- full render confirms runtime uses `clickhouse-weave` and only the migration
  init container uses `clickhouse-weave-migrator`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional, separate Kubernetes secret references for Weave Trace migration credentials.
  * Migration credentials are used only by the migration container; runtime containers continue using standard credentials.
  * Added support for container-specific environment variable configuration.

* **Bug Fixes**
  * Helm rendering now reports clear errors when migration credentials are not provided through supported secret references.

* **Documentation**
  * Documented credential configuration and guidance for coordinating credentials during A/B password rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
