### PR TITLE
fix(operator-wandb): select OLAP for new Weave instances [WB-39770]

### DIFF
--- a/charts/operator-wandb/Chart.lock
+++ b/charts/operator-wandb/Chart.lock
@@ -116,5 +116,5 @@ dependencies:
 - name: clickhouse
   repository: file://charts/clickhouse
   version: 9.1.1
-digest: sha256:ed7f78a8a6734b804a09ffadba6fb241ca0cb9ba069ad001e51a5a0795da045b
-generated: "2026-09-08T14:40:52.894753-05:00"
+digest: sha256:12e305cf15cc75fe07526f69b4ec920b8dc03e892cd993eec31cfa1cd3741281
+generated: "2026-09-10T12:02:10.034327-05:00"

--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.14
+version: 0.44.15
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 
@@ -196,3 +196,6 @@ dependencies:
     condition: clickhouse.install
     repository: file://charts/clickhouse
     version: 9.1.1
+    import-values:
+      - child: exports.weaveTrace
+        parent: global.weaveTrace

--- a/charts/operator-wandb/README.md
+++ b/charts/operator-wandb/README.md
@@ -264,19 +264,36 @@ The following credentials can be pulled from external Kubernetes Secrets:
 |-----------|-------------------|------------------------|
 | **MySQL** | `global.mysql.*` | Each field (host, port, database, user, password) can be a string or a map with `valueFrom` |
 | **Redis** | `global.redis.secret` | `secretName`, `secretKey` |
-| **Weave Trace ClickHouse** | `global.clickhouse.*` (default) or `global.olap.weaveTrace.*` (opt-in) | Select with `global.weaveTrace.clickhouseSource`; each connection field can be a string or a map with `valueFrom` |
+| **Weave Trace ClickHouse** | `global.clickhouse.*` or an enabled `global.olap.weaveTrace.*` profile | `global.weaveTrace.clickhouseSource` defaults to `auto`; each connection field can be a string or a map with `valueFrom` |
 | **Kafka** | `global.kafka.passwordSecret` | `name`, `passwordKey` |
 | **OIDC** | `global.auth.oidc.oidcSecret` | `name`, `secretKey` |
 | **Session signing** | `global.auth.sessionKey`, `global.auth.sessionKeyPrevious` | Literal value or a map with `valueFrom` |
 | **SMTP** | `global.email.smtp.*` | Each field (host, port, user, password) can be a string or a map with `valueFrom` |
 
-`global.weaveTrace.clickhouseSource` defaults to `legacy`, so Weave Trace and
-its workers continue to use `global.clickhouse` even when the OLAP profile is
-enabled. Set `global.olap.weaveTrace.enabled: true` to make the profile
-available, then set `global.weaveTrace.clickhouseSource: olap` to perform the
-cutover. Selecting a disabled OLAP profile or an unknown source fails chart
-rendering. The chart does not infer enrollment from either connection, so
-existing and bundled ClickHouse installations keep their current behavior.
+`global.weaveTrace.clickhouseSource` defaults to `auto`. Once Weave is installed
+and its OLAP connection and credentials are provisioned, setting
+`global.olap.weaveTrace.enabled: true` selects that profile automatically if
+there is no customized `global.clickhouse` configuration and `clickhouse.install`
+is false. The stock chart defaults, including the templated bundled hostname,
+do not count as a configured legacy connection. Nonempty custom settings,
+including host or credential references, retain the legacy connection.
+
+| Source | Enabled OLAP profile | Customized legacy configuration or bundled ClickHouse | Selected connection |
+| --- | --- | --- | --- |
+| `auto` (default) | Yes | No | OLAP |
+| `auto` (default) | Yes | Yes | Legacy |
+| `auto` (default) | No | Either | Legacy |
+| `legacy` | Either | Either | Legacy |
+| `olap` | Yes | Either | OLAP |
+| `olap` | No | Either | Render error |
+
+Set `global.weaveTrace.clickhouseSource: olap` explicitly to cut over an existing
+legacy installation. An explicit `legacy` value, including a value retained in
+an older release or user spec, prevents automatic selection. Unknown source
+values fail rendering. These settings select a connection; they do not install
+Weave, create database users, or provision Secrets. Configure the Weave-specific
+credential references in the OLAP profile before enabling it; missing fields
+still inherit from `global.olap.default`.
 
 For a separate migration identity, enable
 `global.olap.weaveTrace.migrator` and provide its user and password through

--- a/charts/operator-wandb/charts/clickhouse/values.yaml
+++ b/charts/operator-wandb/charts/clickhouse/values.yaml
@@ -1,6 +1,12 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+# Imported only when this dependency is enabled. Weave's sibling subcharts
+# receive the marker through global values without needing the parent context.
+exports:
+  weaveTrace:
+    bundledClickhouse: true
+
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value

--- a/charts/operator-wandb/templates/_clickhouse.tpl
+++ b/charts/operator-wandb/templates/_clickhouse.tpl
@@ -50,3 +50,52 @@ Return the database password
 {{- define "wandb.clickhouse.password" -}}
 {{- print $.Values.global.clickhouse.password -}}
 {{- end -}}
+
+{{/*
+Helm fills global.clickhouse with chart defaults even when no legacy connection
+was configured. Ignore those defaults and empty fields; preserve any nonempty
+customization, including valueFrom maps and password Secret overrides.
+Keep this baseline aligned with global.clickhouse in values.yaml. The automatic
+selection tests verify that untouched chart defaults do not count as enrollment.
+*/}}
+{{- define "wandb.weaveTraceLegacyClickhouseConfigured" -}}
+  {{- $defaults := dict
+  "host" "{{ .Release.Name }}-clickhouse-headless"
+    "port" ""
+    "password" ""
+    "passwordSecret" (dict "name" "" "passwordKey" "CLICKHOUSE_PASSWORD")
+    "database" "weave_trace_db"
+    "user" "default"
+    "replicated" false
+  -}}
+  {{- $configured := false -}}
+  {{- range $key, $value := default (dict) .Values.global.clickhouse -}}
+    {{- if and (not (empty $value)) (not (deepEqual $value (get $defaults $key))) -}}
+      {{- $configured = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- $configured -}}
+{{- end -}}
+
+{{/*
+Resolve one source for Weave runtime containers and its migration init container.
+Auto selects an enabled OLAP profile only without legacy or bundled ClickHouse.
+Explicit legacy/olap values remain available for opt-out and deliberate cutover.
+*/}}
+{{- define "wandb.weaveTraceClickhouseSource" -}}
+  {{- $source := default "auto" .Values.global.weaveTrace.clickhouseSource -}}
+  {{- if not (has $source (list "auto" "legacy" "olap")) -}}
+    {{- fail (printf "global.weaveTrace.clickhouseSource must be one of: auto, legacy, olap; got %q" $source) -}}
+  {{- end -}}
+  {{- $config := include "wandb.olapConfig" (dict "root" . "featureName" "weaveTrace") | fromYaml -}}
+  {{- if eq $source "auto" -}}
+    {{- $legacyConfigured := eq (include "wandb.weaveTraceLegacyClickhouseConfigured" .) "true" -}}
+    {{- $bundled := default false .Values.global.weaveTrace.bundledClickhouse -}}
+    {{- $useOlap := and $config.enabled (not $legacyConfigured) (not $bundled) -}}
+    {{- $source = ternary "olap" "legacy" $useOlap -}}
+  {{- end -}}
+  {{- if and (eq $source "olap") (not $config.enabled) -}}
+    {{- fail "global.olap.weaveTrace.enabled must be true when global.weaveTrace.clickhouseSource is olap" -}}
+  {{- end -}}
+{{- $source -}}
+{{- end -}}

--- a/charts/operator-wandb/templates/_env.tpl
+++ b/charts/operator-wandb/templates/_env.tpl
@@ -333,22 +333,15 @@ Global values will override any chart-specific values.
 
 {{- define "wandb.weaveTraceClickhouseEnvs" -}}
   {{- /*
-    Weave Trace still consumes WF_CLICKHOUSE_* variables. Select the new OLAP
-    connection only when global.weaveTrace.clickhouseSource is explicitly set
-    to "olap"; otherwise preserve the legacy global.clickhouse behavior for
-    existing and bundled installations.
+    Weave Trace still consumes WF_CLICKHOUSE_* variables. Resolve the connection
+    through the shared source helper so runtime and migration identities follow
+    the same automatic selection or explicit legacy/olap override.
 
     OLAP normally emits <PREFIX>_PASSWORD. Weave expects WF_CLICKHOUSE_PASS,
     so this compatibility helper renders the Weave contract directly.
   */ -}}
   {{- $config := include "wandb.olapConfig" (dict "root" . "featureName" "weaveTrace") | fromYaml -}}
-  {{- $source := default "legacy" .Values.global.weaveTrace.clickhouseSource -}}
-  {{- if not (has $source (list "legacy" "olap")) -}}
-    {{- fail (printf "global.weaveTrace.clickhouseSource must be one of: legacy, olap; got %q" $source) -}}
-  {{- end -}}
-  {{- if and (eq $source "olap") (not $config.enabled) -}}
-    {{- fail "global.olap.weaveTrace.enabled must be true when global.weaveTrace.clickhouseSource is olap" -}}
-  {{- end -}}
+  {{- $source := include "wandb.weaveTraceClickhouseSource" . -}}
   {{- if eq $source "olap" }}
     {{- $envs := list -}}
     {{- $envs = append $envs (include "wandb.weaveTraceOlapEnv" (dict "root" . "name" "WF_CLICKHOUSE_HOST" "value" $config.host) | fromYaml) -}}
@@ -377,7 +370,7 @@ Global values will override any chart-specific values.
     credentials.
   */ -}}
   {{- $config := include "wandb.olapConfig" (dict "root" . "featureName" "weaveTrace") | fromYaml -}}
-  {{- $source := default "legacy" .Values.global.weaveTrace.clickhouseSource -}}
+  {{- $source := include "wandb.weaveTraceClickhouseSource" . -}}
   {{- $migrator := default (dict) $config.migrator -}}
   {{- $migratorEnabled := default false $migrator.enabled -}}
   {{- if and (eq $source "olap") $migratorEnabled -}}

--- a/charts/operator-wandb/tests/fixtures/weave_trace_olap.yaml
+++ b/charts/operator-wandb/tests/fixtures/weave_trace_olap.yaml
@@ -1,0 +1,47 @@
+# A connection profile provisioned before an SA enables Weave's OLAP connection.
+weave-trace:
+  install: true
+weave-trace-worker:
+  install: true
+weave-evaluate-model-worker:
+  install: true
+weave-trace-agent-scoring-worker:
+  install: true
+global:
+  olap:
+    default:
+      user:
+        valueFrom:
+          configMapKeyRef:
+            name: clickhouse-olap
+            key: user
+      password:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-olap-password
+            key: password
+    weaveTrace:
+      enabled: true
+      host: managed-clickhouse.example.com
+      user:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-weave
+            key: username
+      password:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-weave
+            key: password
+      migrator:
+        enabled: true
+        user:
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-weave-migrator
+              key: username
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-weave-migrator
+              key: password

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_auto_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_auto_test.yaml
@@ -1,0 +1,308 @@
+suite: Weave Trace automatic ClickHouse selection
+templates:
+  - charts/weave-trace/templates/deployment.yaml
+  - charts/weave-trace-worker/templates/deployment.yaml
+  - charts/weave-evaluate-model-worker/templates/deployment.yaml
+  - charts/weave-trace-agent-scoring-worker/templates/deployment.yaml
+values:
+  - fixtures/weave_trace_olap.yaml
+release:
+  name: wandb
+  namespace: default
+
+tests:
+  - it: selects an enabled OLAP profile and dedicated identities without a legacy connection
+    template: charts/weave-trace/templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: password
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-migrator
+                key: username
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-migrator
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+          count: 1
+          any: true
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+          count: 1
+          any: true
+
+  - it: uses the same automatic connection for the trace worker
+    template: charts/weave-trace-worker/templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: username
+
+  - it: uses the same automatic connection for the evaluate-model worker
+    template: charts/weave-evaluate-model-worker/templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: username
+
+  - it: uses the same automatic connection for the agent-scoring worker
+    template: charts/weave-trace-agent-scoring-worker/templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave
+                key: username
+
+  - it: treats an empty legacy host as unconfigured
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.host: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+
+  - it: treats an empty legacy override block as unconfigured
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse: {}
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+
+  - it: keeps the legacy connection when the OLAP profile is disabled
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.olap.weaveTrace.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: wandb-clickhouse-headless
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            value: default
+
+  - it: preserves a configured legacy host and migration identity
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.host: legacy-clickhouse.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: legacy-clickhouse.example.com
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            value: default
+
+  - it: preserves an explicitly configured in-cluster hostname
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.host: wandb-clickhouse-headless
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: wandb-clickhouse-headless
+
+  - it: preserves a legacy host supplied through a Secret
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.host:
+        valueFrom:
+          secretKeyRef:
+            name: legacy-clickhouse
+            key: host
+      global.clickhouse.port: "8443"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: legacy-clickhouse
+                key: host
+
+  - it: preserves a custom legacy password Secret even without a custom host
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.passwordSecret.name: legacy-clickhouse
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: legacy-clickhouse
+                key: CLICKHOUSE_PASSWORD
+
+  - it: preserves a legacy password supplied through valueFrom
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.password:
+        valueFrom:
+          secretKeyRef:
+            name: legacy-clickhouse
+            key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: legacy-clickhouse
+                key: password
+
+  - it: preserves a custom legacy port
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.port: "9000"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_PORT
+            value: "9000"
+
+  - it: preserves a custom legacy database
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.database: existing_weave
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_DATABASE
+            value: existing_weave
+
+  - it: preserves a custom legacy user
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.user: existing-user
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            value: existing-user
+
+  - it: preserves bundled ClickHouse even with an enabled OLAP profile
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      clickhouse.install: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: wandb-clickhouse-headless
+
+  - it: preserves self-managed replicated ClickHouse settings
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.replicated: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_REPLICATED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: wandb-clickhouse-headless
+
+  - it: honors an explicit legacy selection even without legacy overrides
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.weaveTrace.clickhouseSource: legacy
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: wandb-clickhouse-headless
+
+  - it: lets an explicit OLAP selection override an existing legacy connection
+    template: charts/weave-trace/templates/deployment.yaml
+    set:
+      global.clickhouse.host: legacy-clickhouse.example.com
+      global.weaveTrace.clickhouseSource: olap
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WF_CLICKHOUSE_HOST
+            value: managed-clickhouse.example.com
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: WF_CLICKHOUSE_USER
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-weave-migrator
+                key: username

--- a/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
+++ b/charts/operator-wandb/tests/weave_trace_clickhouse_env_test.yaml
@@ -363,7 +363,7 @@ tests:
       global.weaveTrace.clickhouseSource: automatic
     asserts:
       - failedTemplate:
-          errorMessage: 'global.weaveTrace.clickhouseSource must be one of: legacy, olap; got "automatic"'
+          errorMessage: 'global.weaveTrace.clickhouseSource must be one of: auto, legacy, olap; got "automatic"'
 
   - it: stores a literal OLAP password in a chart-owned Secret
     template: templates/olap.yaml

--- a/charts/operator-wandb/values.yaml
+++ b/charts/operator-wandb/values.yaml
@@ -236,9 +236,10 @@ global:
 
   weaveTrace:
     # Selects which ClickHouse connection is rendered into Weave Trace workloads.
-    # "legacy" preserves global.clickhouse; "olap" selects global.olap.weaveTrace.
-    # Enabling the OLAP profile alone does not change the active connection.
-    clickhouseSource: legacy
+    # "auto" uses an enabled global.olap.weaveTrace profile when global.clickhouse
+    # has no custom settings and bundled ClickHouse is not installed.
+    # "legacy" always preserves global.clickhouse; "olap" explicitly overrides it.
+    clickhouseSource: auto
 
   # OLAP database configuration (ClickHouse)
   #
@@ -307,8 +308,9 @@ global:
       params:
         max_open_conns: 300
     # Weave Trace keeps its legacy WF_CLICKHOUSE_* environment variable names.
-    # Enabling this makes the profile available. Set
-    # global.weaveTrace.clickhouseSource to "olap" to select it.
+    # Enabling this selects the profile automatically for instances without
+    # legacy ClickHouse configuration. To override an existing connection, also
+    # set global.weaveTrace.clickhouseSource to "olap".
     weaveTrace:
       enabled: false
       port: "8443"


### PR DESCRIPTION
When Weave is already installed and has no customized legacy ClickHouse connection, enabling `global.olap.weaveTrace` currently leaves its workloads on the legacy connection. This change makes that enablement sufficient when the OLAP profile and credentials have already been provisioned.

`global.weaveTrace.clickhouseSource` now defaults to `auto`:

- An enabled OLAP profile is selected when no nonempty legacy customization or bundled ClickHouse is present.
- Configured legacy connections and bundled ClickHouse remain on legacy until explicitly overridden with `clickhouseSource: olap`.
- An explicit `legacy` selection remains an opt-out. A disabled OLAP profile retains legacy, and explicitly selecting a disabled profile still fails rendering.

Runtime and migration containers share the same source resolver. Helm's default legacy fields do not count as custom configuration; custom hosts, credential references, ports, users, databases, and replication settings do. A dependency export carries bundled ClickHouse presence to the sibling Weave subcharts. The chart version advances to `0.44.15`.

The connection profile still supplies the runtime and migrator credential references. This does not install Weave, provision credentials, or broaden the QA-only Terraform enrollment.

Validation: 128 Helm unit tests passed, including 19 new selection cases; all 56 existing snapshots matched without updates; 16 template-tooling tests, formatting, maintainability checks, and Helm lint passed. Rendering and snapshots used Helm 3.20.1, matching CI. Before the fix, the new suite reproduced six automatic-selection failures.

Jira: [WB-39770 — M2: Add a per-customer opt-in for dt-managed Weave](https://coreweave.atlassian.net/browse/WB-39770).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weave Trace now automatically selects the appropriate ClickHouse source.
  * Added support for explicit `auto`, `legacy`, and `olap` ClickHouse modes.
  * Weave Trace OLAP can provide ClickHouse connections and credentials automatically.
  * Existing legacy and bundled ClickHouse configurations remain supported.

* **Bug Fixes**
  * Improved validation and handling of incompatible ClickHouse source selections.
  * Increased Anaconda health-check intervals and timeouts to improve reliability during startup and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->