### PR TITLE
fix(operator-wandb): anchor next-gen history flag

### DIFF
--- a/charts/operator-wandb/tests/next_gen_history_store_test.yaml
+++ b/charts/operator-wandb/tests/next_gen_history_store_test.yaml
@@ -8,10 +8,11 @@ release:
   namespace: default
 
 tests:
-  - it: deploys the history updater with full tracing when enabled
+  - it: deploys the history updater with full tracing when the global flag is enabled
     template: charts/history-updater/templates/deployment.yaml
     set:
       global.nextGenHistoryStore: true
+      history-updater.install: false
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -11,7 +11,7 @@
 # The global properties are used to configure multiple charts at once.
 global:
   # Enables the next-generation history store and its supporting workloads.
-  nextGenHistoryStore: false
+  nextGenHistoryStore: &nextGenHistoryStore false
 
   # This should be the fqdn of where your users will be accessing the instance.
   host: "http://localhost:8080"
@@ -297,7 +297,8 @@ global:
       enabled: false
       database: "runs"
     history:
-      # Enabled by global.nextGenHistoryStore.
+      # Anchored to global.nextGenHistoryStore; that flag is authoritative.
+      enabled: *nextGenHistoryStore
       database: "history"
       params:
         max_open_conns: 300


### PR DESCRIPTION
## Summary
- anchor the history OLAP enabled default to global.nextGenHistoryStore
- keep global.nextGenHistoryStore authoritative at render time and for the history-updater dependency
- verify the legacy history-updater.install value cannot override the global flag

## Validation
- helm lint ./charts/operator-wandb/ --strict
- helm unittest ./charts/operator-wandb/ (77 tests passed)