### PR TITLE
feat: Suppport remote config for lumen

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.12
+version: 0.44.13
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.13
+version: 0.44.14
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 

--- a/charts/operator-wandb/templates/_lumen.tpl
+++ b/charts/operator-wandb/templates/_lumen.tpl
@@ -21,6 +21,14 @@
 /app/definitions/collector/managed-install.yaml
 {{- end -}}
 
+{{- define "wandb.lumen.remoteConfigEnabled" -}}
+{{- dig "lumen" "remoteConfig" "enabled" false .Values.global | toString -}}
+{{- end -}}
+
+{{- define "wandb.lumen.remoteConfigUrl" -}}
+{{- dig "lumen" "remoteConfig" "url" "" .Values.global -}}
+{{- end -}}
+
 {{- define "wandb.lumen.publish.envVars" -}}
   {{- if eq (dig "lumen" "publish" "envVars" false .Values.global | toString) "true" -}}
 true

--- a/charts/operator-wandb/templates/lumen.yaml
+++ b/charts/operator-wandb/templates/lumen.yaml
@@ -7,6 +7,8 @@ metadata:
   name: {{ .Release.Name }}-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "{{ include "wandb.lumen.rulePath" . }}"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "{{ include "wandb.lumen.remoteConfigEnabled" . }}"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: "{{ include "wandb.lumen.remoteConfigUrl" . }}"
   LUMEN_CUSTOMER_NAME: "{{ include "wandb.lumen.customer" . }}"
   LUMEN_DATA_ROOT: "{{ include "wandb.lumen.dataRoot" . }}"
   LUMEN_STAGING_ROOT: "file://{{ include "wandb.lumen.stagingPath" . }}"

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -37,6 +37,13 @@ global:
     customer: ""
     publish:
       envVars: false
+    # Source of the collector rules. When enabled, the agent reads its rules
+    # only from url and fails the run if that object is unreadable; the
+    # configmap-mounted copy at wandb.lumen.rulePath is used only when
+    # disabled, which also makes disabling the flag a rollback path.
+    remoteConfig:
+      enabled: false
+      url: ""
     # Terraform-provided per cluster aws-eks / azure-aks / google-gke.
     # It can be empty for GCP-direct deployments, where no WIF is rendered.
     gcpWorkloadIdentity:

--- a/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-disabled.snap
@@ -1435,6 +1435,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
+++ b/test-configs/operator-wandb/__snapshots__/activity-store-serve-backfill-off.snap
@@ -1439,6 +1439,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-byob-access-key.snap
@@ -1229,6 +1229,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity-refs.snap
@@ -1199,6 +1199,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
+++ b/test-configs/operator-wandb/__snapshots__/azure-workload-identity.snap
@@ -1228,6 +1228,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/default.snap
+++ b/test-configs/operator-wandb/__snapshots__/default.snap
@@ -1576,6 +1576,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/fmb.snap
+++ b/test-configs/operator-wandb/__snapshots__/fmb.snap
@@ -1823,6 +1823,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
+++ b/test-configs/operator-wandb/__snapshots__/glue-leader-election.snap
@@ -1694,6 +1694,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/history-reader.snap
+++ b/test-configs/operator-wandb/__snapshots__/history-reader.snap
@@ -1743,6 +1743,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-grpc.snap
@@ -1721,6 +1721,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
+++ b/test-configs/operator-wandb/__snapshots__/historystore-parquet-only.snap
@@ -1721,6 +1721,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-api-prometheus.snap
@@ -1439,6 +1439,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/keda-executor.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-executor.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-frfu.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
+++ b/test-configs/operator-wandb/__snapshots__/keda-parquet.snap
@@ -1439,6 +1439,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-no-app.snap
@@ -1689,6 +1689,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
+++ b/test-configs/operator-wandb/__snapshots__/local-bypass-with-app.snap
@@ -1721,6 +1721,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-empty-trace-url.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-external-trace.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server-no-weave.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/mcp-server.snap
+++ b/test-configs/operator-wandb/__snapshots__/mcp-server.snap
@@ -1935,6 +1935,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
+++ b/test-configs/operator-wandb/__snapshots__/no-local-bypass.snap
@@ -1721,6 +1721,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
+++ b/test-configs/operator-wandb/__snapshots__/oidc-secret-from-k8s.snap
@@ -1728,6 +1728,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-features-enabled.snap
@@ -2258,6 +2258,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
+++ b/test-configs/operator-wandb/__snapshots__/olap-multi-feature.snap
@@ -1647,6 +1647,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
+++ b/test-configs/operator-wandb/__snapshots__/run-store-accelerator-run-updater.snap
@@ -1934,6 +1934,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
+++ b/test-configs/operator-wandb/__snapshots__/runs-v2-bufstream.snap
@@ -1900,6 +1900,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-api-rate-limits.snap
@@ -1721,6 +1721,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job-no-olap.snap
@@ -1569,6 +1569,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-ch-migration-job.snap
@@ -1965,6 +1965,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env-defaults.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-env.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-console-extraEnv.snap
@@ -1473,6 +1473,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-enable-backfill.snap
@@ -1517,6 +1517,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-history-updater-legacy-disabled.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-history-updater-legacy-disabled.snap
@@ -1569,6 +1569,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-digest-override.snap
@@ -1645,6 +1645,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-image-tag-override.snap
@@ -1645,6 +1645,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-aws.snap
@@ -1452,6 +1452,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: "gs://wandb-lumen-configs"
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-azure.snap
@@ -1452,6 +1452,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: "gs://wandb-lumen-configs"
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp-remote-config.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp-remote-config.snap
@@ -27,48 +27,6 @@ spec:
   - ports:
     - port: 6379
 ---
-# Source: operator-wandb/charts/anaconda2/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: anaconda2
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/api/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: api
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
 # Source: operator-wandb/charts/app/templates/pdb.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -108,48 +66,6 @@ spec:
       operator: DoesNotExist
     matchLabels:
       app.kubernetes.io/name: console
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/filemeta/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-filemeta
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: filemeta
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: filemeta
-      app.kubernetes.io/instance: chartsnap
-  maxUnavailable: 1
----
-# Source: operator-wandb/charts/glue/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchExpressions:
-    - key: batch.kubernetes.io/job-name
-      operator: DoesNotExist
-    matchLabels:
-      app.kubernetes.io/name: glue
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
@@ -195,32 +111,6 @@ spec:
       app.kubernetes.io/instance: chartsnap
   maxUnavailable: 1
 ---
-# Source: operator-wandb/charts/anaconda2/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/api/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
 # Source: operator-wandb/charts/app/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -247,29 +137,16 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
-# Source: operator-wandb/charts/filemeta/templates/serviceaccount.yaml
+# Source: operator-wandb/charts/lumen-agent/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: chartsnap-filemeta
+  name: lumen
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: filemeta
+    app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
----
-# Source: operator-wandb/charts/glue/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
@@ -328,22 +205,6 @@ metadata:
     app.kubernetes.io/version: 7.2.4
     helm.sh/chart: '###CHART_VERSION###'
 ---
-# Source: operator-wandb/charts/reloader/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader
-  namespace: default
----
 # Source: operator-wandb/charts/weave/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -364,8 +225,6 @@ metadata:
   name: chartsnap-bucket
   labels:
 data:
-  ACCESS_KEY: bWluaW8=
-  SECRET_KEY: dGVzdHBhc3N3b3Jk
 ---
 # Source: operator-wandb/templates/clickhouse.yaml
 apiVersion: v1
@@ -445,7 +304,7 @@ metadata:
   name: "chartsnap-redis-secret"
   labels:
 data:
-  REDIS_PASSWORD: cmVkaXMxMjM=
+  REDIS_PASSWORD:
   REDIS_CA_CERT:
 ---
 # Source: operator-wandb/templates/session-key.yaml
@@ -472,32 +331,6 @@ metadata:
   labels:
 data:
   SMTP_PASSWORD: ""
----
-# Source: operator-wandb/charts/mysql/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: chartsnap-mysql-initdb
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-data:
-  my.cnf: |
-    [mysqld]
-    binlog_format = 'ROW'
-    innodb_online_alter_log_max_size = 268435456
-    sync_binlog = 1
-    innodb_flush_log_at_trx_commit = 1
-    binlog_row_image = 'MINIMAL'
-    local-infile = 1
-    sort_buffer_size = 33554432
-  # We need RELOAD, SELECT, and LOCK TABLES for making backups
-  initdb.sql: |
-    GRANT SESSION_VARIABLES_ADMIN,RELOAD,SELECT,LOCK TABLES ON *.* TO `wandb`@`%`;
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/configmap.yaml
 apiVersion: v1
@@ -1282,7 +1115,7 @@ data:
   GORILLA_LICENSE_CERT_PATH: "/jwks.json"
   GORILLA_FILE_METADATA_SOURCE_IS_INTERNAL: "true"
   GORILLA_SESSION_LENGTH: "720h"
-  GORILLA_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
   GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE: "/view-spec-updater-linux"
   GORILLA_PARQUET_RPC_PATH: "/_goRPC_"
   GORILLA_ONPREM_API_KEY_PREFIX: "local"
@@ -1318,8 +1151,8 @@ data:
   PARQUET_HOST: "http://chartsnap-parquet:8087"
   OPERATOR_ENABLED: "true"
   LOGGING_ENABLED: "true"
-  GORILLA_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
-  ANACONDA_ENABLED: "false"
+  GORILLA_SWEEP_PROVIDER: "http://chartsnap-app:8082"
+  ANACONDA_ENABLED: "true"
 ---
 # Source: operator-wandb/templates/bucket.yaml
 apiVersion: v1
@@ -1328,9 +1161,9 @@ metadata:
   name: chartsnap-bucket-configmap
   labels:
 data:
-  BUCKET_NAME: "minio:9000/bucket"
+  BUCKET_NAME: ""
   BUCKET_PATH: ""
-  AWS_REGION: "us-east-1"
+  AWS_REGION: ""
   AWS_S3_KMS_ID: ""
   GORILLA_DEFAULT_REGION: "minio-local"
 ---
@@ -1522,7 +1355,7 @@ data:
   GORILLA_STATSD_PORT: "0"
   GORILLA_LICENSE_CERT_PATH: /jwks.json
   # T-shirt size for deployment
-  GORILLA_TSHIRT_SIZE: "testing"
+  GORILLA_TSHIRT_SIZE: "small"
   GORILLA_ONPREM: "true"
   ONPREM: "true"
 ---
@@ -1538,7 +1371,7 @@ data:
   GORILLA_GLUE_FRONTEND_HOST: "http://localhost:8080"
   GORILLA_GLUE_LICENSE_CERT_PATH: "/jwks.json"
   # Values that correspond to existing configurations from gorilla.yaml
-  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-anaconda2:8082"
+  GORILLA_GLUE_SWEEP_PROVIDER: "http://chartsnap-app:8082"
   GORILLA_GLUE_SESSION_LENGTH: "720h"
   GORILLA_GLUE_DEV: "false"
   GORILLA_USE_PARQUET_HISTORY_STORE: "true"
@@ -1606,7 +1439,7 @@ metadata:
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  GLUE_ENABLED: "false"
+  GLUE_ENABLED: "true"
   GORILLA_GLUE_CONTAINER_PORT: "9173"
   HOST: "http://localhost:8080"
   LOCAL_K8S_SIGNER_SECRET_NAME: "chartsnap-internal-signer"
@@ -1619,10 +1452,10 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
-  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
-  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "true"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: "gs://wandb-lumen-config/managed-install.yaml"
   LUMEN_CUSTOMER_NAME: ""
-  LUMEN_DATA_ROOT: ""
+  LUMEN_DATA_ROOT: "gs://wandb-lumen-configs"
   LUMEN_STAGING_ROOT: "file:///vol/staging"
 ---
 # Source: operator-wandb/templates/lumen.yaml
@@ -1783,6 +1616,25 @@ data:
           valueHooks:
             - URIPassword
 ---
+# Source: operator-wandb/templates/lumen.yaml
+# WIF only needed for lumen dataRoot, not when using standard wandb-bucket
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-lumen-gcp-wif
+data:
+  credential-config.json: |
+    {
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "file": "/var/run/secrets/tokens/gcp-ksa/token",
+        "format": { "type": "text" }
+      }
+    }
+---
 # Source: operator-wandb/templates/nginx.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -1816,18 +1668,6 @@ data:
         }
         location /console {
           proxy_pass http://chartsnap-console:8082;
-        }
-
-        location /api {
-          proxy_pass http://chartsnap-api:8081;
-        }
-
-        location /graphql {
-          proxy_pass http://chartsnap-api:8081;
-        }
-
-        location /graphql2 {
-          proxy_pass http://chartsnap-api:8081;
         }
       }
     }
@@ -1889,7 +1729,7 @@ data:
   PORT: "8080"
   API_PATH_PREFIX: "/traces"
   WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
-  WANDB_BASE_URL: "http://chartsnap-api:8081/"
+  WANDB_BASE_URL: "http://chartsnap-app:8080/"
   WF_TRACE_SERVER_URL: "http://localhost:8080/traces"
   WF_ENFORCE_PASSWORD_LENGTH: "false"
   WEAVE_ENABLE_ONLINE_EVAL: "false"
@@ -1899,7 +1739,7 @@ data:
   WANDB_INTERNAL_SERVICE_TOKEN_SECRET_NAME: "weave-worker-auth"
   KAFKA_BROKER_HOST: "bufstream.bufstream.svc.cluster.local"
   KAFKA_BROKER_PORT: "9092"
-  WEAVE_REDIS_URL: "redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
+  WEAVE_REDIS_URL: "redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)"
 ---
 # Source: operator-wandb/templates/weave.yaml
 apiVersion: v1
@@ -1910,7 +1750,7 @@ metadata:
 data:
   GORILLA_ONPREM: "true"
   PORT: "9994"
-  WANDB_BASE_URL: "http://chartsnap-api:8081/"
+  WANDB_BASE_URL: "http://chartsnap-app:8080/"
   WANDB_PUBLIC_BASE_URL: "http://localhost:8080"
   WEAVE_LOG_FORMAT: "json"
   WEAVE_SERVER_NUM_WORKERS: "4"
@@ -1920,25 +1760,6 @@ data:
   WEAVE_CACHE_CHECK_INTERVAL: "60"
   WEAVE_CACHE_SIZE_LIMIT: "20Gi"
   WEAVE_CACHE_CLEAR_PERCENT: "80"
----
-# Source: operator-wandb/charts/mysql/templates/pvc.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: chartsnap-mysql-data
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: "20Gi"
 ---
 # Source: operator-wandb/charts/prometheus/charts/instance/templates/pvc.yaml
 apiVersion: v1
@@ -2194,34 +2015,6 @@ subjects:
   name: system:unauthenticated
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: operator-wandb/charts/api/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
----
 # Source: operator-wandb/charts/app/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -2250,132 +2043,41 @@ rules:
   verbs:
   - get
 ---
-# Source: operator-wandb/charts/glue/templates/role.yaml
+# Source: operator-wandb/charts/lumen-agent/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: chartsnap-glue
+  name: chartsnap-lumen-agent
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
+    app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
----
-# Source: operator-wandb/charts/reloader/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader-role
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
+  - pods
   - configmaps
+  - secrets
   verbs:
-  - list
   - get
-  - watch
+  - list
 - apiGroups:
-  - "apps"
+  - apps
   resources:
+  - replicasets
   - deployments
-  - daemonsets
-  - statefulsets
   verbs:
-  - list
-  - get
-  - update
-  - patch
-- apiGroups:
-  - "batch"
-  resources:
-  - cronjobs
-  verbs:
-  - list
   - get
 - apiGroups:
-  - "batch"
+  - apps.wandb.com
   resources:
-  - jobs
+  - weightsandbiases
   verbs:
-  - create
-  - delete
-  - list
   - get
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
----
-# Source: operator-wandb/charts/api/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-subjects:
-- kind: ServiceAccount
-  name: chartsnap-api
-  namespace: default
-roleRef:
-  kind: Role
-  name: chartsnap-api
-  apiGroup: rbac.authorization.k8s.io
+  - list
 ---
 # Source: operator-wandb/charts/app/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2397,93 +2099,25 @@ roleRef:
   name: chartsnap-app
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: operator-wandb/charts/glue/templates/rolebinding.yaml
+# Source: operator-wandb/charts/lumen-agent/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: chartsnap-glue
+  name: chartsnap-lumen-agent
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
+    app.kubernetes.io/name: lumen-agent
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/version: "v0.1.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
 - kind: ServiceAccount
-  name: chartsnap-glue
+  name: lumen
   namespace: default
 roleRef:
   kind: Role
-  name: chartsnap-glue
+  name: chartsnap-lumen-agent
   apiGroup: rbac.authorization.k8s.io
----
-# Source: operator-wandb/charts/reloader/templates/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-  name: chartsnap-reloader-role-binding
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: chartsnap-reloader-role
-subjects:
-- kind: ServiceAccount
-  name: chartsnap-reloader
-  namespace: default
----
-# Source: operator-wandb/charts/anaconda2/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8082
-    protocol: TCP
-    targetPort: http
-  selector:
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
----
-# Source: operator-wandb/charts/api/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 8081
-    protocol: TCP
-    targetPort: api
-  selector:
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
 ---
 # Source: operator-wandb/charts/app/templates/service.yaml
 apiVersion: v1
@@ -2496,6 +2130,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "chartsnap-app-backend-config"}'
 spec:
   type: ClusterIP
   ports:
@@ -2526,6 +2163,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "chartsnap-console-backend-config"}'
 spec:
   type: ClusterIP
   ports:
@@ -2535,32 +2175,6 @@ spec:
   selector:
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: chartsnap
----
-# Source: operator-wandb/charts/mysql/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: chartsnap-mysql
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-  - port: 3306
-    protocol: TCP
-    targetPort: mysql
-  selector:
-    helm.sh/chart: mysql-0.1.0
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
-    app.kubernetes.io/managed-by: Helm
 ---
 # Source: operator-wandb/charts/otel/charts/daemonset/templates/service.yaml
 apiVersion: v1
@@ -2612,6 +2226,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "chartsnap-parquet-backend-config"}'
 spec:
   type: ClusterIP
   ports:
@@ -2792,6 +2409,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "chartsnap-weave-backend-config"}'
 spec:
   type: ClusterIP
   ports:
@@ -2840,17 +2460,6 @@ spec:
         checksum/configmap: 9a93c1a7e19d470e13c897633e852dbfe03075bfe12f97f73b087cb1b4a5971
     spec:
       serviceAccountName: chartsnap-otel-daemonset
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
-      nodeSelector:
-        global-key: global-value
       securityContext:
         runAsUser: 1000
         runAsGroup: 0
@@ -2954,714 +2563,6 @@ spec:
         hostPath:
           path: /var/lib/docker/containers
       hostNetwork: false
----
-# Source: operator-wandb/charts/anaconda2/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-anaconda2
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: anaconda2
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: anaconda2
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: anaconda2
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      containers:
-      - name: anaconda2
-        envFrom:
-        - configMapRef:
-            name: chartsnap-anaconda2-configmap
-        env:
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: DD_AGENT_HOST
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: DD_TRACE_AGENT_HOSTNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "wandb/anaconda2:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8082
-          name: http
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ping
-            port: http
-          timeoutSeconds: 2
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ping
-            port: http
-          timeoutSeconds: 2
-        resources:
-          limits:
-            cpu: "1"
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      nodeSelector:
-        global-key: global-value
-      serviceAccountName: chartsnap-anaconda2
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: anaconda2
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: anaconda2
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
-# Source: operator-wandb/charts/api/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-api
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: api
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: api
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: api
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "false"
-    spec:
-      containers:
-      - name: api
-        args:
-        - gorilla
-        envFrom:
-        - configMapRef:
-            name: chartsnap-api-configmap
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - secretRef:
-            name: chartsnap-gorilla-session-key
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: noop://
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LIMITER
-          value: noop://
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-              name: gorilla-coreweave-observability
-              optional: true
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8081
-          name: api
-          protocol: TCP
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 30
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ready
-            port: api
-          periodSeconds: 5
-          successThreshold: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/
-          name: temp-dir
-      initContainers:
-      - name: migrate-db
-        command:
-        - bash
-        - -c
-        - |
-          LOG_FILE="/tmp/migrate.log"
-          ./megabinary migrate --db=$GORILLA_METADATA_STORE --runs-db=$GORILLA_RUN_STORE --usage-db=$GORILLA_USAGE_STORE 2>&1 | tee -a $LOG_FILE
-          EXIT_CODE=${PIPESTATUS[0]}
-          MIGRATION_FILE_MISSING_ERROR_CODE=101
-          if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq $MIGRATION_FILE_MISSING_ERROR_CODE ]]; then
-            exit 0
-          else
-            # missing migration error log from golang-migrate@v4 -- older versions of megabinary
-            if grep -q "no migration found for version" $LOG_FILE; then
-              exit 0
-            fi
-            exit $EXIT_CODE
-          fi
-        envFrom:
-        - configMapRef:
-            name: chartsnap-api-configmap
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - secretRef:
-            name: chartsnap-gorilla-session-key
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: noop://
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LIMITER
-          value: noop://
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
-              name: gorilla-coreweave-observability
-              optional: true
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/
-          name: temp-dir
-      nodeSelector:
-        api-key: api-value
-      serviceAccountName: chartsnap-api
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      tolerations:
-      - key: api-key1
-        operator: Equal
-        value: api-value1
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: api
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: api
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - emptyDir: {}
-        name: temp-dir
 ---
 # Source: operator-wandb/charts/app/templates/deployment.yaml
 apiVersion: apps/v1
@@ -3774,11 +2675,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_NAME)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -3809,23 +2712,23 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
         - name: KAFKA_CLIENT_PASSWORD
@@ -3883,26 +2786,18 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: BUCKET_QUEUE
           value: "internal://"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
-        - name: GORILLA_FILEMETA_ENABLED
-          value: "false"
         - name: GORILLA_GLUE_CONTAINER_PORT
           value: "8083"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
-        - name: GORILLA_STORAGE_BUCKET
-          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -3956,9 +2851,12 @@ spec:
               - sleep
               - "25"
         resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 2Gi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -4050,11 +2948,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
+        - name: GORILLA_STORAGE_BUCKET
+          value: s3://$(BUCKET_NAME)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -4085,23 +2985,23 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
         - name: KAFKA_CLIENT_PASSWORD
@@ -4159,26 +3059,18 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: BUCKET_QUEUE
           value: "internal://"
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
         - name: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
           valueFrom:
             secretKeyRef:
               key: GORILLA_COREWEAVE_OBSERVABILITY_API_KEY
               name: gorilla-coreweave-observability
               optional: true
-        - name: GORILLA_FILEMETA_ENABLED
-          value: "false"
         - name: GORILLA_GLUE_CONTAINER_PORT
           value: "8083"
         - name: GORILLA_GLUE_VIEW_SPEC_UPDATER_EXECUTABLE
           value: "/usr/local/bin/view-spec-updater-linux"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         - name: GORILLA_LICENSE_CERT_PATH
           value: "/var/app/jwks.json"
-        - name: GORILLA_STORAGE_BUCKET
-          value: "s3://local-files"
         - name: GORILLA_TASK_CONFIG_PATH
           value: "/etc/service/gorilla-glue/glue_tasks_local.yaml"
         - name: GORILLA_VIEW_SPEC_UPDATER_EXECUTABLE
@@ -4202,8 +3094,6 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      nodeSelector:
-        global-key: global-value
       serviceAccountName: chartsnap-app
       securityContext:
         fsGroup: 0
@@ -4214,15 +3104,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -4296,10 +3177,6 @@ spec:
         - configMapRef:
             name: chartsnap-console-configmap
         env:
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -4335,8 +3212,8 @@ spec:
             cpu: "2"
             memory: 2Gi
           requests:
-            cpu: 50m
-            memory: 64Mi
+            cpu: "1"
+            memory: 1Gi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -4347,8 +3224,6 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      nodeSelector:
-        global-key: global-value
       serviceAccountName: chartsnap-console
       securityContext:
         fsGroup: 0
@@ -4359,15 +3234,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -4400,612 +3266,6 @@ spec:
           - key: REDIS_CA_CERT
             path: redis_ca.pem
           optional: true
----
-# Source: operator-wandb/charts/filemeta/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-filemeta
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: filemeta
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: filemeta
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: filemeta
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "false"
-    spec:
-      containers:
-      - name: filemeta
-        args:
-        - filemeta
-        envFrom:
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: noop://
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_SUBSCRIPTIONS_FILEMETA
-          value: 'kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):9092/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?consumer_group_id=filemeta&num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)'
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-      nodeSelector:
-        global-key: global-value
-      serviceAccountName: chartsnap-filemeta
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: filemeta
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: filemeta
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
----
-# Source: operator-wandb/charts/glue/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: chartsnap-glue
-  labels:
-    helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: glue
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    reloader.stakater.com/auto: "true"
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: glue
-      app.kubernetes.io/instance: chartsnap
-  template:
-    metadata:
-      annotations:
-        lumen.wandb.ai/agent: "true"
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: glue
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "latest"
-        app.kubernetes.io/managed-by: Helm
-        azure.workload.identity/use: "false"
-    spec:
-      containers:
-      - name: glue
-        args:
-        - glue
-        envFrom:
-        - configMapRef:
-            name: chartsnap-bucket-configmap
-        - configMapRef:
-            name: chartsnap-global-configmap
-        - secretRef:
-            name: chartsnap-global-secret
-        - configMapRef:
-            name: chartsnap-glue-configmap
-        - configMapRef:
-            name: chartsnap-kafka-configmap
-        - configMapRef:
-            name: chartsnap-redis-configmap
-        env:
-        - name: G_HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: GORILLA_CUSTOMER_SECRET_STORE_K8S_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_ACCESS_ID
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_COREWEAVE_WANDB_INTEGRATION_SECRET_KEY
-              name: gorilla-coreweave-caios
-              optional: true
-        - name: AZURE_STORAGE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: ACCESS_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: SECRET_KEY
-              name: chartsnap-bucket
-              optional: true
-        - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: MYSQL_PASSWORD
-              name: chartsnap-mysql
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: chartsnap-mysql
-        - name: MYSQL_DATABASE
-          value: wandb_local
-        - name: MYSQL_USER
-          value: wandb
-        - name: MYSQL
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_ANALYTICS_SINK
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_METADATA_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_USAGE_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: REDIS_PASSWORD
-              name: chartsnap-redis-secret
-              optional: true
-        - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
-        - name: GORILLA_TASK_QUEUE
-          value: noop://
-        - name: KAFKA_CLIENT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: KAFKA_CLIENT_PASSWORD
-              name: chartsnap-kafka
-              optional: true
-        - name: GORILLA_FILE_STREAM_STORE_ADDRESS
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_ADDR
-          value: kafka://$(KAFKA_CLIENT_USER):$(KAFKA_CLIENT_PASSWORD)@$(KAFKA_BROKER_HOST):$(KAFKA_BROKER_PORT)/$(KAFKA_TOPIC_RUN_UPDATE_SHADOW_QUEUE)?num_partitions=$(KAFKA_RUN_UPDATE_SHADOW_QUEUE_NUM_PARTITIONS)
-        - name: GORILLA_HISTORY_STORE
-          value: http://chartsnap-parquet:8087/_goRPC_,mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_PARQUET_LIVE_HISTORY_STORE
-          value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/$(MYSQL_DATABASE)?tls=preferred
-        - name: GORILLA_FILE_STREAM_WORKER_STORE_ADDRESS
-          value: ""
-        - name: GORILLA_STATSIG_KEY
-          valueFrom:
-            secretKeyRef:
-              key: GORILLA_STATSIG_KEY
-              name: gorilla-statsig
-              optional: true
-        - name: SMTP_HOST
-          value: ""
-        - name: SMTP_PORT
-          value: "587"
-        - name: SMTP_USER
-          value: ""
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: SMTP_PASSWORD
-              name: chartsnap-smtp-secret
-        - name: GORILLA_EMAIL_SINK
-          value: https://api.wandb.ai/email/dispatch
-        - name: LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: GORILLA_LICENSE
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: chartsnap-license
-        - name: SSL_CERT_FILE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: SSL_CERT_DIR
-          value: /etc/ssl/certs
-        - name: REQUESTS_CA_BUNDLE
-          value: /etc/ssl/certs/ca-certificates.crt
-        - name: GORILLA_LUMEN_ADDR
-          value: :16060
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add: []
-            drop: []
-          privileged: false
-          readOnlyRootFilesystem: false
-        image: "wandb/megabinary:latest"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-        - containerPort: 16060
-          name: lumen
-          protocol: TCP
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 1
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - name: wandb-ca-certs-root
-          mountPath: /usr/local/share/ca-certificates/
-        - name: wandb-ca-certs
-          mountPath: /usr/local/share/ca-certificates/inline
-        - name: wandb-ca-certs-user
-          mountPath: /usr/local/share/ca-certificates/configmap
-        - name: redis-ca
-          mountPath: /etc/ssl/certs/redis_ca.pem
-          subPath: redis_ca.pem
-        - mountPath: /tmp/
-          name: temp-dir
-      initContainers:
-      nodeSelector:
-        global-key: global-value
-      serviceAccountName: chartsnap-glue
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsNonRoot: true
-        runAsUser: 999
-        seccompProfile:
-          type: RuntimeDefault
-      terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: glue
-        maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchLabels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: glue
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - name: wandb-ca-certs-root
-        emptyDir: {}
-      - name: wandb-ca-certs
-        configMap:
-          name: "chartsnap-ca-certs"
-      - name: wandb-ca-certs-user
-        configMap:
-          name: 'noCertProvided'
-          optional: true
-      - name: redis-ca
-        secret:
-          secretName: 'chartsnap-redis-secret'
-          items:
-          - key: REDIS_CA_CERT
-            path: redis_ca.pem
-          optional: true
-      - emptyDir: {}
-        name: temp-dir
 ---
 # Source: operator-wandb/charts/parquet/templates/deployment.yaml
 apiVersion: apps/v1
@@ -5112,13 +3372,13 @@ spec:
               name: chartsnap-bucket
               optional: true
         - name: BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_FILE_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: GORILLA_STORAGE_BUCKET
-          value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+          value: s3://$(BUCKET_NAME)
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -5149,23 +3409,23 @@ spec:
               name: chartsnap-redis-secret
               optional: true
         - name: REDIS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_AUDITOR_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_FILE_METADATA_SOURCE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_LOCKER
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_METADATA_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_SETTINGS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_USAGE_METRICS_CACHE
-          value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+          value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
         - name: GORILLA_TASK_QUEUE
           value: noop://
         - name: KAFKA_CLIENT_PASSWORD
@@ -5221,10 +3481,16 @@ spec:
           value: /etc/ssl/certs/ca-certificates.crt
         - name: GORILLA_LUMEN_ADDR
           value: :16060
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
+        - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
           value: "true"
+        - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+          value: "100"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+          value: "1000000"
+        - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+          value: "25"
+        - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+          value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5260,9 +3526,12 @@ spec:
           successThreshold: 1
           timeoutSeconds: 30
         resources:
+          limits:
+            cpu: "4"
+            memory: 16Gi
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 8Gi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -5273,8 +3542,6 @@ spec:
         - name: redis-ca
           mountPath: /etc/ssl/certs/redis_ca.pem
           subPath: redis_ca.pem
-      nodeSelector:
-        global-key: global-value
       serviceAccountName: chartsnap-parquet
       securityContext:
         fsGroup: 0
@@ -5285,15 +3552,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -5431,94 +3689,6 @@ spec:
         persistentVolumeClaim:
           claimName: chartsnap-prometheus-server
 ---
-# Source: operator-wandb/charts/reloader/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    meta.helm.sh/release-namespace: "default"
-    meta.helm.sh/release-name: "chartsnap"
-  labels:
-    app: chartsnap-reloader
-    chart: "reloader-1.3.0"
-    release: "chartsnap"
-    heritage: "Helm"
-    app.kubernetes.io/managed-by: "Helm"
-    group: com.stakater.platform
-    provider: stakater
-    version: v1.3.0
-  name: chartsnap-reloader
-  namespace: default
-spec:
-  replicas: 1
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: chartsnap-reloader
-      release: "chartsnap"
-  template:
-    metadata:
-      labels:
-        app: chartsnap-reloader
-        chart: "reloader-1.3.0"
-        release: "chartsnap"
-        heritage: "Helm"
-        app.kubernetes.io/managed-by: "Helm"
-        group: com.stakater.platform
-        provider: stakater
-        version: v1.3.0
-    spec:
-      containers:
-      - image: "ghcr.io/stakater/reloader:v1.3.0"
-        imagePullPolicy: IfNotPresent
-        name: chartsnap-reloader
-        env:
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: '1'
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-              divisor: '1'
-        - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        ports:
-        - name: http
-          containerPort: 9090
-        livenessProbe:
-          httpGet:
-            path: /live
-            port: http
-          timeoutSeconds: 5
-          failureThreshold: 5
-          periodSeconds: 10
-          successThreshold: 1
-          initialDelaySeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: http
-          timeoutSeconds: 5
-          failureThreshold: 5
-          periodSeconds: 10
-          successThreshold: 1
-          initialDelaySeconds: 10
-        securityContext: {}
-        args:
-        - "--log-level=info"
-        - "--reload-on-create=true"
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      serviceAccountName: chartsnap-reloader
----
 # Source: operator-wandb/charts/weave/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -5564,10 +3734,6 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5596,9 +3762,12 @@ spec:
             port: http
           periodSeconds: 10
         resources:
+          limits:
+            cpu: "4"
+            memory: 16Gi
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "1"
+            memory: 8Gi
         volumeMounts:
         - name: wandb-ca-certs-root
           mountPath: /usr/local/share/ca-certificates/
@@ -5627,10 +3796,6 @@ spec:
           value: /etc/ssl/certs
         - name: REQUESTS_CA_BUNDLE
           value: /etc/ssl/certs/ca-certificates.crt
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -5661,8 +3826,6 @@ spec:
           name: temp-dir
         - mountPath: /vol/weave/cache
           name: cache
-      nodeSelector:
-        global-key: global-value
       serviceAccountName: chartsnap-weave
       securityContext:
         fsGroup: 0
@@ -5673,15 +3836,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 60
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -5721,120 +3875,69 @@ spec:
           sizeLimit: '20Gi'
         name: cache
 ---
-# Source: operator-wandb/charts/mysql/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
+# Source: operator-wandb/charts/parquet/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
 metadata:
-  name: chartsnap-mysql
+  name: chartsnap-parquet
   labels:
     helm.sh/chart: '###CHART_VERSION###'
-    app.kubernetes.io/name: mysql
+    app.kubernetes.io/name: parquet
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/version: "1.16.0"
-    wandb.com/app-name: mysql-0.1.0
+    app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: chartsnap
-      helm.sh/chart: mysql-0.1.0
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/version: "1.16.0"
-      wandb.com/app-name: mysql-0.1.0
-      app.kubernetes.io/managed-by: Helm
-  template:
-    metadata:
-      labels:
-        helm.sh/chart: '###CHART_VERSION###'
-        app.kubernetes.io/name: mysql
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/version: "1.16.0"
-        wandb.com/app-name: mysql-0.1.0
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
-      nodeSelector:
-        global-key: global-value
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 0
-        fsGroup: 999
-        fsGroupChangePolicy: OnRootMismatch
-        runAsNonRoot: true
-      containers:
-      - name: mysql
-        image: "mysql:latest"
-        securityContext:
-          allowPrivilegeEscalation: false
-        ports:
-        - name: mysql
-          containerPort: 3306
-          protocol: TCP
-        env:
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "chartsnap-mysql"
-              key: "MYSQL_PASSWORD"
-        - name: MYSQL_PORT
-          value: "3306"
-        - name: MYSQL_HOST
-          value: "chartsnap-mysql"
-        - name: MYSQL_DATABASE
-          value: "wandb_local"
-        - name: MYSQL_USER
-          value: "wandb"
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: chartsnap-mysql
-              key: MYSQL_ROOT_PASSWORD
-        livenessProbe:
-          tcpSocket:
-            port: 3306
-        readinessProbe:
-          tcpSocket:
-            port: 3306
-        startupProbe:
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          failureThreshold: 60
-          tcpSocket:
-            port: 3306
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/mysql
-        - name: initdb
-          mountPath: /docker-entrypoint-initdb.d/initdb.sql
-          subPath: initdb.sql
-        - name: initdb
-          mountPath: /etc/mysql/my.cnf
-          subPath: my.cnf
-        resources:
-          limits:
-            cpu: 4000m
-            memory: 8Gi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-      volumes:
-      - name: initdb
-        configMap:
-          name: chartsnap-mysql-initdb
-      - name: data
-        persistentVolumeClaim:
-          claimName: chartsnap-mysql-data
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: chartsnap-parquet-bc
+  minReplicas: 2
+  maxReplicas: 2
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+---
+# Source: operator-wandb/charts/weave/templates/hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: chartsnap-weave
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: chartsnap-weave-bc
+  minReplicas: 2
+  maxReplicas: 2
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 # Source: operator-wandb/charts/redis/templates/master/application.yaml
 apiVersion: apps/v1
@@ -5999,6 +4102,155 @@ spec:
         requests:
           storage: "8Gi"
 ---
+# Source: operator-wandb/charts/lumen-agent/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chartsnap-lumen-agent
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: lumen-agent
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "v0.1.5"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "0 * * * *"
+  suspend: false
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 5
+      template:
+        metadata:
+          labels:
+            helm.sh/chart: '###CHART_VERSION###'
+            app.kubernetes.io/name: lumen-agent
+            app.kubernetes.io/instance: chartsnap
+            app.kubernetes.io/version: "v0.1.5"
+            app.kubernetes.io/managed-by: Helm
+            azure.workload.identity/use: "false"
+        spec:
+          containers:
+          - name: collector
+            command:
+            - /app/entrypoint.sh
+            - agent
+            envFrom:
+            - configMapRef:
+                name: chartsnap-bucket-configmap
+            - configMapRef:
+                name: chartsnap-lumen-configmap
+            env:
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: ACCESS_KEY
+                  name: chartsnap-bucket
+                  optional: true
+            - name: BUCKET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: ACCESS_KEY
+                  name: chartsnap-bucket
+                  optional: true
+            - name: BUCKET_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: SECRET_KEY
+                  name: chartsnap-bucket
+                  optional: true
+            - name: BUCKET
+              value: s3://$(BUCKET_NAME)
+            - name: GORILLA_FILE_STORE
+              value: s3://$(BUCKET_NAME)
+            - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
+              value: s3://$(BUCKET_NAME)
+            - name: GORILLA_STORAGE_BUCKET
+              value: s3://$(BUCKET_NAME)
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/gcp/credential-config.json"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: []
+                drop: []
+              privileged: false
+              readOnlyRootFilesystem: false
+            image: "us-docker.pkg.dev/wandb-production/public/wandb/lumen:v0.1.5"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 2
+                memory: 4Gi
+              requests:
+                cpu: 1
+                memory: 4Gi
+            volumeMounts:
+            - name: lumen-staging-dir
+              mountPath: /vol/staging
+            - name: gcp-ksa
+              mountPath: /var/run/secrets/tokens/gcp-ksa
+              readOnly: true
+            - name: gcp-wif-config
+              mountPath: /var/secrets/gcp
+              readOnly: true
+            - name: lumen-managed-install
+              mountPath: /app/definitions/collector/managed-install.yaml
+              subPath: managed-install.yaml
+              readOnly: true
+          restartPolicy: OnFailure
+          serviceAccountName: lumen
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: lumen-agent
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: chartsnap
+                app.kubernetes.io/name: lumen-agent
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          volumes:
+          - name: lumen-staging-dir
+            emptyDir: {}
+          - name: gcp-ksa
+            projected:
+              sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+                  audience: //iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider
+          - name: gcp-wif-config
+            configMap:
+              name: "chartsnap-lumen-gcp-wif"
+          - name: lumen-managed-install
+            configMap:
+              name: "chartsnap-lumen-rules"
+---
 # Source: operator-wandb/charts/parquet/templates/cronjob.yaml
 apiVersion: batch/v1
 kind: CronJob
@@ -6097,13 +4349,13 @@ spec:
                   name: chartsnap-bucket
                   optional: true
             - name: BUCKET
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: s3://$(BUCKET_NAME)
             - name: GORILLA_FILE_STORE
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: s3://$(BUCKET_NAME)
             - name: GORILLA_RUN_UPDATE_SHADOW_QUEUE_OVERFLOW_BUCKET_STORE
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: s3://$(BUCKET_NAME)
             - name: GORILLA_STORAGE_BUCKET
-              value: s3://$(BUCKET_ACCESS_KEY):$(BUCKET_SECRET_KEY)@$(BUCKET_NAME)
+              value: s3://$(BUCKET_NAME)
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -6134,23 +4386,23 @@ spec:
                   name: chartsnap-redis-secret
                   optional: true
             - name: REDIS
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_ACTIVITY_STORE_CACHE_ADDRESS
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_AUDITOR_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_FILE_METADATA_SOURCE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_LOCKER
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_METADATA_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_SETTINGS_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_USAGE_METRICS_CACHE
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
+              value: redis://$(REDIS_HOST):$(REDIS_PORT)$(REDIS_PARAMS)
             - name: GORILLA_TASK_QUEUE
               value: noop://
             - name: KAFKA_CLIENT_PASSWORD
@@ -6206,14 +4458,20 @@ spec:
               value: /etc/ssl/certs/ca-certificates.crt
             - name: GORILLA_LUMEN_ADDR
               value: :16060
-            - name: GLOBAL_ADMIN_API_KEY
-              value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+            - name: GORILLA_LUMEN_ENV_VARS_EXPOSED
+              value: "true"
             - name: GORILLA_GLUE_EXECUTE
               value: "true"
             - name: GORILLA_GLUE_EXECUTE_TASK_NAME
               value: "EXPORTHISTORYTOPARQUET"
-            - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-              value: "true"
+            - name: GORILLA_MYSQL_MAX_OPEN_CONNS
+              value: "100"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_MAX_CHUNKS
+              value: "1000000"
+            - name: GORILLA_PARQUET_READER_METADATA_CACHE_SIZE
+              value: "25"
+            - name: GORILLA_PARQUET_READER_PARQUET_BYTE_CACHE_MB
+              value: "1500"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -6240,8 +4498,6 @@ spec:
             - name: redis-ca
               mountPath: /etc/ssl/certs/redis_ca.pem
               subPath: redis_ca.pem
-          nodeSelector:
-            global-key: global-value
           restartPolicy: Never
           serviceAccountName: chartsnap-parquet
           securityContext:
@@ -6252,15 +4508,6 @@ spec:
             runAsUser: 999
             seccompProfile:
               type: RuntimeDefault
-          tolerations:
-          - effect: NoSchedule
-            key: global-key1
-            operator: Equal
-            value: global-value1
-          - effect: NoSchedule
-            key: global-key2
-            operator: Equal
-            value: global-value2
           topologySpreadConstraints:
           - labelSelector:
               matchLabels:
@@ -6293,6 +4540,90 @@ spec:
               - key: REDIS_CA_CERT
                 path: redis_ca.pem
               optional: true
+---
+# Source: operator-wandb/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chartsnap
+  labels:
+spec:
+  ingressClassName:
+  tls: []
+  rules:
+  - host: localhost:8080
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: chartsnap-app
+            port:
+              number: 8080
+      - pathType: Prefix
+        path: /console
+        backend:
+          service:
+            name: chartsnap-console
+            port:
+              number: 8082
+---
+# Source: operator-wandb/charts/app/templates/service.yaml
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: chartsnap-app-backend-config
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  timeoutSec: 120
+---
+# Source: operator-wandb/charts/console/templates/service.yaml
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: chartsnap-console-backend-config
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  timeoutSec: 120
+---
+# Source: operator-wandb/charts/parquet/templates/service.yaml
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: chartsnap-parquet-backend-config
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: parquet
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  timeoutSec: 120
+---
+# Source: operator-wandb/charts/weave/templates/service.yaml
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: chartsnap-weave-backend-config
+  labels:
+    helm.sh/chart: '###CHART_VERSION###'
+    app.kubernetes.io/name: weave
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  timeoutSec: 120
 ---
 # Source: operator-wandb/charts/appRenamePostHook/templates/serviceaccount.yaml
 apiVersion: v1
@@ -6505,7 +4836,7 @@ spec:
     - name: WANDB_BASE_URL
       value: "http://chartsnap-nginx:8080"
     - name: WANDB_API_KEY
-      value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
+      value: ""
     command:
     - sh
     - -c
@@ -6545,10 +4876,6 @@ spec:
         - /cleanup-scripts/post_upgrade.sh
         envFrom:
         env:
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6558,15 +4885,9 @@ spec:
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
         volumeMounts:
         - mountPath: /cleanup-scripts
           name: app-rename-cleanup
-      nodeSelector:
-        global-key: global-value
       restartPolicy: Never
       serviceAccountName: chartsnap-app-rename-post-hook
       securityContext:
@@ -6577,15 +4898,6 @@ spec:
         runAsUser: 999
         seccompProfile:
           type: RuntimeDefault
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -6640,10 +4952,6 @@ spec:
         - /cleanup-scripts/pre_upgrade.sh
         envFrom:
         env:
-        - name: GLOBAL_ADMIN_API_KEY
-          value: "local-e6473d304d3487851f5e2501657d3d81f8420874"
-        - name: GORILLA_INSECURE_ALLOW_API_KEY_ADMIN_ACCESS
-          value: "true"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -6653,15 +4961,9 @@ spec:
           readOnlyRootFilesystem: false
         image: "alpine/k8s:1.31.12"
         imagePullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
         volumeMounts:
         - mountPath: /cleanup-scripts
           name: app-rename-cleanup
-      nodeSelector:
-        global-key: global-value
       restartPolicy: Never
       serviceAccountName: chartsnap-app-rename-pre-hook
       securityContext:
@@ -6672,15 +4974,6 @@ spec:
         runAsUser: 999
         seccompProfile:
           type: RuntimeDefault
-      tolerations:
-      - effect: NoSchedule
-        key: global-key1
-        operator: Equal
-        value: global-value1
-      - effect: NoSchedule
-        key: global-key2
-        operator: Equal
-        value: global-value2
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-gcp.snap
@@ -1452,6 +1452,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: "gs://wandb-lumen-configs"
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-custom-bucket.snap
@@ -1452,6 +1452,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: "s3://customer-onprem-bucket/lumen"
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-lumen-onprem-default-bucket.snap
@@ -1454,6 +1454,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-mysql-cacert-inline.snap
@@ -1510,6 +1510,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-no-oidc-settings-extra-cors.snap
@@ -1474,6 +1474,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-default.snap
@@ -1489,6 +1489,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-oidc-settings-extra-cors.snap
@@ -1489,6 +1489,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-priority-classes.snap
@@ -1517,6 +1517,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from-secret.snap
@@ -1446,6 +1446,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
+++ b/test-configs/operator-wandb/__snapshots__/snap-smtp-mail-from.snap
@@ -1439,6 +1439,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
+++ b/test-configs/operator-wandb/__snapshots__/url-encoded-password.snap
@@ -1721,6 +1721,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-clickhouse-secret.snap
@@ -1460,6 +1460,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
+++ b/test-configs/operator-wandb/__snapshots__/user-defined-secrets.snap
@@ -1968,6 +1968,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace-with-worker.snap
@@ -2224,6 +2224,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/__snapshots__/weave-trace.snap
+++ b/test-configs/operator-wandb/__snapshots__/weave-trace.snap
@@ -2037,6 +2037,8 @@ metadata:
   name: chartsnap-lumen-configmap
 data:
   LUMEN_AGENT_CONFIG_PATH: "/app/definitions/collector/managed-install.yaml"
+  LUMEN_AGENT_REMOTE_CONFIG_ENABLED: "false"
+  LUMEN_AGENT_REMOTE_CONFIG_URL: ""
   LUMEN_CUSTOMER_NAME: ""
   LUMEN_DATA_ROOT: ""
   LUMEN_STAGING_ROOT: "file:///vol/staging"

--- a/test-configs/operator-wandb/snap-lumen-gcp-remote-config.yaml
+++ b/test-configs/operator-wandb/snap-lumen-gcp-remote-config.yaml
@@ -1,0 +1,16 @@
+global:
+  cloudProvider: gcp
+  lumen:
+    dataRoot: gs://wandb-lumen-configs
+    publish:
+      envVars: true
+    # Rules come only from the bucket object; the configmap-mounted copy at
+    # wandb.lumen.rulePath stays mounted but is not read.
+    remoteConfig:
+      enabled: true
+      url: gs://wandb-lumen-config/managed-install.yaml
+    gcpWorkloadIdentity:
+      audience: //iam.googleapis.com/projects/281760294016/locations/global/workloadIdentityPools/gke-default-pool/providers/gke-default-provider
+
+lumen-agent:
+  install: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional remote configuration for the Lumen agent through a configurable URL.
  - Added settings to enable or disable remote configuration, with remote configuration disabled by default.
  - When enabled, the agent uses rules from the configured remote source and reports an error if they cannot be read.
  - Added support for bucket-backed remote configuration with GCP Workload Identity.

- **Chores**
  - Updated the Helm chart version to 0.44.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->