### PR TITLE
chore: Update gcloud emulators used in CI tests

### DIFF
--- a/test-configs/bigtable/values.yaml
+++ b/test-configs/bigtable/values.yaml
@@ -2,7 +2,7 @@ containers:
   bigtable-emulator:
     image:
       repository: "gcr.io/google.com/cloudsdktool/google-cloud-cli"
-      tag: "520.0.0-emulators"
+      tag: "583.0.0-emulators"
     args:
       - "gcloud"
       - "beta"

--- a/test-configs/pubsub/values.yaml
+++ b/test-configs/pubsub/values.yaml
@@ -2,7 +2,7 @@ containers:
   pubsub-emulator:
     image:
       repository: "gcr.io/google.com/cloudsdktool/google-cloud-cli"
-      tag: "520.0.0-emulators"
+      tag: "583.0.0-emulators"
     args:
       - "gcloud"
       - "beta"


### PR DESCRIPTION
It looks like the old images are not published anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bigtable emulator used in testing to version 583.0.0.
  * Updated the Pub/Sub emulator used in testing to version 583.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->