### PR TITLE
fix(operator-wandb): replace OLAP value references atomically [WB-36557]

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.10
+version: 0.44.11
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_olap.tpl
+++ b/charts/operator-wandb/templates/_olap.tpl
@@ -6,13 +6,20 @@ Usage:
 
 Returns: YAML string of the merged config map.
 
-Sprig `merge` deep-merges nested maps (like params). Feature keys win,
-missing keys fall through from default.
+Feature values replace defaults as complete values, including valueFrom maps.
+The params map is the exception: its nested keys are merged so a feature can
+override one parameter while inheriting the others.
 */}}
 {{- define "wandb.olapConfig" -}}
   {{- $default := deepCopy (default (dict) (index .root.Values.global.olap "default")) -}}
   {{- $feature := deepCopy (default (dict) (index .root.Values.global.olap .featureName)) -}}
-{{- toYaml (merge $feature $default) -}}
+  {{- $config := merge (deepCopy $feature) $default -}}
+  {{- range $key, $value := $feature -}}
+    {{- if ne $key "params" -}}
+      {{- $_ := set $config $key (deepCopy $value) -}}
+    {{- end -}}
+  {{- end -}}
+{{- toYaml $config -}}
 {{- end -}}
 
 {{/*

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -135,6 +135,52 @@ tests:
                 name: weave-clickhouse
                 key: username
 
+  - it: replaces default value references with Weave-specific references
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      weave-trace.install: true
+      global.weaveTrace.clickhouseSource: olap
+      global.olap.default:
+        user:
+          valueFrom:
+            configMapKeyRef:
+              name: clickhouse-default
+              key: user
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-default
+              key: password
+      global.olap.weaveTrace:
+        enabled: true
+        user:
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-weave
+              key: username
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-weave
+              key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: password
+
   - it: gives only the migration init container its dedicated identity
     template: charts/weave-trace/templates/deployment.yaml
     set:


### PR DESCRIPTION
## Summary

- replace feature-level OLAP values as complete values instead of deep-merging Kubernetes `valueFrom` selectors
- preserve deep-merge behavior for the `params` map
- add a regression test covering a default ConfigMap user overridden by a Weave Secret user
- bump `operator-wandb` to `0.44.11`

## Why

Managed spec supplies the shared OLAP user through a `configMapKeyRef` and the Weave profile overrides it with a `secretKeyRef`. The existing recursive merge produces one invalid `valueFrom` containing both selectors. Kubernetes requires exactly one source.

This keeps the shared default credential intact for other OLAP consumers while allowing Weave to use its least-privilege runtime identity.

## Validation

- `python3 scripts/format_templates.py`
- `python3 -m unittest discover -s scripts/tests`
- `python3 scripts/check_template_maintainability.py`
- `helm lint charts/operator-wandb`
- `helm unittest charts/operator-wandb` (79 tests)
- `./snapshots.sh run` with Helm `3.20.1` (all snapshots matched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OLAP configuration overrides so feature-specific settings replace defaults as intended.
  * Preserved inherited parameter values while allowing individual parameters to be customized.
  * Fixed Weave trace ClickHouse credentials to use Weave-specific references when configured, instead of default OLAP references.

* **Chores**
  * Updated the operator-wandb Helm chart version to 0.44.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->