### PR TITLE
fix(azure): separate storage identity rollout from account consolidation

### DIFF
--- a/charts/lumen/Chart.lock
+++ b/charts/lumen/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
-digest: sha256:541b57c62629d87b2005d19134e0fba306517057cc9bca65035ecb63b5f2d81d
-generated: "2026-09-02T16:15:46.187432-05:00"
+  version: 0.12.9
+digest: sha256:eeffb57af802af570e31c8a3761038bf7d32bf0a87fe8af50e685ab7d4aed1b0
+generated: "2026-09-08T14:45:47.672818-05:00"

--- a/charts/lumen/Chart.yaml
+++ b/charts/lumen/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lumen
 description: A Helm chart for deploying the W&B Lumen processor and notebook
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: 1.0.0
 
 maintainers:
@@ -13,9 +13,9 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: processor
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
   - name: wandb-base
     alias: notebook
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base

--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -1,43 +1,43 @@
 dependencies:
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: mysql
   repository: file://charts/mysql
   version: 0.1.0
@@ -61,19 +61,19 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: stackdriver
   repository: file://charts/stackdriver
   version: 0.1.0
@@ -82,39 +82,39 @@ dependencies:
   version: 0.1.0
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 1.3.0
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:9a3c6c4b1aa211aeb20b347e223d3fb43702f4b9d8b923c8d11b3f07f712d52d
-generated: "2026-09-03T13:34:04.189488-05:00"
+digest: sha256:ed7f78a8a6734b804a09ffadba6fb241ca0cb9ba069ad001e51a5a0795da045b
+generated: "2026-09-08T14:40:52.894753-05:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.12
+version: 0.44.13
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -14,67 +14,67 @@ maintainers:
 dependencies:
   - name: wandb-base
     alias: app
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: app.install
   - name: wandb-base
     alias: appRenamePreHook
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: appRenamePreHook.install
   - name: wandb-base
     alias: appRenamePostHook
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: appRenamePostHook.install
   - name: wandb-base
     alias: api
     condition: global.api.enabled
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: console
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: console.install
   - name: wandb-base
     alias: weave
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: weave.install
   - name: wandb-base
     alias: weave-trace
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: weave-trace.install
   - name: wandb-base
     alias: weave-trace-worker
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: weave-trace-worker.install
   - name: wandb-base
     alias: weave-evaluate-model-worker
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: weave-evaluate-model-worker.install
   - name: wandb-base
     alias: weave-trace-agent-scoring-worker
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: weave-trace-agent-scoring-worker.install
   - name: wandb-base
     alias: executor
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: executor.install
   - name: wandb-base
     alias: parquet
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: parquet.install
   - name: wandb-base
     alias: parquet-metadata-cache
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: parquet-metadata-cache.install
   - name: mysql
@@ -109,20 +109,20 @@ dependencies:
     alias: flat-run-fields-updater
     condition: flat-run-fields-updater.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: history-updater
     condition: global.olap.history.enabled,history-updater.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: run-store-accelerator-run-updater
     condition: run-store-accelerator-run-updater.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: filestream
-    version: "0.12.8"
+    version: "0.12.9"
     repository: file://../wandb-base
     condition: filestream.install
   - name: wandb-base
@@ -142,52 +142,52 @@ dependencies:
     alias: frontend
     condition: frontend.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: filemeta
     condition: filemeta.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: anaconda2
     condition: anaconda2.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: internalSignerPreHook
     condition: global.localService.bypass
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: metric-observer
     condition: metric-observer.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: glue
     condition: global.glue.enabled
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: settingsMigrationJob
     condition: settingsMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: clickhouseMigrationJob
     condition: clickhouseMigrationJob.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: mcp-server
     condition: mcp-server.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: wandb-base
     alias: lumen-agent
     condition: lumen-agent.install
     repository: file://../wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
   - name: reloader
     condition: reloader.install
     version: 1.3.0

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -120,6 +120,13 @@ rollout, set `global.azureStorageIdentity.serviceAccount.mode: component` to kee
 the existing Kubernetes service accounts. Consolidation with `grouped` is a separate
 migration.
 
+Inventory optional storage consumers and workloads left over from older chart
+releases. If parquet uses the metadata cache, keep
+`parquet-metadata-cache.install: true` and configure its service account for Azure
+identity too. It can reuse the parquet account when their permissions match.
+Check that every replacement pod is ready and every old replica has terminated;
+an available old pod can hide a replacement that is failing to start.
+
 Keep the existing storage key secret during validation so removing the identity
 opt-in restores key authentication. Verify actual run-file and artifact uploads
 and downloads, and check that server-issued SAS URLs use the intended managed

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -105,6 +105,27 @@ global:
   priorityClassName: ""
 ```
 
+### Azure managed storage workload identity
+
+Before setting `global.azureStorageIdentity`, deploy a server build containing
+[instance-level Azure identity support and blob-scoped SAS signing](https://github.com/wandb/core/pull/48160).
+Check the images running in every storage-consuming workload, including component
+image overrides. A chart upgrade or a projected Azure token does not make an older
+server use workload identity; it can still sign requests with an empty account key
+after the chart removes `AZURE_STORAGE_KEY`.
+
+Provision the instance managed identity, storage permissions, and federated
+credentials through Terraform before enabling the chart setting. For an initial
+rollout, set `global.azureStorageIdentity.serviceAccount.mode: component` to keep
+the existing Kubernetes service accounts. Consolidation with `grouped` is a separate
+migration.
+
+Keep the existing storage key secret during validation so removing the identity
+opt-in restores key authentication. Verify actual run-file and artifact uploads
+and downloads, and check that server-issued SAS URLs use the intended managed
+identity with blob scope (`sr=b`). Pod readiness alone does not validate storage
+authentication.
+
 ### Global Pod Scheduling
 
 The chart supports global `nodeSelector`, `tolerations`, and `priorityClassName` configuration that applies to **ALL components** (W&B services, databases, monitoring, etc.). This provides centralized control over pod scheduling and priority across your entire W&B deployment.

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -120,6 +120,14 @@ rollout, set `global.azureStorageIdentity.serviceAccount.mode: component` to kee
 the existing Kubernetes service accounts. Consolidation with `grouped` is a separate
 migration.
 
+Set `global.defaultBucket.azureAuthMethod: workloadIdentity` to select the
+deployment identity for the managed bucket. Set it to `accessKey` to use the
+storage key while keeping the identity available. When omitted, the chart retains
+the previous behavior: a configured global or legacy default-bucket identity
+selects workload identity; otherwise it uses the key. A named `global.bucket`
+overrides the complete default bucket configuration, including authentication;
+its own `azureAuthMethod` selects the method independently.
+
 Inventory optional storage consumers and workloads left over from older chart
 releases. If parquet uses the metadata cache, keep
 `parquet-metadata-cache.install: true` and configure its service account for Azure
@@ -127,8 +135,8 @@ identity too. It can reuse the parquet account when their permissions match.
 Check that every replacement pod is ready and every old replica has terminated;
 an available old pod can hide a replacement that is failing to start.
 
-Keep the existing storage key secret during validation so removing the identity
-opt-in restores key authentication. Verify actual run-file and artifact uploads
+Retain the storage key securely during validation so selecting `accessKey` and
+supplying the key restores key authentication. Verify actual run-file and artifact uploads
 and downloads, and check that server-issued SAS URLs use the intended managed
 identity with blob scope (`sr=b`). Pod readiness alone does not validate storage
 authentication.

--- a/charts/operator-wandb/charts/bufstream/templates/_helpers.tpl
+++ b/charts/operator-wandb/charts/bufstream/templates/_helpers.tpl
@@ -27,6 +27,14 @@ the component account.
 */}}
 {{- define "bufstream.azureStorageServiceAccountEnabled" -}}
   {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+  {{- $mode := default "shared" $serviceAccount.mode -}}
+  {{- /* Bufstream has cluster-scoped node permissions; retain its account. */ -}}
+{{- and (include "bufstream.azureStorageIdentityEnabled" . | trim | eq "true") (eq $mode "shared") -}}
+{{- end -}}
+
+{{- define "bufstream.azureStorageIdentityEnabled" -}}
+  {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
   {{- $globalConfigured := and (not (empty $identity.tenantId)) (not (empty $identity.clientId)) -}}
   {{- $bucket := default (dict) .Values.global.bucket -}}
   {{- $hasCustomerBucket := not (empty $bucket.name) -}}

--- a/charts/operator-wandb/charts/bufstream/templates/deployment.yaml
+++ b/charts/operator-wandb/charts/bufstream/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: {{ .Values.bufstream.deployment.kind | default "Deployment" }}
 {{- $podLabels := deepCopy (default (dict) .Values.bufstream.deployment.podLabels) }}
-{{- if include "bufstream.azureStorageServiceAccountEnabled" . | trim | eq "true" }}
+{{- if include "bufstream.azureStorageIdentityEnabled" . | trim | eq "true" }}
   {{- $_ := set $podLabels "azure.workload.identity/use" "true" }}
 {{- end }}
 metadata:

--- a/charts/operator-wandb/charts/bufstream/templates/service-account.yaml
+++ b/charts/operator-wandb/charts/bufstream/templates/service-account.yaml
@@ -1,4 +1,13 @@
 {{- if and .Values.bufstream.serviceAccount.create (not (include "bufstream.azureStorageServiceAccountEnabled" . | trim | eq "true")) }}
+  {{- $annotations := deepCopy (default (dict) .Values.bufstream.serviceAccount.annotations) -}}
+  {{- if include "bufstream.azureStorageIdentityEnabled" . | trim | eq "true" -}}
+    {{- $identity := .Values.global.azureStorageIdentity -}}
+    {{- if kindIs "string" $identity.clientId -}}
+      {{- $_ := set $annotations "azure.workload.identity/client-id" $identity.clientId -}}
+    {{- else if not (hasKey $annotations "azure.workload.identity/client-id") -}}
+      {{- fail "Bufstream requires a literal azure.workload.identity/client-id annotation when Azure clientId is a reference" -}}
+    {{- end -}}
+  {{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,7 +15,7 @@ metadata:
   namespace: {{ include "bufstream.namespace" . }}
   labels:
     {{- include "bufstream.labels" . | nindent 4 }}
-  {{- with .Values.bufstream.serviceAccount.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -28,7 +28,11 @@ key path unless they explicitly select workload identity.
   {{- $clientId := default "" $bucket.azureClientId -}}
   {{- $globalConfigured := and (not (empty $globalTenantId)) (not (empty $globalClientId)) -}}
   {{- $bucketIdentityConfigured := and (not (empty $tenantId)) (not (empty $clientId)) -}}
-  {{- $authMethod := default "" .Values.global.bucket.azureAuthMethod -}}
+  {{- $authMethod := default "" $bucket.azureAuthMethod -}}
+  {{- $bucketConfigPath := "global.defaultBucket" -}}
+  {{- if $hasCustomerBucket -}}
+    {{- $bucketConfigPath = "global.bucket" -}}
+  {{- end -}}
   {{- if ne (empty $globalTenantId) (empty $globalClientId) -}}
     {{- fail "global.azureStorageIdentity.tenantId and clientId must be provided together" -}}
   {{- end -}}
@@ -36,17 +40,17 @@ key path unless they explicitly select workload identity.
     {{- fail "Azure bucket azureTenantId and azureClientId must be provided together" -}}
   {{- end -}}
   {{- if and (not (empty $authMethod)) (not (has $authMethod (list "accessKey" "workloadIdentity"))) -}}
-    {{- fail "global.bucket.azureAuthMethod must be accessKey or workloadIdentity" -}}
+    {{- fail (printf "%s.azureAuthMethod must be accessKey or workloadIdentity" $bucketConfigPath) -}}
   {{- end -}}
   {{- $enabled := false -}}
-  {{- if and $hasCustomerBucket (eq $authMethod "workloadIdentity") -}}
+  {{- if and (eq $bucket.provider "az") (eq $authMethod "workloadIdentity") -}}
     {{- if not $globalConfigured -}}
-      {{- fail "global.azureStorageIdentity.tenantId and clientId are required when global.bucket.azureAuthMethod is workloadIdentity" -}}
+      {{- fail (printf "global.azureStorageIdentity.tenantId and clientId are required when %s.azureAuthMethod is workloadIdentity" $bucketConfigPath) -}}
     {{- end -}}
     {{- $tenantId = $globalTenantId -}}
     {{- $clientId = $globalClientId -}}
     {{- $enabled = true -}}
-  {{- else if and $hasCustomerBucket (eq $authMethod "accessKey") -}}
+  {{- else if eq $authMethod "accessKey" -}}
     {{- $enabled = false -}}
   {{- else if and $hasCustomerBucket (eq $bucket.provider "az") $bucketIdentityConfigured -}}
     {{- /* Backward compatibility for existing bucket-scoped identity values. */ -}}
@@ -147,6 +151,7 @@ templates/weave-trace-serviceaccount.yaml. Must stay identical to
   {{- $secretKey := "" -}}
   {{- $azureTenantId := "" -}}
   {{- $azureClientId := "" -}}
+  {{- $azureAuthMethod := "" -}}
   {{- if .Values.global.bucket.name -}}
     {{- $provider = .Values.global.bucket.provider -}}
     {{- $path = .Values.global.bucket.path -}}
@@ -154,6 +159,7 @@ templates/weave-trace-serviceaccount.yaml. Must stay identical to
     {{- $secretKey = default "" .Values.global.bucket.secretKey -}}
     {{- $azureTenantId = default "" .Values.global.bucket.azureTenantId -}}
     {{- $azureClientId = default "" .Values.global.bucket.azureClientId -}}
+    {{- $azureAuthMethod = default "" .Values.global.bucket.azureAuthMethod -}}
 name: {{ .Values.global.bucket.name }}
 region: {{ .Values.global.bucket.region }}
 kmsKey: {{ .Values.global.bucket.kmsKey }}
@@ -164,6 +170,7 @@ kmsKey: {{ .Values.global.bucket.kmsKey }}
     {{- $secretKey = default "" .Values.global.defaultBucket.secretKey -}}
     {{- $azureTenantId = default "" .Values.global.defaultBucket.azureTenantId -}}
     {{- $azureClientId = default "" .Values.global.defaultBucket.azureClientId -}}
+    {{- $azureAuthMethod = default "" .Values.global.defaultBucket.azureAuthMethod -}}
 name: {{ .Values.global.defaultBucket.name }}
 region: {{ .Values.global.defaultBucket.region }}
 kmsKey: {{ .Values.global.defaultBucket.kmsKey }}
@@ -174,6 +181,7 @@ accessKey: {{ $accessKey }}
 secretKey: {{ $secretKey }}
 azureTenantId: {{ $azureTenantId | toJson }}
 azureClientId: {{ $azureClientId | toJson }}
+azureAuthMethod: {{ $azureAuthMethod | toJson }}
 accessKeyName: {{ .Values.global.bucket.secret.accessKeyName }}
 secretKeyName: {{ .Values.global.bucket.secret.secretKeyName }}
 secretName: {{ include "wandb.bucket.secret" . }}

--- a/charts/operator-wandb/templates/_bucket.tpl
+++ b/charts/operator-wandb/templates/_bucket.tpl
@@ -79,9 +79,14 @@ Legacy bucket-scoped identities deliberately retain their component accounts.
 {{- define "wandb.azureStorageServiceAccountEnabled" -}}
   {{- $identity := include "wandb.azureStorageIdentity" . | fromYaml -}}
   {{- $globalIdentity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $serviceAccount := default (dict) $globalIdentity.serviceAccount -}}
+  {{- $mode := default "shared" $serviceAccount.mode -}}
+  {{- if not (has $mode (list "shared" "component" "grouped")) -}}
+    {{- fail "global.azureStorageIdentity.serviceAccount.mode must be shared, component, or grouped" -}}
+  {{- end -}}
   {{- $globalConfigured := and (not (empty $globalIdentity.tenantId)) (not (empty $globalIdentity.clientId)) -}}
   {{- $weaveUsesDefaultBucket := include "wandb.weaveTraceUsesAzureWorkloadIdentity" . | trim | eq "true" -}}
-{{- and $globalConfigured (or $identity.enabled $weaveUsesDefaultBucket) -}}
+{{- and $globalConfigured (or $identity.enabled $weaveUsesDefaultBucket) (ne $mode "component") -}}
 {{- end }}
 
 {{- define "wandb.azureStorageServiceAccountName" -}}

--- a/charts/operator-wandb/tests/azure_storage_auth_test.yaml
+++ b/charts/operator-wandb/tests/azure_storage_auth_test.yaml
@@ -5,6 +5,9 @@ templates:
   - charts/app/templates/deployment.yaml
   - charts/app/templates/serviceaccount.yaml
   - charts/app/templates/rolebinding.yaml
+  - charts/console/templates/deployment.yaml
+  - charts/console/templates/rolebinding.yaml
+  - charts/parquet/templates/deployment.yaml
   - charts/weave-trace/templates/deployment.yaml
   - charts/bufstream/templates/deployment.yaml
   - charts/bufstream/templates/service-account.yaml
@@ -588,3 +591,397 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: externally-created-bucket-access
+
+  - it: keeps app on the correct account in component mode
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-app
+
+  - it: keeps console on the correct account in component mode
+    template: charts/console/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-console
+
+  - it: keeps parquet on the correct account in component mode
+    template: charts/parquet/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-parquet
+
+  - it: keeps weave-trace on the correct account in component mode
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global:
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: true
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-weave-trace
+
+  - it: keeps Console cluster permissions separate in component mode
+    template: charts/console/templates/rolebinding.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: chartsnap-console
+
+  - it: keeps app on the correct account in grouped mode
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-app
+
+  - it: keeps console on the correct account in grouped mode
+    template: charts/console/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-console
+
+  - it: keeps parquet on the correct account in grouped mode
+    template: charts/parquet/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: wandb-bucket-access
+
+  - it: keeps weave-trace on the correct account in grouped mode
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global:
+        weave-trace:
+          fileStorage:
+            useDefaultBucket: true
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+      weave-trace:
+        install: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-weave-trace
+
+  - it: keeps Console cluster permissions separate in grouped mode
+    template: charts/console/templates/rolebinding.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: chartsnap-console
+
+  - it: allows prefixed internal Azure WIF without enabling Weave file storage
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+
+  - it: preserves legacy BYOB federation subjects during grouped internal WIF
+    template: charts/app/templates/deployment.yaml
+    set:
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container/prefix
+          accessKey: stale-managed-key
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+        bucket:
+          provider: az
+          name: customer-storage
+          path: customer-container/prefix
+          azureTenantId: legacy-tenant
+          azureClientId: legacy-client
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: chartsnap-app
+
+  - it: preserves the Bufstream identity and node-reader isolation in component mode for deployment.yaml
+    template: charts/bufstream/templates/deployment.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: bufstream-service-account
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+
+  - it: preserves the Bufstream identity and node-reader isolation in component mode for service-account.yaml
+    template: charts/bufstream/templates/service-account.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+    asserts:
+      - equal:
+          path: metadata.name
+          value: bufstream-service-account
+      - equal:
+          path: metadata.annotations["azure.workload.identity/client-id"]
+          value: client-id
+
+  - it: preserves the Bufstream identity and node-reader isolation in component mode for cluster-role-bind.yaml
+    template: charts/bufstream/templates/cluster-role-bind.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: component
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: bufstream-service-account
+
+  - it: preserves the Bufstream identity and node-reader isolation in grouped mode for deployment.yaml
+    template: charts/bufstream/templates/deployment.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: bufstream-service-account
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+
+  - it: preserves the Bufstream identity and node-reader isolation in grouped mode for service-account.yaml
+    template: charts/bufstream/templates/service-account.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+    asserts:
+      - equal:
+          path: metadata.name
+          value: bufstream-service-account
+      - equal:
+          path: metadata.annotations["azure.workload.identity/client-id"]
+          value: client-id
+
+  - it: preserves the Bufstream identity and node-reader isolation in grouped mode for cluster-role-bind.yaml
+    template: charts/bufstream/templates/cluster-role-bind.yaml
+    set:
+      bufstream:
+        install: true
+        discoverZoneFromNode: true
+      global:
+        defaultBucket:
+          provider: az
+          name: managed-storage-account
+          path: managed-container
+        azureStorageIdentity:
+          tenantId: tenant-id
+          clientId: client-id
+          serviceAccount:
+            mode: grouped
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: bufstream-service-account

--- a/charts/operator-wandb/tests/default_bucket_azure_auth_test.yaml
+++ b/charts/operator-wandb/tests/default_bucket_azure_auth_test.yaml
@@ -1,0 +1,164 @@
+suite: Default Azure bucket authentication selection
+templates:
+  - templates/bucket.yaml
+  - charts/app/templates/deployment.yaml
+release:
+  name: chartsnap
+set:
+  global:
+    defaultBucket:
+      provider: az
+      name: managed-account
+      path: managed-container
+      accessKey: managed-key
+    azureStorageIdentity:
+      tenantId: tenant-id
+      clientId: client-id
+      serviceAccount:
+        mode: component
+
+tests:
+  - it: renders the default key when accessKey is selected with identity available
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.defaultBucket.azureAuthMethod: accessKey
+    asserts:
+      - equal:
+          path: data.ACCESS_KEY
+          value: bWFuYWdlZC1rZXk=
+
+  - it: injects the default key while retaining workload identity token injection
+    template: charts/app/templates/deployment.yaml
+    set:
+      global.defaultBucket.azureAuthMethod: accessKey
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: chartsnap-bucket
+                key: ACCESS_KEY
+                optional: true
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_CLIENT_ID
+          any: true
+
+  - it: suppresses the default key when workloadIdentity is explicitly selected
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.defaultBucket.azureAuthMethod: workloadIdentity
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+
+  - it: passes deployment identity credentials when explicitly selected
+    template: charts/app/templates/deployment.yaml
+    set:
+      global.defaultBucket.azureAuthMethod: workloadIdentity
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_CLIENT_ID
+            value: client-id
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AZURE_STORAGE_KEY
+          any: true
+
+  - it: preserves identity inference when the default selector is omitted
+    template: templates/bucket.yaml
+    documentIndex: 1
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+
+  - it: preserves default key authentication without a configured identity
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.azureStorageIdentity: null
+    asserts:
+      - equal:
+          path: data.ACCESS_KEY
+          value: bWFuYWdlZC1rZXk=
+
+  - it: does not inherit default workload identity into an implicit key BYOB bucket
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.defaultBucket.azureAuthMethod: workloadIdentity
+      global.bucket:
+        provider: az
+        name: customer-account
+        path: customer-container
+        accessKey: customer-key
+    asserts:
+      - equal:
+          path: data.ACCESS_KEY
+          value: Y3VzdG9tZXIta2V5
+
+  - it: allows workload identity BYOB while the default bucket uses a key
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.defaultBucket.azureAuthMethod: accessKey
+      global.bucket:
+        provider: az
+        name: customer-account
+        path: customer-container
+        azureAuthMethod: workloadIdentity
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+
+  - it: ignores the bucket selector without a named bucket override
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.defaultBucket.azureAuthMethod: workloadIdentity
+      global.bucket.azureAuthMethod: accessKey
+    asserts:
+      - notExists:
+          path: data.ACCESS_KEY
+
+  - it: permits explicit key auth over a legacy default identity
+    template: templates/bucket.yaml
+    documentIndex: 1
+    set:
+      global.defaultBucket.azureAuthMethod: accessKey
+      global.defaultBucket.azureTenantId: legacy-tenant
+      global.defaultBucket.azureClientId: legacy-client
+    asserts:
+      - equal:
+          path: data.ACCESS_KEY
+          value: bWFuYWdlZC1rZXk=
+
+  - it: rejects an invalid default authentication method
+    template: charts/app/templates/deployment.yaml
+    set:
+      global.defaultBucket.azureAuthMethod: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: global.defaultBucket.azureAuthMethod must be accessKey or workloadIdentity
+
+  - it: requires a deployment identity for explicit default workload identity
+    template: charts/app/templates/deployment.yaml
+    set:
+      global.defaultBucket.azureAuthMethod: workloadIdentity
+      global.azureStorageIdentity: null
+    asserts:
+      - failedTemplate:
+          errorMessage: global.azureStorageIdentity.tenantId and clientId are required when global.defaultBucket.azureAuthMethod is workloadIdentity

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -452,6 +452,12 @@ global:
     # One deployment-wide account for Azure storage workload identity. Set
     # create: false when infrastructure creates and federates this account.
     serviceAccount:
+      # Existing WIF installations retain shared behavior unless explicitly
+      # migrated. New managed rollouts use component, then optionally grouped.
+      # component: preserve all component ServiceAccounts and federation.
+      # grouped: share ordinary storage workers, preserving privileged accounts
+      # and Weave internal authentication. Retain old FICs during migration.
+      mode: shared
       name: "wandb-bucket-access"
       create: true
       annotations: {}

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -437,9 +437,10 @@ global:
         name: ""
         secretKey: "OIDC_SECRET"
 
-  # Infrastructure-managed Azure workload identity for this deployment. The
-  # managed default bucket uses this identity. A customer Azure bucket can opt
-  # in with global.bucket.azureAuthMethod: workloadIdentity.
+  # Infrastructure-managed Azure workload identity for this deployment.
+  # Select authentication separately with defaultBucket.azureAuthMethod or
+  # bucket.azureAuthMethod. Configuring this identity enables token injection
+  # even when the effective bucket explicitly uses accessKey authentication.
   # Requires a server build containing wandb/core#48160 in every storage consumer.
   # Verify running component images before opting in; see the README rollout steps.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
@@ -476,8 +477,14 @@ global:
     path: ""
     region: ""
     kmsKey: ""
-    # Azure (provider "az") identity-based auth. Each value can be a literal
-    # string or a Kubernetes EnvVarSource-style map. When both are set the application
+    # Azure only: accessKey or workloadIdentity (uses global.azureStorageIdentity).
+    # Unset preserves existing behavior: a configured global or legacy bucket
+    # identity selects workload identity; otherwise the storage key is used.
+    # A named global.bucket overrides this bucket, including its auth method.
+    azureAuthMethod: null
+    # Legacy Azure (provider "az") identity-based auth. Each value can be a literal
+    # string or a Kubernetes EnvVarSource-style map. With no azureAuthMethod set,
+    # when both are set the application
     # authenticates to Blob storage with an Entra ID workload identity
     # (user-delegation SAS) and the storage account access key is optional.
     # The chart adds the required workload-identity pod label to services that
@@ -489,7 +496,7 @@ global:
 
   # If specified, the application will use this bucket for all storage operations, and will not be overridable by the user.
   bucket:
-    # Azure only. Existing configurations default to access-key authentication.
+    # Azure only. Unset preserves key auth or an existing legacy bucket identity.
     # Set to workloadIdentity to use global.azureStorageIdentity.
     azureAuthMethod: null
     # Legacy bucket-scoped identity values remain supported.

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -440,6 +440,8 @@ global:
   # Infrastructure-managed Azure workload identity for this deployment. The
   # managed default bucket uses this identity. A customer Azure bucket can opt
   # in with global.bucket.azureAuthMethod: workloadIdentity.
+  # Requires a server build containing wandb/core#48160 in every storage consumer.
+  # Verify running component images before opting in; see the README rollout steps.
   # Each value can be a literal string or a Kubernetes EnvVarSource-style map:
   #   clientId:
   #     valueFrom:

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 0.2.4
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
+  version: 0.12.9
 - name: wandb-base
   repository: file://../wandb-base
-  version: 0.12.8
-digest: sha256:3ff5b21b31f6b5cf3e36bde39eabcf427f3757133cd66ef4ce7c2784ffa90e1a
-generated: "2026-09-02T16:15:40.820323-05:00"
+  version: 0.12.9
+digest: sha256:e7e2f984ea3910802462c2d8633164848ef1a1debe222bc9021ffc8f5884d43f
+generated: "2026-09-08T14:45:48.157093-05:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: orchestrator
 description: Orchestrator Helm chart for Kubernetes
 type: application
-version: 1.4.7
+version: 1.4.8
 appVersion: 1.0.0
 
 maintainers:
@@ -18,19 +18,19 @@ dependencies:
   - alias: web
     name: wandb-base
     condition: web.install
-    version: "0.12.8"
+    version: "0.12.9"
     repository: "file://../wandb-base"
   - alias: workspace-engine
     name: wandb-base
     condition: workspace-engine.install
-    version: "0.12.8"
+    version: "0.12.9"
     repository: "file://../wandb-base"
   - alias: workspace-engine-controllers
     name: wandb-base
     condition: workspace-engine-controllers.install
-    version: "0.12.8"
+    version: "0.12.9"
     repository: "file://../wandb-base"
   - alias: identity
     name: wandb-base
-    version: "0.12.8"
+    version: "0.12.9"
     repository: "file://../wandb-base"

--- a/charts/wandb-base/Chart.yaml
+++ b/charts/wandb-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wandb-base
 description: A generic helm chart for deploying services to kubernetes
 type: application
-version: 0.12.8
+version: 0.12.9
 icon: https://wandb.ai/logo.svg
 
 maintainers:

--- a/charts/wandb-base/templates/_helpers.tpl
+++ b/charts/wandb-base/templates/_helpers.tpl
@@ -103,6 +103,11 @@ their component accounts.
 */}}
 {{- define "wandb-base.azureStorageServiceAccountEnabled" -}}
   {{- $identity := default (dict) .Values.global.azureStorageIdentity -}}
+  {{- $serviceAccount := default (dict) $identity.serviceAccount -}}
+  {{- $mode := default "shared" $serviceAccount.mode -}}
+  {{- if not (has $mode (list "shared" "component" "grouped")) -}}
+    {{- fail "global.azureStorageIdentity.serviceAccount.mode must be shared, component, or grouped" -}}
+  {{- end -}}
   {{- $globalConfigured := and (not (empty $identity.tenantId)) (not (empty $identity.clientId)) -}}
   {{- $bucket := default (dict) .Values.global.bucket -}}
   {{- $hasCustomerBucket := not (empty $bucket.name) -}}
@@ -123,7 +128,12 @@ their component accounts.
   {{- else -}}
     {{- $enabled = $workloadIdentity -}}
   {{- end -}}
-{{- and $globalConfigured (or $usesDeploymentIdentity $explicitSharedServiceAccount) $enabled -}}
+  {{- /* Keep Kubernetes RBAC and Weave internal-JWT subjects separate. */ -}}
+  {{- $role := default (dict) .Values.role -}}
+  {{- $componentAccount := default (dict) .Values.serviceAccount -}}
+  {{- $canGroup := and (not $role.create) (not $explicitSharedServiceAccount) (not $componentAccount.useWeaveTraceIdentity) -}}
+  {{- $share := or (eq $mode "shared") (and (eq $mode "grouped") $canGroup) -}}
+{{- and $globalConfigured (or $usesDeploymentIdentity $explicitSharedServiceAccount) $enabled $share -}}
 {{- end }}
 
 {{- define "wandb-base.azureStorageServiceAccountName" -}}


### PR DESCRIPTION
## What

Add independent Azure bucket authentication selection and storage ServiceAccount modes for managed WIF rollout. `global.defaultBucket.azureAuthMethod` accepts `accessKey` or `workloadIdentity`; a named `global.bucket` overrides the default bucket and selects authentication independently.

## Why

An available managed identity should not prevent explicit key authentication. Initial WIF rollout must also preserve component permissions and Weave's trusted service-account subjects before consolidating ordinary storage workers.

## How

- An omitted default auth selector preserves existing behavior. A configured global or legacy default-bucket identity selects WIF; otherwise the key is used.
- Explicit default `accessKey` retains key authentication while the global identity remains available for token injection. Explicit `workloadIdentity` requires the deployment identity and suppresses generated storage keys.
- Named BYOB buckets retain their own key or legacy identity settings; they do not inherit the default bucket selector or credentials.
- Keep `shared` as the existing ServiceAccount mode default. Add `component` to retain current accounts and `grouped` to consolidate ordinary storage workers while preserving Kubernetes RBAC and Weave subjects. Bufstream retains its node-reader account.
- Weave default-bucket storage remains a separate opt-in.
- Bump wandb-base to 0.12.9 and operator-wandb to 0.44.13. Lumen and orchestrator dependency versions advance with the base chart.

Core's `enable_azure_default_storage_identity` selects explicit default WIF and `component` mode. Account consolidation has its own flag. Deploy the required runtime support and chart before enabling these flags; retain existing federation mappings during migration and rollback.

## Testing

- 109 Helm tests pass, including 12 new cases for explicit default auth, token injection alongside key auth, BYOB precedence, compatibility when omitted, and invalid selections.
- Operator snapshots match. Chart lint, pinned template formatting, 16 tooling tests, and maintainability checks pass.
- Prior Azure QA prerelease validation covered managed run files/artifacts, user-delegation SAS, representative key/identity BYOB, and Weave's default ClickHouse storage. The new selector still requires validation with this updated prerelease in QA.

Related: wandb/core#49026, wandb/console#149, WB-37694.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure storage workload identity service-account modes: shared, component, and grouped.
  * Added per-bucket selection between access-key and workload-identity authentication.
  * Improved Azure identity handling across application, console, parquet, Weave, and Bufstream deployments.
  * Added validation for supported modes and required service-account annotations.

* **Documentation**
  * Added Azure identity setup, rollout, migration, and storage-authentication guidance.

* **Chores**
  * Updated Helm chart versions and the shared chart dependency to version 0.12.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->