### PR TITLE
fix(operator-wandb): publish Weave OLAP selection in 0.44.16 [WB-39770]

### DIFF
--- a/charts/operator-wandb/Chart.yaml
+++ b/charts/operator-wandb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator-wandb
 description: A Helm chart for deploying W&B to Kubernetes
 type: application
-version: 0.44.15
+version: 0.44.16
 appVersion: 1.0.0
 icon: https://wandb.ai/logo.svg
 


### PR DESCRIPTION
The automatic Weave OLAP selection fix merged in #703 after `operator-wandb-0.44.15` had already been published by #695. Both changes used chart version `0.44.15`, so the release workflow left the existing package in place. Downloading `0.44.15` from `charts.wandb.ai` confirms that it still defaults `clickhouseSource` to `legacy` and lacks the new source resolver.

Bump the chart to `0.44.16` so the already-merged fix is published under a new version. This changes only the chart version.

Validation: Helm lint passed and all 128 chart unit tests passed. Rebuilt chart dependencies and regenerated all 56 chart snapshots using Helm 3.20.1; the generated snapshots are unchanged, and all 56 passed the subsequent comparison.

Jira: [WB-39770](https://coreweave.atlassian.net/browse/WB-39770).


[WB-39770]: https://coreweave.atlassian.net/browse/WB-39770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart release version to 0.44.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->