### PR TITLE
fix(operator-wandb): relax glue liveness probe period

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.16
+version: 0.44.17
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -2825,7 +2825,7 @@ glue:
           path: /healthz
           port: 8080
         initialDelaySeconds: 30
-        periodSeconds: 1
+        periodSeconds: 10
         timeoutSeconds: 1
         successThreshold: 1
         failureThreshold: 3

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -6496,7 +6496,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -4807,7 +4807,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -5523,7 +5523,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -5501,7 +5501,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -5501,7 +5501,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -4802,7 +4802,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -5502,7 +5502,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -5018,7 +5018,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -5501,7 +5501,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -5551,7 +5551,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -6420,7 +6420,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -4778,7 +4778,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
+++ b/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
@@ -6202,7 +6202,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -6168,7 +6168,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -5557,7 +5557,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -5173,7 +5173,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -5317,7 +5317,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -5317,7 +5317,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-tolerations-and-selectors.snap
@@ -4933,7 +4933,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -5501,7 +5501,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -6002,7 +6002,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -6284,7 +6284,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -6003,7 +6003,7 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         resources:


### PR DESCRIPTION
## What

Relaxes the `glue` container's liveness probe from `periodSeconds: 1` to `10` in `charts/operator-wandb/values.yaml`, and regenerates the 23 snapshots that render a glue Deployment. Chart version goes to `0.44.13`.

Nothing else about the probe changes: path, port, `initialDelaySeconds`, `timeoutSeconds`, `successThreshold`, and `failureThreshold` are untouched.

## Why

`/healthz` on glue reports the scheduler's heartbeat age, which moves on a 30s cadence, so polling it once a second only added load.

It also made the probe fragile. Three consecutive 1s timeouts restarted the pod within 3s; at a 10s period those same three failures have to land across 30s, so brief CPU starvation is much less likely to restart what is a singleton scheduler.

Companion to wandb/core#53429, which makes `/healthz` fail after 300s without a scheduler heartbeat instead of always returning 200. Until that binary ships this probe is still a no-op, so this can land first and is safe on its own.

## Testing

- `./snapshots.sh run`: `PASS All snapshots matched`, 0 failures.
- `helm unittest ./charts/operator-wandb`: 79 tests, 7 suites, all pass.
- `ct lint --target-branch main`: `All charts linted successfully`, version bump accepted.
- `scripts/format_templates.py` (helmfmt 0.5.0, the version pinned in `lint.yaml`), `python3 -m unittest discover -s scripts/tests` (16 tests), and `scripts/check_template_maintainability.py`: all clean, no files modified.

Snapshots were verified rather than trusted: every one of the 23 changed lines was confirmed to sit inside a `kind: Deployment`, `name: chartsnap-glue` resource, so no other service's probe moved.

Note for anyone regenerating snapshots: `./snapshots.sh update` on helm 3.19 also deletes 52 unrelated `seLinuxOptions: null` lines. That drift reproduces on an unmodified tree, so it is pre-existing and is deliberately excluded here. It does not appear under helm 3.20.1, the version `test-operator-wandb.yaml` pins, and all snapshot tests pass on that version. Pinning helm locally to match CI would avoid the trap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the glue container’s liveness check interval to improve stability.

* **Chores**
  * Updated the operator chart version and refreshed chart component versions.
  * Improved configuration value propagation for ClickHouse and Weave Trace settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->