### PR TITLE
fix(operator-wandb): declare nginx log source on the frontend pods

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.7
+version: 0.44.8
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -2610,6 +2610,8 @@ history-reader:
 
 frontend:
   install: false
+  podAnnotations:
+    ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
   podSecurityContext:
     runAsUser: 101
   image:

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -6090,6 +6090,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -4445,6 +4445,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -5161,6 +5161,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -5139,6 +5139,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -5139,6 +5139,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -4440,6 +4440,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -5140,6 +5140,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -5139,6 +5139,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -5189,6 +5189,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -5751,6 +5751,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -4384,6 +4384,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
+++ b/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
@@ -5820,6 +5820,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -5786,6 +5786,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -5195,6 +5195,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -4087,6 +4087,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -4745,6 +4745,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -5139,6 +5139,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -5614,6 +5614,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -5922,6 +5922,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -5641,6 +5641,8 @@ spec:
       app.kubernetes.io/instance: chartsnap
   template:
     metadata:
+      annotations:
+        ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
       labels:
         helm.sh/chart: '###CHART_VERSION###'
         app.kubernetes.io/name: frontend


### PR DESCRIPTION
## What

Adds one autodiscovery annotation to the frontend pods so their nginx logs arrive in Datadog as
`source:nginx` / `service:frontend`:

```yaml
frontend:
  podAnnotations:
    ad.datadoghq.com/frontend.logs: '[{"source": "nginx", "service": "frontend"}]'
```

With `source:nginx`, Datadog's built-in Nginx integration pipeline parses these logs — grok, `level`
extraction, status remapping — so nginx `[warn]` lines stop being classified as errors. Chart
version bumped 0.44.7 → 0.44.8; the snapshot files that render the frontend pod gain exactly these
two lines and nothing else.

## Why

Without an `ad.datadoghq.com` logs annotation, the Datadog Agent infers a container's log source
from its short image name, so these logs arrive as `source:frontend-nginx` — a name that matches no
integration pipeline, leaving the nginx error stream unparsed. The same inference sets the
log-level `service`, overriding the intended `frontend`. Datadog's convention is that `source`
names the technology (which activates integration pipelines and out-of-the-box assets) and
`service` names the app.

Fixing this in pipeline configuration instead does not work: Datadog's Nginx integration pipeline
is read-only (updates are accepted and silently discarded), and cloning its processors into a
custom pipeline would drift whenever Datadog updates the original. Declaring the source at the pod
is the supported mechanism.

## Rollout

Each install picks the annotation up when its operator applies chart ≥ 0.44.8 and the frontend pods
restart. Pods not yet restarted keep emitting the old source and stay unparsed — exactly today's
behavior, so there is no regression window.

Note the effect is deliberately narrow: the frontend's access logs are already emitted as
structured JSON, which the Agent parses before pipelines run, so they are unaffected. Only the
raw-text nginx error-stream lines gain parsing (and correct `warn` severity).

## Testing

`./snapshots.sh run` and `helm unittest` pass locally on CI's toolchain (helm 3.20.1,
cascade-built dependencies with the stakater/prometheus repos). The regenerated snapshots' entire
diff is the two annotation lines across the test configs that install the frontend.
